### PR TITLE
Fix black screen for windows standalone

### DIFF
--- a/test-libversion.c
+++ b/test-libversion.c
@@ -727,10 +727,15 @@ int main(int argc, char **argv)
         puglProcessEvents(view);
         monotonic_clock_gettime(&post_events);
 
+#ifndef _WIN32
         puglEnterContext(view);
+#endif
         if(z.zest)
             needs_redraw = z.zest_tick(z.zest);
+#ifndef _WIN32
         puglLeaveContext(view, 0);
+#endif
+
         monotonic_clock_gettime(&post_tick);
 
 #define TIME_DIFF(a,b) (b.tv_sec-a.tv_sec + 1e-9 *(b.tv_nsec-a.tv_nsec))


### PR DESCRIPTION
In a windows build `puglEnterContext` & `puglLeaveContext` call `BeginPaint` & `EndPaint`. These functions should only be called in response to an `WM_PAINT` event. Calling it outside a WM_PAINT event causes the window to be marked as updated. Therefor no further WM_PAINT events are sent resulting in a black window.

See: https://github.com/zynaddsubfx/zyn-fusion-build/issues/28