### PR TITLE
Add build instructions for OSX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,21 @@ all:
 		./deps/libuv-v1.9.1/.libs/libuv.a  -lm -lX11 -lGL -lpthread
 	$(CC) test-libversion.c deps/pugl/build/libpugl-0.a -ldl -o zest -lX11 -lGL -lpthread -I deps/pugl -std=gnu99
 
+osx:
+	ruby ./rebuild-fcache.rb
+	cd deps/nanovg/src   && $(CC) nanovg.c -c -fPIC
+	$(AR) rc deps/libnanovg.a deps/nanovg/src/*.o
+	cd deps/pugl         && ./waf configure --no-cairo --static
+#	cd deps/pugl         && ./waf configure --no-cairo --static --debug
+	cd deps/pugl         && ./waf
+	cd src/osc-bridge    && CFLAGS="-I ../../deps/libuv-v1.9.1/include " make lib
+	cd mruby             && MRUBY_CONFIG=../build_config.rb rake
+	$(CC) -shared -o libzest.so `find mruby/build/host -type f | grep -e "\.o$$" | grep -v bin` ./deps/libnanovg.a \
+		./deps/libnanovg.a \
+		src/osc-bridge/libosc-bridge.a \
+		./deps/libuv-v1.9.1/.libs/libuv.a  -lm -framework OpenGL -lpthread
+	$(CC) test-libversion.c deps/pugl/build/libpugl-0.a -ldl -o zest -framework OpenGL -framework AppKit -lpthread -I deps/pugl -std=gnu99
+
 windows:
 	cd deps/nanovg/src   && $(CC) -mstackrealign nanovg.c -c
 	$(AR) rc deps/libnanovg.a deps/nanovg/src/*.o

--- a/README.adoc
+++ b/README.adoc
@@ -1,3 +1,7 @@
+= Zyn-Fusion User Interface
+
+
+
 Welcome to the source of the Zyn-Fusion user interface.
 
 ### Preparations

--- a/README.adoc
+++ b/README.adoc
@@ -1,10 +1,9 @@
 = Zyn-Fusion User Interface
 
 
-
 Welcome to the source of the Zyn-Fusion user interface.
 
-### Preparations
+== Preparations
 
 After cloning the repository, initialize the submodules:
 [source,bash]
@@ -13,7 +12,7 @@ git submodule init
 git submodule update
 ----
 
-## Building
+== Building
 
 To build you'll want to use the Makefile:
 [source,bash]
@@ -24,7 +23,7 @@ make
 ----
 and the ahead-of-time qml compiler 'rebuild-fcache.rb'.
 
-### Building on OS X
+=== Building on OS X
 
 In order to make the build work on a recent OSX (at the time of writing, 10.13),
 run the make process as follows:
@@ -40,7 +39,7 @@ There will be a number of deprecation warnings, these can be ignored.
 The main difference to the Linux build are the linking options (The process links against
 the `OpenGL` and the `AppKit` frameworks.
 
-## Running
+== Running
 
 The build process will create a `libzest.so` library and the `zest` executable.
 See the link:contributing.adoc[contributing.adoc] document for information about

--- a/README.adoc
+++ b/README.adoc
@@ -1,4 +1,16 @@
 Welcome to the source of the Zyn-Fusion user interface.
+
+### Preparations
+
+After cloning the repository, initialize the submodules:
+[source,bash]
+----
+git submodule init
+git submodule update
+----
+
+## Building
+
 To build you'll want to use the Makefile:
 [source,bash]
 ----
@@ -7,6 +19,28 @@ make builddep
 make
 ----
 and the ahead-of-time qml compiler 'rebuild-fcache.rb'.
+
+### Building on OS X
+
+In order to make the build work on a recent OSX (at the time of writing, 10.13),
+run the make process as follows:
+
+[source,bash]
+----
+make setup
+make builddep
+OS=Mac make osx
+----
+There will be a number of deprecation warnings, these can be ignored.
+
+The main difference to the Linux build are the linking options (The process links against
+the `OpenGL` and the `AppKit` frameworks.
+
+## Running
+
+The build process will create a `libzest.so` library and the `zest` executable.
+See the link:contributing.adoc[contributing.adoc] document for information about
+running the application and changing it.
 
 Enjoy,
 --Mark McCurry

--- a/contributing.adoc
+++ b/contributing.adoc
@@ -95,19 +95,19 @@ First, open up 'src/mruby-zest/qml/Knob.qml'
 
 This defines a knob and it decends from the valuator base class.
 Let's take a look at the draw() function.
-Within the draw function add 'background color("ffffff")' and then save the
+Within the draw function add `background color("ffffff")` and then save the
 file.
 If hotloading is working you should see the background behind each one of the
 knobs change to white. If you aren't using hotloading, then closing and running
-"make && make run" should get you to the same spot.
+`make && make run` should get you to the same spot.
 
 From there, it's possible to probe other parts of the drawing process.
-Comment out the background change with "#" and then let's try changing the
+Comment out the background change with `#` and then let's try changing the
 color of something that is drawn.
 
 Go to the first 'vg.path' section and change the fill_color to
-'color("550000")' and in the next 'vg.path' section change the color to
-'color(:red)'.
+`color("550000")` and in the next 'vg.path' section change the color to
+`color(:red)`.
 Save the file and you should now see the new drawing changes in the live GUI.
 This is just a quick example, but you should get the idea.
 


### PR DESCRIPTION
Extended the documentation for building mruby-zest on a recent version of OSX
closes #7 