### PR TITLE
Pull libuv 1.40.0 as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -58,3 +58,6 @@
 [submodule "deps/mruby-process"]
 	path = deps/mruby-process
 	url = https://github.com/iij/mruby-process
+[submodule "deps/libuv"]
+	path = deps/libuv
+	url = https://github.com/libuv/libuv

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ addons:
     packages:
     - mesa-common-dev
     - libgl1-mesa-dev
+    - libuv1-dev
+    - pkg-config
 sudo: false
 script:
     - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,4 @@ addons:
     - libgl1-mesa-dev
 sudo: false
 script:
-    - make setup
-    - make builddep
     - make

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,15 @@
 
-all: deps/libuv.a
+all:
 	ruby ./rebuild-fcache.rb
 	cd deps/nanovg/src   && $(CC) nanovg.c -c -fPIC
 	$(AR) rc deps/libnanovg.a deps/nanovg/src/*.o
 	cd deps/mruby-file-stat/src && ../configure
-	cd src/osc-bridge    && CFLAGS="-I ../../deps/libuv/include " make lib
+	cd src/osc-bridge    && make lib
 	cd mruby             && MRUBY_CONFIG=../build_config.rb rake
 	$(CC) -shared -o libzest.so `find mruby/build/host -type f | grep -v mrbc | grep -e "\.o$$" | grep -v bin` ./deps/libnanovg.a \
 		./deps/libnanovg.a \
 		src/osc-bridge/libosc-bridge.a \
-		./deps/libuv.a  -lm -lX11 -lGL -lpthread
+		$(pkg-config --libs libuv) -lm -lX11 -lGL -lpthread
 	$(CC) test-libversion.c deps/pugl/pugl/pugl_x11.c \
 		  -DPUGL_HAVE_GL \
 		  -ldl -o zest -lX11 -lGL -lpthread -I deps/pugl -std=gnu99

--- a/README.adoc
+++ b/README.adoc
@@ -12,13 +12,14 @@ git submodule init
 git submodule update
 ----
 
-== Building
+== Building on Linux
+
+Zynfusion depends on libuv and mesa (packages libuv1-dev, mesa-common-dev,
+libgl1-mesa-dev on Debian variants).
 
 To build you'll want to use the Makefile:
 [source,bash]
 ----
-make setup
-make builddep
 make
 ----
 and the ahead-of-time qml compiler 'rebuild-fcache.rb'.
@@ -30,8 +31,6 @@ run the make process as follows:
 
 [source,bash]
 ----
-make setup
-make builddep
 OS=Mac make osx
 ----
 There will be a number of deprecation warnings, these can be ignored.

--- a/build_config.rb
+++ b/build_config.rb
@@ -96,7 +96,7 @@ build_type.new(build_name) do |conf|
   conf.cc do |cc|
       cc.include_paths << "#{`pwd`.strip}/../deps/nanovg/src"
       cc.include_paths << "#{`pwd`.strip}/../deps/pugl/"
-      cc.include_paths << "#{`pwd`.strip}/../deps/libuv-v1.9.1/include/"
+      cc.include_paths << "#{`pwd`.strip}/../deps/libuv/include/"
       cc.include_paths << "/usr/share/mingw-w64/include/" if windows
       cc.include_paths << "/usr/x86_64-w64-mingw32/include/" if windows
       cc.flags << "-DLDBL_EPSILON=1e-6" if windows

--- a/contributing.adoc
+++ b/contributing.adoc
@@ -78,14 +78,11 @@ dev (e.g. listening to some music).
 Then from the mruby-zest-build repo:
 
 --------------------------------------------------------------------------------
-make setup
-make builddep
 make
 make run
 --------------------------------------------------------------------------------
 
-This will build the GUI and connect it to the remote zyn (note, you should not
-need to rerun setup/builddep from now on).
+This will build the GUI and connect it to the remote zyn.
 
 Ok, now the GUI is running and it should be connected to a running instance of
 zynaddsubfx. Now what?


### PR DESCRIPTION
Here's another proposal to simplify things a bit, by using submodule to pull in libuv, instead of using the published tarball.

Caveats:
- this change also upgrades libuv from 1.9.1 to 1.40.0. I only tested it (lightly) on Linux. A lower-risk change would be to keep the version the same, it's straightforward to do.
- there must have been a good reason to use the tarball version instead of a submodule, which I lack the context for. Happy to update this PR accordingly.