### PR TITLE
mruby-widget-lib: api: Add API for updating Zest UI

### DIFF
--- a/src/mruby-widget-lib/mrblib/script.rb
+++ b/src/mruby-widget-lib/mrblib/script.rb
@@ -439,6 +439,12 @@ class ZRunner
         cnt
     end
 
+    def forget_all_state
+        # Explicity require Zest UI to update itself.
+        # Invoke this method when user changes a preset in VST host.
+        $remote.damage("/")
+    end
+
     ########################################
     #      Widget Hotloading Support       #
     ########################################

--- a/src/mruby-widget-lib/src/api.c
+++ b/src/mruby-widget-lib/src/api.c
@@ -421,3 +421,17 @@ zest_get_remote_url(zest_t *z)
     return mrb_string_value_ptr(mrb, out);
 }
 
+/**
+ * zest_forget_all_state()
+ * 
+ * Explicity require Zest UI to update itself.
+ * Invoke this method in DPF's DISTHRO::UI::stateChanged()
+ *   so that Zest UI can respond to preset changes in VST host.
+ */
+EXPORT void
+zest_forget_all_state(zest_t *z)
+{
+    mrb_state *mrb = z->mrb;
+    mrb_funcall(z->mrb, z->runner, "forget_all_state", 0);
+    check_error(z->mrb);
+}


### PR DESCRIPTION
DAWs like REAPER support saving VST's state as so-called "user presets"
 (or directly saving it into project file). And in most VST plugins,
when you load a "user preset", the state (aka. configurations) of
that plugin is restored, and the UI is also updated according to the state.

But for a long time, Zyn-Fusion doesn't support this feature. This will
be troublesome for DAW users. To solve this, I added a method
zest_forget_all_state(). It will send OSC message "damage" to inform
ZynAddSubFX that the UI is outdated, and an update is needed.

Invoke this method in DPF plugin's DISTRHO::UI::stateChanged() so that
every time VST host loads presets can Zest UI be updated
correspondingly.

Thanks @fundamental for instructions.

Related issue: #35