### PR TITLE
Conversion of mruby-zest and osc-bridge to git-subrepo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -37,9 +37,6 @@
 [submodule "src/mruby-qml-parse"]
 	path = src/mruby-qml-parse
 	url = https://github.com/mruby-zest/mruby-qml-parse
-[submodule "deps/osc-bridge"]
-	path = src/osc-bridge
-	url = https://github.com/mruby-zest/osc-bridge
 [submodule "deps/mruby-complex"]
 	path = deps/mruby-complex
 	url = https://github.com/pbosetti/mruby-complex

--- a/.gitmodules
+++ b/.gitmodules
@@ -34,9 +34,6 @@
 [submodule "src/mruby-qml-spawn"]
 	path = src/mruby-qml-spawn
 	url = https://github.com/mruby-zest/mruby-qml-spawn
-[submodule "src/mruby-zest"]
-	path = src/mruby-zest
-	url = https://github.com/mruby-zest/mruby-zest
 [submodule "src/mruby-qml-parse"]
 	path = src/mruby-qml-parse
 	url = https://github.com/mruby-zest/mruby-qml-parse

--- a/src/mruby-zest/.gitrepo
+++ b/src/mruby-zest/.gitrepo
@@ -1,0 +1,12 @@
+; DO NOT EDIT (unless you know what you are doing)
+;
+; This subdirectory is a git "subrepo", and this file is maintained by the
+; git-subrepo command. See https://github.com/git-commands/git-subrepo#readme
+;
+[subrepo]
+	remote = git@github.com:mruby-zest/mruby-zest.git
+	branch = master
+	commit = 74b9e70e903b8aa571231eb92b1ce878efc84d94
+	parent = cea6b6eb72310cbbc81b0e1686ce855f5d823053
+	method = merge
+	cmdver = 0.4.3

--- a/src/mruby-zest/LICENSE
+++ b/src/mruby-zest/LICENSE
@@ -1,0 +1,502 @@
+                  GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 2.1, February 1999
+
+ Copyright (C) 1991, 1999 Free Software Foundation, Inc.
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+[This is the first released version of the Lesser GPL.  It also counts
+ as the successor of the GNU Library Public License, version 2, hence
+ the version number 2.1.]
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+Licenses are intended to guarantee your freedom to share and change
+free software--to make sure the software is free for all its users.
+
+  This license, the Lesser General Public License, applies to some
+specially designated software packages--typically libraries--of the
+Free Software Foundation and other authors who decide to use it.  You
+can use it too, but we suggest you first think carefully about whether
+this license or the ordinary General Public License is the better
+strategy to use in any particular case, based on the explanations below.
+
+  When we speak of free software, we are referring to freedom of use,
+not price.  Our General Public Licenses are designed to make sure that
+you have the freedom to distribute copies of free software (and charge
+for this service if you wish); that you receive source code or can get
+it if you want it; that you can change the software and use pieces of
+it in new free programs; and that you are informed that you can do
+these things.
+
+  To protect your rights, we need to make restrictions that forbid
+distributors to deny you these rights or to ask you to surrender these
+rights.  These restrictions translate to certain responsibilities for
+you if you distribute copies of the library or if you modify it.
+
+  For example, if you distribute copies of the library, whether gratis
+or for a fee, you must give the recipients all the rights that we gave
+you.  You must make sure that they, too, receive or can get the source
+code.  If you link other code with the library, you must provide
+complete object files to the recipients, so that they can relink them
+with the library after making changes to the library and recompiling
+it.  And you must show them these terms so they know their rights.
+
+  We protect your rights with a two-step method: (1) we copyright the
+library, and (2) we offer you this license, which gives you legal
+permission to copy, distribute and/or modify the library.
+
+  To protect each distributor, we want to make it very clear that
+there is no warranty for the free library.  Also, if the library is
+modified by someone else and passed on, the recipients should know
+that what they have is not the original version, so that the original
+author's reputation will not be affected by problems that might be
+introduced by others.
+
+  Finally, software patents pose a constant threat to the existence of
+any free program.  We wish to make sure that a company cannot
+effectively restrict the users of a free program by obtaining a
+restrictive license from a patent holder.  Therefore, we insist that
+any patent license obtained for a version of the library must be
+consistent with the full freedom of use specified in this license.
+
+  Most GNU software, including some libraries, is covered by the
+ordinary GNU General Public License.  This license, the GNU Lesser
+General Public License, applies to certain designated libraries, and
+is quite different from the ordinary General Public License.  We use
+this license for certain libraries in order to permit linking those
+libraries into non-free programs.
+
+  When a program is linked with a library, whether statically or using
+a shared library, the combination of the two is legally speaking a
+combined work, a derivative of the original library.  The ordinary
+General Public License therefore permits such linking only if the
+entire combination fits its criteria of freedom.  The Lesser General
+Public License permits more lax criteria for linking other code with
+the library.
+
+  We call this license the "Lesser" General Public License because it
+does Less to protect the user's freedom than the ordinary General
+Public License.  It also provides other free software developers Less
+of an advantage over competing non-free programs.  These disadvantages
+are the reason we use the ordinary General Public License for many
+libraries.  However, the Lesser license provides advantages in certain
+special circumstances.
+
+  For example, on rare occasions, there may be a special need to
+encourage the widest possible use of a certain library, so that it becomes
+a de-facto standard.  To achieve this, non-free programs must be
+allowed to use the library.  A more frequent case is that a free
+library does the same job as widely used non-free libraries.  In this
+case, there is little to gain by limiting the free library to free
+software only, so we use the Lesser General Public License.
+
+  In other cases, permission to use a particular library in non-free
+programs enables a greater number of people to use a large body of
+free software.  For example, permission to use the GNU C Library in
+non-free programs enables many more people to use the whole GNU
+operating system, as well as its variant, the GNU/Linux operating
+system.
+
+  Although the Lesser General Public License is Less protective of the
+users' freedom, it does ensure that the user of a program that is
+linked with the Library has the freedom and the wherewithal to run
+that program using a modified version of the Library.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.  Pay close attention to the difference between a
+"work based on the library" and a "work that uses the library".  The
+former contains code derived from the library, whereas the latter must
+be combined with the library in order to run.
+
+                  GNU LESSER GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License Agreement applies to any software library or other
+program which contains a notice placed by the copyright holder or
+other authorized party saying it may be distributed under the terms of
+this Lesser General Public License (also called "this License").
+Each licensee is addressed as "you".
+
+  A "library" means a collection of software functions and/or data
+prepared so as to be conveniently linked with application programs
+(which use some of those functions and data) to form executables.
+
+  The "Library", below, refers to any such software library or work
+which has been distributed under these terms.  A "work based on the
+Library" means either the Library or any derivative work under
+copyright law: that is to say, a work containing the Library or a
+portion of it, either verbatim or with modifications and/or translated
+straightforwardly into another language.  (Hereinafter, translation is
+included without limitation in the term "modification".)
+
+  "Source code" for a work means the preferred form of the work for
+making modifications to it.  For a library, complete source code means
+all the source code for all modules it contains, plus any associated
+interface definition files, plus the scripts used to control compilation
+and installation of the library.
+
+  Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running a program using the Library is not restricted, and output from
+such a program is covered only if its contents constitute a work based
+on the Library (independent of the use of the Library in a tool for
+writing it).  Whether that is true depends on what the Library does
+and what the program that uses the Library does.
+
+  1. You may copy and distribute verbatim copies of the Library's
+complete source code as you receive it, in any medium, provided that
+you conspicuously and appropriately publish on each copy an
+appropriate copyright notice and disclaimer of warranty; keep intact
+all the notices that refer to this License and to the absence of any
+warranty; and distribute a copy of this License along with the
+Library.
+
+  You may charge a fee for the physical act of transferring a copy,
+and you may at your option offer warranty protection in exchange for a
+fee.
+
+  2. You may modify your copy or copies of the Library or any portion
+of it, thus forming a work based on the Library, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) The modified work must itself be a software library.
+
+    b) You must cause the files modified to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    c) You must cause the whole of the work to be licensed at no
+    charge to all third parties under the terms of this License.
+
+    d) If a facility in the modified Library refers to a function or a
+    table of data to be supplied by an application program that uses
+    the facility, other than as an argument passed when the facility
+    is invoked, then you must make a good faith effort to ensure that,
+    in the event an application does not supply such function or
+    table, the facility still operates, and performs whatever part of
+    its purpose remains meaningful.
+
+    (For example, a function in a library to compute square roots has
+    a purpose that is entirely well-defined independent of the
+    application.  Therefore, Subsection 2d requires that any
+    application-supplied function or table used by this function must
+    be optional: if the application does not supply it, the square
+    root function must still compute square roots.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Library,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Library, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote
+it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Library.
+
+In addition, mere aggregation of another work not based on the Library
+with the Library (or with a work based on the Library) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may opt to apply the terms of the ordinary GNU General Public
+License instead of this License to a given copy of the Library.  To do
+this, you must alter all the notices that refer to this License, so
+that they refer to the ordinary GNU General Public License, version 2,
+instead of to this License.  (If a newer version than version 2 of the
+ordinary GNU General Public License has appeared, then you can specify
+that version instead if you wish.)  Do not make any other change in
+these notices.
+
+  Once this change is made in a given copy, it is irreversible for
+that copy, so the ordinary GNU General Public License applies to all
+subsequent copies and derivative works made from that copy.
+
+  This option is useful when you wish to copy part of the code of
+the Library into a program that is not a library.
+
+  4. You may copy and distribute the Library (or a portion or
+derivative of it, under Section 2) in object code or executable form
+under the terms of Sections 1 and 2 above provided that you accompany
+it with the complete corresponding machine-readable source code, which
+must be distributed under the terms of Sections 1 and 2 above on a
+medium customarily used for software interchange.
+
+  If distribution of object code is made by offering access to copy
+from a designated place, then offering equivalent access to copy the
+source code from the same place satisfies the requirement to
+distribute the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  5. A program that contains no derivative of any portion of the
+Library, but is designed to work with the Library by being compiled or
+linked with it, is called a "work that uses the Library".  Such a
+work, in isolation, is not a derivative work of the Library, and
+therefore falls outside the scope of this License.
+
+  However, linking a "work that uses the Library" with the Library
+creates an executable that is a derivative of the Library (because it
+contains portions of the Library), rather than a "work that uses the
+library".  The executable is therefore covered by this License.
+Section 6 states terms for distribution of such executables.
+
+  When a "work that uses the Library" uses material from a header file
+that is part of the Library, the object code for the work may be a
+derivative work of the Library even though the source code is not.
+Whether this is true is especially significant if the work can be
+linked without the Library, or if the work is itself a library.  The
+threshold for this to be true is not precisely defined by law.
+
+  If such an object file uses only numerical parameters, data
+structure layouts and accessors, and small macros and small inline
+functions (ten lines or less in length), then the use of the object
+file is unrestricted, regardless of whether it is legally a derivative
+work.  (Executables containing this object code plus portions of the
+Library will still fall under Section 6.)
+
+  Otherwise, if the work is a derivative of the Library, you may
+distribute the object code for the work under the terms of Section 6.
+Any executables containing that work also fall under Section 6,
+whether or not they are linked directly with the Library itself.
+
+  6. As an exception to the Sections above, you may also combine or
+link a "work that uses the Library" with the Library to produce a
+work containing portions of the Library, and distribute that work
+under terms of your choice, provided that the terms permit
+modification of the work for the customer's own use and reverse
+engineering for debugging such modifications.
+
+  You must give prominent notice with each copy of the work that the
+Library is used in it and that the Library and its use are covered by
+this License.  You must supply a copy of this License.  If the work
+during execution displays copyright notices, you must include the
+copyright notice for the Library among them, as well as a reference
+directing the user to the copy of this License.  Also, you must do one
+of these things:
+
+    a) Accompany the work with the complete corresponding
+    machine-readable source code for the Library including whatever
+    changes were used in the work (which must be distributed under
+    Sections 1 and 2 above); and, if the work is an executable linked
+    with the Library, with the complete machine-readable "work that
+    uses the Library", as object code and/or source code, so that the
+    user can modify the Library and then relink to produce a modified
+    executable containing the modified Library.  (It is understood
+    that the user who changes the contents of definitions files in the
+    Library will not necessarily be able to recompile the application
+    to use the modified definitions.)
+
+    b) Use a suitable shared library mechanism for linking with the
+    Library.  A suitable mechanism is one that (1) uses at run time a
+    copy of the library already present on the user's computer system,
+    rather than copying library functions into the executable, and (2)
+    will operate properly with a modified version of the library, if
+    the user installs one, as long as the modified version is
+    interface-compatible with the version that the work was made with.
+
+    c) Accompany the work with a written offer, valid for at
+    least three years, to give the same user the materials
+    specified in Subsection 6a, above, for a charge no more
+    than the cost of performing this distribution.
+
+    d) If distribution of the work is made by offering access to copy
+    from a designated place, offer equivalent access to copy the above
+    specified materials from the same place.
+
+    e) Verify that the user has already received a copy of these
+    materials or that you have already sent this user a copy.
+
+  For an executable, the required form of the "work that uses the
+Library" must include any data and utility programs needed for
+reproducing the executable from it.  However, as a special exception,
+the materials to be distributed need not include anything that is
+normally distributed (in either source or binary form) with the major
+components (compiler, kernel, and so on) of the operating system on
+which the executable runs, unless that component itself accompanies
+the executable.
+
+  It may happen that this requirement contradicts the license
+restrictions of other proprietary libraries that do not normally
+accompany the operating system.  Such a contradiction means you cannot
+use both them and the Library together in an executable that you
+distribute.
+
+  7. You may place library facilities that are a work based on the
+Library side-by-side in a single library together with other library
+facilities not covered by this License, and distribute such a combined
+library, provided that the separate distribution of the work based on
+the Library and of the other library facilities is otherwise
+permitted, and provided that you do these two things:
+
+    a) Accompany the combined library with a copy of the same work
+    based on the Library, uncombined with any other library
+    facilities.  This must be distributed under the terms of the
+    Sections above.
+
+    b) Give prominent notice with the combined library of the fact
+    that part of it is a work based on the Library, and explaining
+    where to find the accompanying uncombined form of the same work.
+
+  8. You may not copy, modify, sublicense, link with, or distribute
+the Library except as expressly provided under this License.  Any
+attempt otherwise to copy, modify, sublicense, link with, or
+distribute the Library is void, and will automatically terminate your
+rights under this License.  However, parties who have received copies,
+or rights, from you under this License will not have their licenses
+terminated so long as such parties remain in full compliance.
+
+  9. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Library or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Library (or any work based on the
+Library), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Library or works based on it.
+
+  10. Each time you redistribute the Library (or any work based on the
+Library), the recipient automatically receives a license from the
+original licensor to copy, distribute, link with or modify the Library
+subject to these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties with
+this License.
+
+  11. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Library at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Library by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Library.
+
+If any portion of this section is held invalid or unenforceable under any
+particular circumstance, the balance of the section is intended to apply,
+and the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  12. If the distribution and/or use of the Library is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Library under this License may add
+an explicit geographical distribution limitation excluding those countries,
+so that distribution is permitted only in or among countries not thus
+excluded.  In such case, this License incorporates the limitation as if
+written in the body of this License.
+
+  13. The Free Software Foundation may publish revised and/or new
+versions of the Lesser General Public License from time to time.
+Such new versions will be similar in spirit to the present version,
+but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Library
+specifies a version number of this License which applies to it and
+"any later version", you have the option of following the terms and
+conditions either of that version or of any later version published by
+the Free Software Foundation.  If the Library does not specify a
+license version number, you may choose any version ever published by
+the Free Software Foundation.
+
+  14. If you wish to incorporate parts of the Library into other free
+programs whose distribution conditions are incompatible with these,
+write to the author to ask for permission.  For software which is
+copyrighted by the Free Software Foundation, write to the Free
+Software Foundation; we sometimes make exceptions for this.  Our
+decision will be guided by the two goals of preserving the free status
+of all derivatives of our free software and of promoting the sharing
+and reuse of software generally.
+
+                            NO WARRANTY
+
+  15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO
+WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
+EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR
+OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY
+KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE
+LIBRARY IS WITH YOU.  SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME
+THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
+WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY
+AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU
+FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR
+CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE
+LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING
+RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
+FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF
+SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+           How to Apply These Terms to Your New Libraries
+
+  If you develop a new library, and you want it to be of the greatest
+possible use to the public, we recommend making it free software that
+everyone can redistribute and change.  You can do so by permitting
+redistribution under these terms (or, alternatively, under the terms of the
+ordinary General Public License).
+
+  To apply these terms, attach the following notices to the library.  It is
+safest to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least the
+"copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the library's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+Also add information on how to contact you by electronic and paper mail.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the library, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the
+  library `Frob' (a library for tweaking knobs) written by James Random Hacker.
+
+  <signature of Ty Coon>, 1 April 1990
+  Ty Coon, President of Vice
+
+That's all there is to it!

--- a/src/mruby-zest/README.adoc
+++ b/src/mruby-zest/README.adoc
@@ -1,0 +1,9 @@
+MRuby-Zest
+----------
+
+This repository contains all of the widgets needed to create the 
+'zyn-fusion' user interface for ZynAddSubFX.
+The .qml files are *not* Qt's QML, but they borrow the syntax and use a
+set of ruby libraries to run them (mruby-qml-parse/mruby-qml-spawn/mruby-nanovg).
+
+This library is available under the LGPLv2+ license.

--- a/src/mruby-zest/example/ApplyButton.qml
+++ b/src/mruby-zest/example/ApplyButton.qml
@@ -1,0 +1,125 @@
+Button {
+    id: app
+    BusyLoop {
+        id: lp
+    }
+    function onMousePress(ev) {
+        if(ev.buttons.include? :leftButton)
+            self.state = :applying
+            self.value = 1.0
+            whenValue.call if whenValue
+            lp.spin = true
+            damage_self
+        elsif(ev.buttons.include? :rightButton)
+            if(children.length == 1)
+                create_radial
+            end
+        end
+    }
+
+    property Symbol state:    :off
+    property Object valueRef: nil
+    onExtern: {
+        app.valueRef = OSC::RemoteParam.new($remote, app.extern)
+        app.valueRef.callback = lambda {|x|
+            app.setValue(x);
+            if(!x)
+                app.state = :off
+            else
+                app.state = :waiting
+            end}
+    }
+
+    function create_radial()
+    {
+        gbl_cx = self.global_x + 0.5*self.w
+        gbl_cy = self.global_y + 0.5*self.h
+        gbl_w  = window.w
+        gbl_h  = window.h
+
+        ropt = [gbl_cx, gbl_cy, gbl_w-gbl_cx, gbl_h-gbl_cy].min
+
+        diameter = [2.0*ropt, 3.0*0.5*(self.w+self.h)].min
+
+        widget = RadialMenu.new(self.db)
+        widget.w = diameter
+        widget.h = diameter
+        widget.x = self.w/2-diameter/2
+        widget.y = self.h/2-diameter/2
+        widget.layer = 2
+        widget.fields = ["off", "1 sec", "off", "10 sec"]
+        widget.callback = lambda {|sel|
+            case sel
+            when 0
+                $auto_apply_dt = 1.0/0.0
+            when 1
+                $auto_apply_dt = 1.0
+            when 2
+                $auto_apply_dt = 1.0/0.0
+            when 3
+                $auto_apply_dt = 10.0
+            end
+            puts "auto apply dt is:"
+            puts $auto_apply_dt
+            puts sel
+        }
+
+        Qml::add_child(self, widget)
+        self.root.smash_draw_seq
+        self.root.damage_item widget
+    }
+
+
+    function setValue(x)
+    {
+        self.value = x
+        lp.spin = false if x == false
+        lp.damage_self
+        damage_self
+    }
+
+    function animate()
+    {
+        now = Time.new
+        $auto_apply_dt   ||= 1.0/0.0
+        @auto_apply_last ||= now
+        if(self.state == :waiting && (now-@auto_apply_last) > $auto_apply_dt)
+            self.state = :applying
+            self.value = 1.0
+            whenValue.call if whenValue
+            lp.spin = true
+            damage_self
+            @auto_apply_last = now
+        end
+
+        if(self.state == :waiting)
+            @phase ||= 0.0
+            self.value = Math.sin(3.14*@phase)
+            @phase += 0.01
+            @phase -= 1.0 if @phase > 1.0
+            damage_self
+            return
+        end
+
+        return if self.value == 0
+        return if self.value == false
+        return if self.value == true
+        self.value *= 0.7
+        self.value  = 0 if self.value < 0.02
+        damage_self
+    }
+
+
+    function layout(l, selfBox) {
+        scale = 100
+        $vg.font_size scale
+        bb = $vg.text_bounds(0, 0, "000 " + label.upcase)
+        if(bb != 0)
+            #Width cannot be so small that letters overflow
+            l.aspect(selfBox, bb, scale)
+        end
+
+        lp.fixed(l, selfBox, 0.1, 0.1, 0.2, 0.8)
+        selfBox
+    }
+}

--- a/src/mruby-zest/example/ArrowBox.qml
+++ b/src/mruby-zest/example/ArrowBox.qml
@@ -1,0 +1,37 @@
+Widget {
+    id: box
+    property Bool active: false
+    property Function whenValue: nil;
+
+    onActive: {
+        box.damage_self
+    }
+
+    function onMousePress(ev) {
+        return if box.active
+
+        box.active = true
+        damage_self
+        whenValue.call if whenValue
+    }
+
+
+    function draw(vg)
+    {
+        scale = 0.5
+        vg.path do
+            vg.move_to((0.5-scale/2)*w,(0.5+scale/2)*h)
+            vg.line_to((0.5-scale/2)*w,(0.5-scale/2)*h)
+            vg.line_to((0.5+scale/2)*w,0.5*h)
+            vg.close_path
+            vg.fill_color(color("bbbbbb")) if !self.active
+            vg.fill_color(color("55ff55")) if  self.active
+            vg.fill
+        end
+    }
+
+    function layout(l, selfBox) {
+        l.aspect(selfBox, 1, 1)
+        selfBox
+    }
+}

--- a/src/mruby-zest/example/BusyLoop.qml
+++ b/src/mruby-zest/example/BusyLoop.qml
@@ -1,0 +1,53 @@
+Widget {
+    layer: 2
+    property Float value: 0.0
+    property Bool  spin:  false
+
+    function animate()
+    {
+        return if !self.spin
+        self.value += 0.01
+        self.value -= 1.0 if self.value > 1.0
+        damage_self
+    }
+
+    function draw(vg)
+    {
+        pi = 3.14159
+        start = 2*pi
+        end_   = 0
+        radius  = 0.25*[h*1.0,w].min
+        inner  = 0.30*[h*1.0,w].min
+        outer = 0.50*[h*1.0,w].min
+
+        #lowest point is 0.707 cy-outer*0.707
+        #shift by 0.293/2 to compinsate
+        cy = h/2
+        cx = w/2;
+        kr = h/4;
+        vg.path do |v|
+            v.arc(cx, cy, outer, start, end_, 1);
+            v.arc(cx, cy, inner, end_, start, 2);
+            v.close_path
+            v.fill_color(color("114575"))
+            v.fill
+        end
+
+        return if !self.spin
+        self.value = 0.0 if(self.value.class != Float)
+        cang  = 2*pi*value
+
+        width = 0.4
+
+        len = (3.0/2.0*pi)*width;
+        startt = 2*pi*value + len;
+
+        vg.path do |v|
+            v.arc(cx, cy, inner, cang, startt, 2);
+            v.arc(cx, cy, outer, startt, cang, 1);
+            v.close_path
+            v.fill_color(color("3AC5EC"))
+            v.fill
+        end
+    }
+}

--- a/src/mruby-zest/example/BypassButton.qml
+++ b/src/mruby-zest/example/BypassButton.qml
@@ -1,0 +1,42 @@
+ToggleButton {
+    function draw_text(vg)
+    {
+        text_color1   = Theme::TextActiveColor
+        text_color2   = Theme::TextColor
+        vg.font_face("bold")
+        vg.font_size h*self.textScale/2
+        if(value == true)
+            vg.fill_color(text_color1)
+        else
+            vg.fill_color(text_color2)
+        end
+        if(layoutOpts.include? :left_text)
+            vg.text_align NVG::ALIGN_LEFT | NVG::ALIGN_MIDDLE
+            vg.text(8,h/2,button.label.upcase)
+        else
+            vg.text_align NVG::ALIGN_CENTER | NVG::ALIGN_MIDDLE
+            vg.text(w/2,h*0.666,"GL FILTER")
+            vg.text(w/2,h*0.333,"BYPASS")
+        end
+    }
+
+    function layout(l, selfBox)
+    {
+        if(!self.layoutOpts.include?(:no_constraint))
+            if(label.length == 1)
+                l.aspect(selfBox, 1, 1)
+            else
+                scale = 100
+                $vg.font_size scale
+                bb1 = $vg.text_bounds(0, 0, "BYPASS")
+                bb2 = $vg.text_bounds(0, 0, "GL FILTER")
+                bb  = [bb1, bb2].max/2
+                if(bb != 0)
+                    #Width cannot be so small that letters overflow
+                    self.aspect2(selfBox, bb, scale)
+                end
+            end
+        end
+        selfBox
+    }
+}

--- a/src/mruby-zest/example/ClearBox.qml
+++ b/src/mruby-zest/example/ClearBox.qml
@@ -1,0 +1,74 @@
+Widget {
+    id: box
+    property Bool  active: true
+    property Value value: false
+    property Function whenValue: nil;
+
+    function onMousePress(ev) {
+        return if !self.active
+        self.value = 1.0
+        whenValue.call if whenValue
+        damage_self
+    }
+
+    function animate()
+    {
+        return if self.value == 0
+        return if self.value == false
+        return if self.value == true
+        self.value *= 0.9
+        self.value  = 0 if self.value < 0.02
+        damage_self
+    }
+
+    function draw(vg)
+    {
+        off_color     = Theme::ButtonInactive
+        on_color      = Theme::ButtonActive
+        cs = 0
+        pad = 1.0/64
+        vg.path do |v|
+            v.rounded_rect(w*pad, h*pad, w*(1-2*pad), h*(1-2*pad), 2)
+            if(self.value == true)
+                cs = 1
+                v.fill_color on_color
+            elsif(self.value.class == Float && self.value != 0)
+                cs = 2
+                t = self.value
+                on = on_color
+                of = Theme::ButtonGrad1
+                v.fill_color(color_rgb(on.r*t + of.r*(1-t),
+                                       on.g*t + of.g*(1-t),
+                                       on.b*t + of.b*(1-t)))
+            else
+                paint = v.linear_gradient(0,0,0,h,
+                Theme::ButtonGrad1, Theme::ButtonGrad2)
+                v.fill_paint paint
+            end
+            v.fill
+            v.stroke_width 1
+            v.stroke
+
+        end
+
+        pad = 1.0/4
+
+        vg.stroke_color(color("bbbbbb")) #if !self.active
+        #vg.stroke_color(color("55ff55")) if  self.active
+        vg.path do
+            vg.move_to(1+pad*w,     1+pad*h)
+            vg.line_to((1-pad)*w-1, (1-pad)*h-1)
+            vg.stroke
+        end
+        vg.path do
+            vg.move_to((1-pad)*w-1,  1+pad*h)
+            vg.line_to(1+pad*w,     (1-pad)*h-1)
+            vg.stroke
+        end
+    }
+
+    function layout(l, selfBox) {
+        l.aspect(selfBox, 1, 1)
+        selfBox
+    }
+}

--- a/src/mruby-zest/example/ColorBox.qml
+++ b/src/mruby-zest/example/ColorBox.qml
@@ -1,0 +1,14 @@
+Widget {
+    property Color bg: color("8f600f")
+    property Float pad: 0.0
+    function draw(vg)
+    {
+        return if bg.nil?
+        pad2 = (1-2*pad)
+        vg.path do |v|
+            v.rect(pad*w,pad*h,pad2*w,pad2*h)
+            v.fill_color self.bg
+            v.fill
+        end
+    }
+}

--- a/src/mruby-zest/example/ColorButton.qml
+++ b/src/mruby-zest/example/ColorButton.qml
@@ -1,0 +1,34 @@
+Button {
+    property Color bg_color: color("000000")
+    function draw_button(vg) {
+        cs = 0
+        vg.path do |v|
+            v.rounded_rect(w*pad, h*pad, w*(1-2*pad), h*(1-2*pad), 2)
+            v.fill_color(self.bg_color)
+            v.fill
+            v.stroke_width 1
+            v.stroke
+        end
+    }
+    
+    function draw_text(vg)
+    {
+        text_color1   = color("111111")
+        text_color2   = color("eeeeee")
+        vg.font_face("bold")
+        vg.font_size h*self.textScale
+        if((self.bg_color.r + self.bg_color.b + self.bg_color.g) > 0.9)
+            vg.fill_color(text_color1)
+        else
+            vg.fill_color(text_color2)
+        end
+
+        if(layoutOpts.include? :left_text)
+            vg.text_align NVG::ALIGN_LEFT | NVG::ALIGN_MIDDLE
+            vg.text(8,h/2,self.label)
+        else
+            vg.text_align NVG::ALIGN_CENTER | NVG::ALIGN_MIDDLE
+            vg.text(w/2,h/2,self.label)
+        end
+    }
+}

--- a/src/mruby-zest/example/ColorScheme.qml
+++ b/src/mruby-zest/example/ColorScheme.qml
@@ -1,0 +1,23 @@
+Widget {
+    Widget {
+        function onSetup(old=nil) {
+            Theme.constants.each do |c|
+                ch = Qml::ColorButton.new(db)
+                ch.label = c.to_s
+                ch.bg_color = Theme.const_get(c)
+                Qml::add_child(self, ch)
+            end
+        }
+
+        function layout(l, selfBox) {
+            Draw::Layout::grid(l, selfBox, children, 8, 6)
+        }
+    }
+    Widget {
+        ColorSel{}
+    }
+
+    function layout(l, selfBox) {
+        Draw::Layout::vfill(l, selfBox, children, [0.60, 0.40])
+    }
+}

--- a/src/mruby-zest/example/ColorSel.qml
+++ b/src/mruby-zest/example/ColorSel.qml
@@ -1,0 +1,90 @@
+Widget {
+    function draw(vg) {
+        @hue ||= 0.2
+        @sx  ||= 0.1
+        @sy  ||= 0.4
+        draw_color_wheel(vg, x, y, w, h,
+            @hue / (2*Math::PI), @sx, @sy)
+    }
+
+    function abs(x) { [x,-x].max }
+
+    function onMousePress(ev) {
+        cx = x + w/2
+        cy = y + h/2
+
+        r1 = min(w,h)/2 - 5
+        r0 = r1 - 20
+
+        xx = ev.pos.x-global_x
+        yy = ev.pos.y-global_y
+
+        dx = (xx-cx)
+        dy = (yy-cy)
+
+        rr = Math::sqrt(dx*dx + dy*dy)
+
+        #puts "#{r1} -- #{rr} -- #{r0}"
+
+        if(r0 < rr && rr < r1)
+            @hue = Math::atan2(dy,dx)
+            #puts @hue
+            damage_self
+        end
+
+        rt = r0 - 6
+
+        tri_upper_x     = cx + rt*Math::cos(@hue)
+        tri_upper_y     = cy + rt*Math::sin(@hue)
+
+        tri_low_left_x  = cx + rt*Math::cos(@hue - (2*Math::PI)/3)
+        tri_low_left_y  = cy + rt*Math::sin(@hue - (2*Math::PI)/3)
+
+        tri_low_right_x = cx + rt*Math::cos(@hue + (2*Math::PI)/3)
+        tri_low_right_y = cy + rt*Math::sin(@hue + (2*Math::PI)/3)
+
+        _ux = tri_upper_x
+        _uy = tri_upper_y
+        _lx = tri_low_left_x
+        _ly = tri_low_left_y
+        _rx = tri_low_right_x
+        _ry = tri_low_right_y
+
+        _bx = (_lx+_rx)/2
+        _by = (_ly+_ry)/2
+
+        ul = dist(xx, yy, _ux, _uy, _lx, _ly)
+        ur = dist(xx, yy, _rx, _ry, _ux, _uy)
+        bt = dist(xx, yy, _lx, _ly, _rx, _ry)
+        md = dist(xx, yy, _ux, _uy, _bx, _by)
+
+        #puts "%%%  #{ul} -- #{ur} -- #{bt}"
+        #puts "inside" if ul > 0 && ur > 0 && bt > 0
+
+        range_y = Math::sqrt((_bx-_ux)*(_bx-_ux)+(_by-_uy)*(_by-_uy))
+        range_x = Math::sqrt((_lx-_rx)*(_lx-_rx)+(_ly-_ry)*(_ly-_ry))/2
+
+
+
+        #puts "y = #{bt/range_y} x = #{md/range_x}"
+        if(ul > 0 && ur > 0 && bt > 0)
+            #Yes, this is intentionally reversed
+            @sy = md/range_x
+
+            @sx = bt/range_y
+            extra = Math::sin(Math::PI/6.0)
+            @sx = @sx*(1+extra) - extra
+            #puts "@sx=#{@sx}  @sy=#{@sy}"
+            damage_self
+        end
+    }
+
+    function dist(px, py, x1, y1, x2, y2)
+    {
+        ((y2-y1)*px - (x2-x1)*py + x2*y1 - y2*x1)/Math::sqrt((y2-y1)*(y2-y1) + (x2-x1)*(x2-x1))
+    }
+    
+    function onMouseMove(ev) {
+        onMousePress(ev)
+    }
+}

--- a/src/mruby-zest/example/ConfirmButton.qml
+++ b/src/mruby-zest/example/ConfirmButton.qml
@@ -1,0 +1,43 @@
+Button {
+    id: toggle
+    property Object valueRef: nil
+    onExtern: {
+        meta = OSC::RemoteMetadata.new($remote, toggle.extern)
+        toggle.label   = meta.short_name if toggle.label.empty?
+        toggle.tooltip = meta.tooltip
+        toggle.valueRef = OSC::RemoteParam.new($remote, toggle.extern)
+        toggle.valueRef.callback = lambda {|x| toggle.setValue(x)}
+    }
+
+    function setValue(x)
+    {
+        self.value = x
+        whenValue.call if whenValue
+        damage_self
+    }
+
+    function onMousePress(ev) {
+        if(self.label != "confirm" && self.value)
+            @true_label = self.label
+            self.label = "confirm"
+            damage_self
+            return
+        elsif(self.label == "confirm")
+            self.label = @true_label
+            damage_self
+        end
+        self.value = !self.value
+        self.valueRef.value = self.value if self.valueRef
+        damage_self
+        whenValue.call if whenValue
+    }
+
+    function onMouseEnter(ev)
+    {
+        if(self.tooltip.nil? || self.tooltip.empty?)
+            self.root.log(:tooltip, "extern = <" + self.extern + ">")
+        else
+            self.root.log(:tooltip, self.tooltip)
+        end
+    }
+}

--- a/src/mruby-zest/example/CopyButton.qml
+++ b/src/mruby-zest/example/CopyButton.qml
@@ -1,0 +1,38 @@
+Button {
+    id: copy_button
+
+    property Int index: nil
+
+    onExtern: {
+        copy_button.tooltip = "copy from " + copy_button.extern.to_s
+    }
+
+    function layout(l, selfBox) {
+        l.aspect(selfBox, 1, 1)
+        selfBox
+    }
+
+    function animate()
+    {
+        return if self.value == 0
+        return if self.value == false
+        return if self.value == true
+        self.value *= 0.9
+        self.value  = 0 if self.value < 0.02
+        damage_self
+    }
+
+    function onMousePress(ev) {
+        return if !self.active
+        self.value = 1.0
+        if($remote && extern && !extern.empty?)
+            if(self.index)
+                $remote.action("/presets/copy", extern, self.index)
+            else
+                $remote.action("/presets/copy", extern)
+            end
+        end
+        damage_self
+    }
+    label: "C"
+}

--- a/src/mruby-zest/example/DataView.qml
+++ b/src/mruby-zest/example/DataView.qml
@@ -1,0 +1,40 @@
+Widget {
+    layer: 1
+    property Array data: nil;
+    property Bool  normal: true
+    property Float pad:   1.0/32
+    property Float fixedpad: 0
+    property Float phase: 0
+    property Bool  ignore_phase: false
+    property Bool under_highlight: false
+
+    function class_name() { "DataView" }
+
+    function draw(vg)
+    {
+        pad2 = (1-2*pad)
+
+        box = Rect.new(w*pad  + fixedpad,   h*pad  + fixedpad,
+                       w*pad2 - 2*fixedpad, h*pad2 - 2*fixedpad)
+
+        vphase = ignore_phase ? 0 : phase
+
+        if(data.class == Array && data[0].class == Float) # regular data
+            Draw::WaveForm::plot(vg, self.data, box, normal, vphase, under_highlight)
+
+        elsif(data.class == Array && data[0] == -40) # returns true in the formant filter view sometimes
+            Draw::WaveForm::plot(vg, self.data, box, normal, vphase, under_highlight)
+
+        elsif(data.class == Array && data[0] == 0 && data[5] == 0)
+            Draw::WaveForm::plot(vg, self.data, box, false, vphase)
+
+        elsif(data.class == Array && data[0].class == Array)
+            Draw::WaveForm::plot(vg, self.data[0], box, normal, vphase)
+            Draw::WaveForm::plot(vg, self.data[1], box, normal, vphase)
+
+        else
+            Draw::WaveForm::sin(vg, box)
+        end
+    }
+}
+

--- a/src/mruby-zest/example/DataViewAlt.qml
+++ b/src/mruby-zest/example/DataViewAlt.qml
@@ -1,0 +1,21 @@
+Widget {
+    id: draw_alt
+    layer: 1
+    property Array points: draw_alt.mk_points
+
+    function mk_points()
+    {
+        pts = []
+        while(pts.length < 256)
+            pts << 0
+        end
+        pts
+    }
+
+    function draw(vg)
+    {
+        pad = 5
+        box = Rect.new(pad, pad, w-2*pad, h-2*pad)
+        Draw::WaveForm::plot(vg, self.points, box, false)
+    }
+}

--- a/src/mruby-zest/example/DemoLayers.qml
+++ b/src/mruby-zest/example/DemoLayers.qml
@@ -1,0 +1,48 @@
+Widget {
+    id: demo
+
+    function draw(vg)
+    {
+        vg.path do |v|
+            v.rect(0,0,w,h)
+            grad = v.linear_gradient(0,0,512,512,NVG.rgba(0,0,0,255),
+            NVG.rgba(rand(255),rand(255),rand(255),255))
+            v.fill_paint = grad
+            v.fill
+        end
+    }
+
+    function onMousePress(ev) { }
+
+    function onMouseHover(ev)
+    {
+        #pos = ev.pos
+        #drect = Rect.new(pos.x-2, pos.y-2, 16, 16)
+        #root.draw_damage(drect, demo.layer)
+    }
+
+    Knob {
+        x: 100
+        y: 200
+        w: 100
+        h: 100
+    }
+    Knob{
+        x: 300
+        y: 200
+        w: 100
+        h: 100
+    }
+    Knob{
+        x: 400
+        y: 200
+        w: 100
+        h: 100
+    }
+    Knob{
+        x: 400
+        y: 300
+        w: 100
+        h: 100
+    }
+}

--- a/src/mruby-zest/example/DummyBox.qml
+++ b/src/mruby-zest/example/DummyBox.qml
@@ -1,0 +1,7 @@
+Widget {
+    function draw(vg)
+    {
+        bb = Rect.new(0, 0, w, h)
+        Draw::GradBox(vg, bb)
+    }
+}

--- a/src/mruby-zest/example/FancyButton.qml
+++ b/src/mruby-zest/example/FancyButton.qml
@@ -1,0 +1,125 @@
+Widget {
+    id: fancy
+    property Function whenClick: nil
+    property Bool     value:     false
+    property Object   valueRef:  nil
+    function class_name() { "FancyButton" }
+
+    onExtern: {
+        meta = OSC::RemoteMetadata.new($remote, fancy.extern)
+        fancy.tooltip = meta.tooltip
+
+        fancy.valueRef = OSC::RemoteParam.new($remote, fancy.extern)
+        fancy.valueRef.callback = Proc.new {|x| fancy.set_sub_value(x)}
+        pow.extern = fancy.extern
+        pow.extern()
+    }
+
+    function set_value(x)
+    {
+        self.value = x
+        damage_self
+    }
+
+    function set_sub_value(x)
+    {
+        pow.value = x
+        damage_self
+    }
+
+    function draw(vg)
+    {
+        pad = 0
+        off_color     = Theme::ButtonInactive
+        on_color      = Theme::ButtonActive
+        cs = 0
+        vg.path do |v|
+            v.rounded_rect(w*pad, h*pad, w*(1-2*pad), h*(1-2*pad), 3)
+            if(self.value == true)
+                cs = 1
+                v.fill_color on_color
+            elsif(self.value.class == Float && self.value != 0)
+                cs = 2
+                t = self.value
+                on = on_color
+                of = Theme::ButtonGrad1
+                v.fill_color(color_rgb(on.r*t + of.r*(1-t),
+                                       on.g*t + of.g*(1-t),
+                                       on.b*t + of.b*(1-t)))
+            else
+                paint = v.linear_gradient(0,0,0,h,
+                Theme::ButtonGrad1, Theme::ButtonGrad2)
+                v.fill_paint paint
+            end
+            v.fill
+            v.stroke_width 1
+            v.stroke
+
+        end
+
+        vg.translate(0.5,0.5)
+
+        vg.path do |v|
+            hh = h/20
+            source_x = (w*pad+3).round()
+            source_y = (h*pad+hh).round()
+            dest_x = (w*(1-2*pad)-2).round()
+            dest_y = source_y
+
+            v.move_to(source_x, source_y)
+            v.line_to(dest_x, dest_y)
+
+            if(cs == 0)
+                v.stroke_color color("5c5c5c")
+            elsif(cs == 1)
+                v.stroke_color color("16a39c")
+            end
+            if([0,1].include?(cs))
+                v.stroke_width 1
+                v.stroke
+            end
+        end
+
+        vg.translate(-0.5,-0.5)
+
+
+        text_color1   = Theme::TextActiveColor
+        text_color2   = Theme::TextColor
+        vg.font_face("bold")
+        vg.font_size h*0.6
+        vg.text_align NVG::ALIGN_CENTER | NVG::ALIGN_MIDDLE
+
+        if(value)
+            vg.fill_color(text_color1)
+        else
+            vg.fill_color(text_color2)
+        end
+
+        vg.text(w/2 + pow.w / 2,h/2,label.upcase)
+    }
+
+    function onMousePress(ev) {
+        #self.value = !self.value
+        #damage_self
+        valueRef.value = true if(value == false && valueRef)
+        whenClick.call if whenClick
+    }
+
+    function layout(l,selfBox)
+    {
+        box = pow.fixed(l, selfBox, 0, 0, 0.25, 1)
+        box.x = 0
+        box.y = 0
+        box.h = selfBox.h
+        if(layoutOpts.include? :no_constraint)
+            box.w = 0.25*selfBox.w
+        end
+        selfBox
+    }
+
+    PowButton {
+        id: pow
+        function class_name() { "PowButton" }
+    }
+
+}

--- a/src/mruby-zest/example/FileButton.qml
+++ b/src/mruby-zest/example/FileButton.qml
@@ -1,0 +1,47 @@
+TriggerButton {
+    id: filebutton
+    property String extval: ".scl";
+    whenValue: lambda { filebutton.file_select() }
+
+    function onMousePress(ev) {
+        return if !self.active
+        self.value = 1.0
+        whenValue.call if whenValue
+        damage_self
+    }
+
+    function setup_widget(w)
+    {
+        w.onSetup()
+        w.children.each do |c|
+            setup_widget(c)
+        end
+    }
+
+    function file_select()
+    {
+        win = window()
+        wid = Qml::FileSelector.new(db)
+        wid.whenValue = lambda { |x| filebutton.file_value(x)}
+        wid.x = 0#-global_x
+        wid.y = 0#-global_y
+        wid.w = win.w
+        wid.h = win.h
+        wid.ext = self.extval
+        Qml::add_child(win, wid)
+        self.db.update_values
+        setup_widget wid
+        self.db.update_values
+
+        if(root)
+            root.smash_layout
+            root.damage_item(win, :all)
+        end
+    }
+
+    function file_value(val)
+    {
+        return if val == :cancel
+        $remote.action(self.extern, val)
+    }
+}

--- a/src/mruby-zest/example/FileSelector.qml
+++ b/src/mruby-zest/example/FileSelector.qml
@@ -1,0 +1,308 @@
+Widget {
+    id: file
+    layer: 2
+    property Object valueRef: nil
+    property Function whenValue: nil
+
+    property String ext:       nil
+    property String pat:       nil
+
+    SelColumn {
+        id: folders
+        layer: 2
+        layoutOpts: [:no_constraint]
+        extern: "/file_list_dirs"
+        style: :overlay
+        label: "Folder"
+        doupcase: false
+        nrows: 20
+        clear_on_extern: true
+        whenValue: lambda {
+            return if folders.selected.empty?
+            file.browser.change_dir_rel(folders.selected)
+            file.check
+        }
+    }
+    SelColumn {
+        id: files
+        layer: 2
+        layoutOpts: [:no_constraint]
+        extern: "/file_list_files"
+        style: :overlay
+        label: "Files"
+        nrows: 20
+        doupcase: false
+        clear_on_extern: true
+        pattern: Regexp.new(file.pat) if file.pat
+        whenValue: lambda {
+            return if files.selected.empty?
+            file.browser.change_file(files.selected)
+            file.check
+        }
+    }
+    TextField {
+        id: line
+        style: :overlay
+        layoutOpts: [:no_constraint]
+        layer: 2;
+    }
+    TriggerButton {
+        id:    ebutton
+        layoutOpts: [:no_constraint]
+        layer: 2;
+        label: "Enter"
+        whenValue: lambda {file.whenEnter}
+        function draw(vg) {
+            parent.draw_button(vg, w, h, self.pad)
+            parent.draw_text(vg, w, h, self.label, self.textScale)
+        }
+    }
+
+    Menu {
+        id: favs
+        options: []
+        layer: 2
+        layoutOpts: [:no_constraint]
+        label: "favorites"
+        whenValue: lambda {
+            file.browser.change_dir_abs(favs.options[favs.selected]) if favs.selected
+            file.check
+        }
+    }
+
+    TriggerButton {
+        id: add
+        label: "add favorite"
+        layer: 2
+        layoutOpts: [:no_constraint]
+
+        function onMousePress(ev) {
+            add = "add favorite"
+            clr = "clear favs?"
+            if(ev.buttons.include? :leftButton)
+                file.addFav
+                self.label = add
+                self.whenValue.call if self.whenValue
+            elsif(ev.buttons.include? :rightButton)
+                if(self.label == clr)
+                    file.clrFav
+                    self.label = add
+                else
+                    self.label = clr
+                end
+            end
+            damage_self
+        }
+
+        function draw(vg) {
+            parent.draw_button(vg, w, h, self.pad)
+            parent.draw_text(vg, w, h, self.label, self.textScale)
+        }
+    }
+
+    function draw_text(vg, w, h, text, textScale=0.8)
+    {
+        vg.font_face("bold")
+        vg.font_size h*textScale
+        vg.fill_color color("56c0a5")
+        if(layoutOpts.include? :left_text)
+            vg.text_align NVG::ALIGN_LEFT | NVG::ALIGN_MIDDLE
+            vg.text(8,h/2,text.upcase)
+        else
+            vg.text_align NVG::ALIGN_CENTER | NVG::ALIGN_MIDDLE
+            vg.text(w/2,h/2,text.upcase)
+        end
+    }
+
+    function draw_button(vg, w, h, pad)
+    {
+        vg.path do |v|
+            v.rect(w*pad, h*pad, w*(1-2*pad), h*(1-2*pad))
+            v.stroke_color color("56c0a5")
+            v.stroke_width 1
+            v.stroke
+        end
+    }
+
+
+    //Measurements from mockup
+    //1181x659 mockup
+    //left side 280px pad
+    //right side 900px of 1180 = 280px pad
+    //580px-600px inner trough
+    //30px-64px top
+    //813px-834px top tough
+    //85-573px selector y
+    //594-628px add y
+    function layout(l, selfBox) {
+        mockx   = 1181.0
+        mocky   = 659.0
+        xpad    = 280/mockx
+        xskip   = 20/mockx
+
+        top_y  = 30/mocky
+        top_h  = 34/mocky
+        top_w  = (813-280)/mockx
+        top_x  = xpad
+        top_x2 = top_x+top_w+xskip
+        top_w2 = 1-xpad-top_x2
+
+        ff_y    = 85/mocky
+        ff_h    = (573-85)/mocky
+        ff_w    = 0.5-xskip/2-xpad
+        ff_x    = xpad
+        ff_x2   = 0.5+0.5*xskip
+
+        fv_y  = 594/mocky
+        fv_h  = (628-594)/mocky
+        fv_x  = xpad
+        fv_x2 = 2*xpad
+        #values from mockup
+        #fv_w  = 0.1
+        #fv_w2 = 0.1
+        #values to not make the current revision look dumb
+        fv_w  = 0.2
+        fv_w2 = 0.2
+
+        sel_folder = children[0]
+        sel_column = children[1]
+        line       = children[2]
+        select     = children[3]
+        favs       = children[4]
+        add_favs   = children[5]
+        sel_folder.fixed(l, selfBox, ff_x,   ff_y,  ff_w,   ff_h)
+        sel_column.fixed(l, selfBox, ff_x2,  ff_y,  ff_w,   ff_h)
+        line.fixed(l,       selfBox, top_x,  top_y, top_w,  top_h)
+        select.fixed(l,     selfBox, top_x2, top_y, top_w2, top_h)
+        favs.fixed(l,       selfBox, fv_x,   fv_y,  fv_w,   fv_h)
+        add_favs.fixed(l,   selfBox, fv_x2,  fv_y,  fv_w2,  fv_h)
+        selfBox
+    }
+
+    function browser() { @browser }
+
+    function onSetup(v=nil) {
+        @browser = FileBrowser.new
+
+        #Get files when home dir (or any subsequent dir) is setup
+        dirs  = OSC::RemoteParam.new($remote, "/file_list_dirs")
+        dirs.callback   = lambda { |x|
+            file.browser.set_dirs(x)
+            file.check
+        }
+        files = OSC::RemoteParam.new($remote, "/file_list_files")
+        files.callback = lambda { |x|
+            file.browser.set_files(x)
+            file.check
+        }
+
+
+        #Get the starting path i.e. the HOME dir
+        home = nil
+        if($current_dir.nil?)
+            home  = OSC::RemoteParam.new($remote, "/file_home_dir")
+            home.callback = lambda { |x|
+                file.browser.set_home_dir(x)
+                file.check
+            }
+        else
+            @browser.set_home_dir($current_dir)
+        end
+
+        fav   = OSC::RemoteParam.new($remote, "/config/favorites")
+        fav.callback  = lambda { |x| set_favs(x) }
+
+        self.valueRef = [dirs, files, home]
+    }
+
+    function set_favs(x)
+    {
+        return if x.nil? || x.empty?
+
+        favs.options =  x  if x.class == Array
+        favs.options = [x] if x.class != Array
+        favs.damage_self
+    }
+
+    function addFav()
+    {
+        #TODO
+        $remote.action("/config/add-favorite", line.label)
+        $remote.action("/config/favorites")
+    }
+
+    function clrFav()
+    {
+        $remote.action("/config/clear-favorites")
+        $remote.action("/config/favorites")
+    }
+
+    function onKey(k, mode)
+    {
+        return if mode != "press"
+        if(k.ord == 27) #esc
+            whenCancel
+            return
+        elsif(k.ord == 9) #tab
+            if(ebutton.value != true)
+                ebutton.value = true
+            else
+                ebutton.value = 0.0
+            end
+            ebutton.damage_self
+            line.label = line.label[0...-1]
+            return
+        elsif(k.ord == 13) #enter
+            line.label = line.label[0...-1]
+            whenEnter
+            return
+        elsif(k.ord == 8)
+            @browser.del_char
+        elsif k.ord >= 32
+            @browser.add_char k
+        end
+
+        check
+    }
+
+    function check()
+    {
+        return if !@browser.needs_refresh
+        @browser.clear_flags
+
+        path = @browser.path
+        if self.ext && !path.end_with?(self.ext)
+            line.label = [@browser.path, self.ext]
+        else
+            line.label = @browser.path
+        end
+        line.damage_self
+        line.instance_eval("undef :onKey") if line.respond_to?(:onKey)
+
+        search = @browser.search_path
+
+        $remote.action("/file_list_dirs",  search)
+        $remote.action("/file_list_files", search)
+    }
+
+    function draw(vg) {
+        background color("000000", 220)
+    }
+
+    function whenEnter() {
+        ll = @browser.path
+        ll = ll + self.ext if self.ext && !ll.end_with?(self.ext)
+        whenValue.call(ll) if whenValue
+        root.ego_death self
+    }
+
+    function whenCancel() {
+        whenValue.call(:cancel) if whenValue
+        root.ego_death self
+    }
+
+    function onMousePress(m)
+    {
+        whenCancel
+    }
+}

--- a/src/mruby-zest/example/Forms.qml
+++ b/src/mruby-zest/example/Forms.qml
@@ -1,0 +1,43 @@
+Widget {
+    id: forms
+    Text {
+        label: forms.label
+    }
+
+    function draw(vg) {
+        vg.path do |v|
+            v.rect(0,0,w,h)
+            paint = v.linear_gradient(0,0,0,h,
+            Theme::ModuleGrad1, Theme::ModuleGrad2)
+            v.fill_paint paint
+            v.fill
+            v.stroke_color(color("000000"))
+            v.stroke
+        end
+    }
+    function onSetup(old=nil) {
+        return if @setup_done
+        children[1..-1].each do |c|
+            ch = Qml::TextBox.new(db)
+            ch.label = c.tooltip
+            ch.align = :left
+            Qml::add_child(self, ch)
+        end
+        @setup_done = true
+    }
+    function layout(l, selfBox) {
+        n = (children.length + 1)/2
+
+        l.fixed_long(children[0], selfBox,
+            0, 0, 1, 1.0/n,
+            0, 0, 0, 0)
+        (1...n).each do |i|
+            l.fixed_long(children[i+n-1], selfBox,
+                0, i/n, 0.75, 0.5/n, 
+                10, 0, 0, 0)
+            l.fixed_long(children[i], selfBox,
+                0.25, (i+0.5)/n, 0.75, 0.5/n, 
+                0, 0, -10, 0)
+        end
+    }
+}

--- a/src/mruby-zest/example/GroupHeader.qml
+++ b/src/mruby-zest/example/GroupHeader.qml
@@ -1,0 +1,68 @@
+Widget {
+    id: titleW
+
+    property Function whenClick:    nil
+    property Bool     toggleable:   false
+    property Bool     copyable:     false
+
+    function onMousePress(ev) {
+        whenClick.call if whenClick
+    }
+
+    function class_name() { "TitleBox" }
+
+    function pack_misc(l, selfBox, ch)
+    {
+        #Create A list of boxes
+        bbs = []
+        n = children.length
+        children.each_with_index do |ch, i|
+            box = l.genConstBox(selfBox.w*i/n, 0,
+            selfBox.w/n, selfBox.h, ch)
+            bb = ch.layout(l, box)
+            bbs << bb
+        end
+
+        bbs[0].x = 15 if bbs[0].x > 15
+
+        #put stuff on backwards
+        bx = selfBox.w
+        bbs[1..-1].reverse.each do |b|
+            b.x  = bx-b.w
+            bx  -= b.w
+        end
+
+        return selfBox
+    }
+
+    function layout(l, selfBox)
+    {
+        pack_misc(l, selfBox, children)
+    }
+
+    Text {
+        id: title
+        label: self.label
+        align: :left
+        textColor: Theme::TextModColor
+        height: 0.8
+    }
+
+    function onSetup(old=nil)
+    {
+        return if children.length != 1
+        if(self.toggleable)
+            pb = Qml::PowButton.new(db)
+            pb.extern = self.toggleable
+            Qml::add_child(self, pb)
+        end
+        if(self.copyable)
+            cb = Qml::CopyButton.new(db)
+            pb = Qml::PasteButton.new(db)
+            cb.extern = self.extern
+            pb.extern = self.extern
+            Qml::add_child(self, cb)
+            Qml::add_child(self, pb)
+        end
+    }
+}

--- a/src/mruby-zest/example/HSlider.qml
+++ b/src/mruby-zest/example/HSlider.qml
@@ -1,0 +1,83 @@
+Valuator {
+    property Bool centered: false;
+    property Float pad: 0.02
+    property Float height: 0.6
+    property Bool  active: true
+    property Bool  value_label: false
+    vertical: false
+
+    function draw_centered(vg, pad)
+    {
+        pad2 = (1-2*pad)
+        va = 1-value
+        if(va >= 0.5)
+            vv   = [0.01, va-0.5+0.01].max
+            src = (w*0.5-w*pad2*vv)
+            dst = (w*0.51)
+            vg.path do |v|
+                v.rect(src, pad*h, (src-dst).abs, pad2*h)
+                v.fill_color Theme::SliderActive
+                v.fill
+            end
+        else
+            vv   = [0.01, 0.5-va+0.01].max
+            vg.path do |v|
+                v.rect(w*0.49, pad*h, pad2*w*vv, pad2*h)
+                v.fill_color Theme::SliderActive
+                v.fill
+            end
+        end
+    }
+
+
+    function draw(vg)
+    {
+        self.dragScale = w
+        pad2 = (1-2*pad)
+        vg.path do |v|
+            v.rect(pad*w, pad*h, pad2*w, pad2*h)
+            v.fill_color Theme::SliderBackground
+            v.stroke_color color(:black)
+            v.fill
+            v.stroke
+        end
+
+        if(centered)
+            draw_centered(vg, pad)
+        else
+            vg.path do |v|
+                v.rect(pad*w, pad*h, value*w*pad2, pad2*h)
+                v.fill_color Theme::SliderActive
+                v.fill
+            end
+        end
+
+        vg.path do |v|
+            v.move_to(w*pad+w*pad2*value, pad*h)
+            v.line_to(w*pad+w*pad2*value, pad2*h)
+            v.stroke_color Theme::SliderStroke
+            v.stroke_width 2.0
+            v.stroke
+        end
+
+        vg.font_face("bold")
+        vg.font_size height*h
+        vg.text_align NVG::ALIGN_CENTER | NVG::ALIGN_MIDDLE
+        vg.fill_color(Draw::fade(Theme::TextColor))
+        if(value_label && self.valueRef)
+            vg.text(w/2,h/2,self.valueRef.display_value.to_s)
+        else
+            vg.text(w/2,h/2,label.upcase)
+        end
+
+
+        if(!self.active)
+            vg.path do
+                vg.move_to(pad*w, pad*h)
+                vg.line_to(pad2*w, pad2*h)
+                vg.stroke_color Theme::SliderStroke
+                vg.stroke
+            end
+        end
+    }
+}

--- a/src/mruby-zest/example/HarmonicEdit.qml
+++ b/src/mruby-zest/example/HarmonicEdit.qml
@@ -1,0 +1,131 @@
+Widget {
+    id: hedit
+    property Function whenValue: nil
+    property Symbol   type: :oscil
+    property Int      totalHarm: 128
+    property Int      oldOff: 0
+    property Int      curOff: 0
+
+    function cb() { whenValue.call if whenValue }
+
+    function clear()
+    {
+        children.each_with_index do |ch, i|
+            mval = 64.1/127.0 if(type == :oscil)
+            mval = 0/127.0  if(type == :subsynth)
+            pval = 64.1/127.0
+            mval = 1.0 if i == 0
+            ch.children[0].value          = mval
+            ch.children[0].valueRef.value = mval
+            ch.children[2].value          = pval
+            ch.children[2].valueRef.value = pval
+        end
+    }
+
+    function animate()
+    {
+        return if(self.oldOff == self.curOff)
+        off = self.curOff
+        self.oldOff = self.curOff
+
+        children.each_with_index do |ch, i|
+            ii = (i+off).to_i.to_s
+            ch.children[1].label = ii
+            if(self.type == :oscil)
+                ch.children[0].extern = self.extern + "magnitude" + ii
+                ch.children[2].extern = self.extern + "phase"     + ii
+            end
+        end
+        damage_self
+    }
+
+    function set_scroll(val)
+    {
+        len  = totalHarm - 32
+        off  = 32*(val*len/32).to_i
+
+        return if(self.oldOff == off)
+        self.curOff = off
+    }
+
+    function onSetup(old=nil)
+    {
+        return if !children.empty?
+        (0...32).each do |ev|
+            hm           = Qml::HarmonicEditSingle.new(db)
+            hm.num       = ev
+            hm.extern    = self.extern
+            hm.slidetype = self.type
+            hm.whenValue = lambda {hedit.cb}
+            Qml::add_child(self, hm)
+        end
+    }
+
+    function layout(l, selfBox)
+    {
+        n = children.length*1.0
+        children.each_with_index do |ch, id|
+            ch.fixed(l, selfBox, id/n, 0, 1.0/n, 1.0)
+        end
+
+        selfBox
+    }
+
+    function draw(vg)
+    {
+        return
+        vg.path do |v|
+            v.rect(0,0,self.w,self.h)
+            v.fill_color color("ff600f")
+            v.fill
+        end
+    }
+
+    function onMousePress(ev) {
+        @active_widget  = root.activeWidget(ev.pos.x, ev.pos.y)
+        @active_y       = ev.pos.y
+        @active_buttons = ev.buttons
+        return if @active_widget.class != Qml::Slider
+        $remote.automate(@active_widget.extern) if(root.learn_mode && @active_widget.extern)
+
+        if(ev.buttons.include? :leftButton)
+            @prev = ev.pos
+            now = Time.new
+            if (@click_time && (now-@click_time) < 0.400)
+                @active_widget.reset
+            end
+            @click_time = now
+        elsif(ev.buttons.include? :rightButton)
+            if(children.empty?)
+                @active_widget.create_radial
+            end
+        elsif(ev.buttons.include? :middleButton)
+            @active_widget.reset
+        else
+            @prev = ev.pos
+        end
+    }
+
+    function onMouseMove(ev) {
+        @active_buttons ||= []
+        fine = root.fine_mode ? 0.05 : 1.0
+        nactive = root.activeWidget(ev.pos.x, ev.pos.y)
+        if(@prev && @active_widget == nactive && @active_buttons.include?(:leftButton))
+            delta = +(ev.pos.y - @prev.y)
+            return if nactive.class != Qml::Slider
+            @active_widget.updatePos(fine*delta/@active_widget.dragScale)
+            @prev = ev.pos
+        elsif(@prev && @active_buttons.include?(:leftButton))
+            @active_widget = :dummy
+            nactive = root.activeWidget(ev.pos.x, @active_y)
+            return if nactive.class != Qml::Slider
+            val = (ev.pos.y-nactive.global_y)/nactive.h
+            nactive.updatePosAbs(1-val)
+        elsif(@active_buttons.include?(:middleButton))
+            @active_widget = :dummy
+            nactive = root.activeWidget(ev.pos.x, @active_y)
+            return if nactive.class != Qml::Slider
+            nactive.reset
+        end
+    }
+}

--- a/src/mruby-zest/example/HarmonicEditSingle.qml
+++ b/src/mruby-zest/example/HarmonicEditSingle.qml
@@ -1,0 +1,71 @@
+ColorBox {
+    property Function whenValue: nil
+    property Int      num: 0
+    property Symbol   slidetype: nil
+    id: hes
+    bg: nil
+
+    function cb()
+    {
+        whenValue.call if whenValue
+    }
+
+    Slider {
+        value: 0.5
+        pad: 0
+        centered: hes.slidetype == :oscil
+        extern: {
+            if(hes.slidetype == :oscil)
+                hes.extern + "magnitude" + hes.num.to_s
+            else
+                hes.extern + "Phmag" + hes.num.to_s
+            end
+        }
+        whenValue: lambda {hes.cb}
+
+        function onSetup(old=nil) {
+            undef :onMousePress if self.respond_to?(:onMousePress)
+            undef :onMouseMove  if self.respond_to?(:onMouseMove)
+        }
+    }
+    Text {
+        layoutOpts: [:ignoreAspect]
+        height: 1.0
+        label: (1+hes.num).to_s
+    }
+
+    Slider {
+        value: 0.5
+        pad: 0
+        centered: hes.slidetype == :oscil
+        extern: {
+            if(hes.slidetype == :oscil)
+                hes.extern + "phase" + hes.num.to_s
+            else
+                hes.extern + "Phrelbw" + hes.num.to_s
+            end
+        }
+        whenValue: lambda {hes.cb}
+
+        function onSetup(old=nil) {
+            undef :onMousePress if self.respond_to?(:onMousePress)
+            undef :onMouseMove  if self.respond_to?(:onMouseMove)
+        }
+
+    }
+
+    function layout(l, selfBox)
+    {
+        children[0].fixed(l, selfBox, 0.0, 0.00, 1.0, 0.47)
+        children[1].fixed(l, selfBox, 0.0, 0.48, 1.0, 0.08)
+        children[2].fixed(l, selfBox, 0.0, 0.57, 1.0, 0.43)
+        selfBox
+    }
+
+    function onSetup(v=nil)
+    {
+        children.each do |c|
+            c.extern()
+        end
+    }
+}

--- a/src/mruby-zest/example/HarmonicView.qml
+++ b/src/mruby-zest/example/HarmonicView.qml
@@ -1,0 +1,67 @@
+Widget {
+    id: harmonic_view
+    property Object type:     :osc
+    property Object valueRef: nil
+
+    onExtern: {
+        rem   = harmonic_view.extern
+        type  = harmonic_view.type
+        rharm = rem                       if(type == :osc)
+        rharm = rem + "oscilgen/spectrum" if(type == :pad)
+
+        ref = OSC::RemoteParam.new($remote, rharm)
+        ref.callback = lambda {|x|
+            #x = x.map {|x| Math.log10(x)}
+            x = Draw::DSP::norm_harmonics(x)
+            nharmonics = 64
+            x = x[0..nharmonics-1] if x.length > nharmonics
+            harmonic_view.points = x
+            harmonic_view.damage_self
+        }
+        refs = [ref]
+        if(type == :pad)
+            ref = OSC::RemoteParam.new($remote,rem + "nhr")
+            ref.callback = lambda {|x|
+                harmonic_view.shift = x
+                harmonic_view.damage_self
+            }
+            refs << ref
+        end
+
+        harmonic_view.valueRef = refs
+
+    }
+
+    function refresh()
+    {
+        vr = self.valueRef
+        if(vr)
+            vr.each do |r|
+                r.refresh
+            end
+        end
+    }
+
+    function make_points()
+    {
+        pts = [1.0, 0.5, 0.0, 0.0, 0.7]
+        loop {
+            break if pts.length == 128
+            pts << 0.0
+        }
+        pts
+    }
+
+
+    property Array points: harmonic_view.make_points
+    property Array shift:  nil
+
+    function draw(vg)
+    {
+        pad  = 1.0/32
+        pad2 = (1-2*pad)
+        background Theme::VisualBackground
+        bb = Rect.new(pad*w, pad*h, pad2*w, pad2*h)
+        Draw::WaveForm::bar(vg, self.points, bb,Theme::HarmonicColor, self.shift)
+    }
+}

--- a/src/mruby-zest/example/Indent.qml
+++ b/src/mruby-zest/example/Indent.qml
@@ -1,0 +1,26 @@
+Widget {
+    id: indent
+    property Unused pad: 2;
+
+    function class_name() { "Indent" }
+    function layout(l, selfBox)
+    {
+        return selfBox if children.empty?
+
+        child = self.children[0]
+
+        chBox = l.genConstBox(pad, pad,
+                selfBox.w-2*pad, selfBox.h-2*pad, child)
+        child.layout(l, chBox)
+        selfBox
+    }
+
+    function draw(vg) {
+        indent_color = color("232C36")
+        vg.path do |v|
+            v.rounded_rect(0, 0, w, h, 3)
+            v.fill_color Theme::VisualBackground
+            v.fill
+        end
+    }
+}

--- a/src/mruby-zest/example/KitButton.qml
+++ b/src/mruby-zest/example/KitButton.qml
@@ -1,0 +1,102 @@
+Widget {
+    id: button
+    property signal action: nil;
+    property Bool   value:    false;
+    property Bool   enable:   false;
+    tooltip: "Use Middle Mouse To Toggle"
+    
+    function set_enable(v) {
+        if(button.enable != v)
+            button.enable = v
+            damage_self
+        end
+    }
+
+    function onMousePress(ev) {
+        if(ev.buttons.include? :leftButton)
+            action.call(:change_view) if action
+        elsif(ev.buttons.include? :middleButton)
+            action.call(:toggle) if action
+        end
+        damage_self
+    }
+
+    function onMerge(val)
+    {
+        button.value = val.value
+    }
+
+    function class_name()
+    {
+        "KitButton"
+    }
+
+    function layout(l, selfBox)
+    {
+        if(selfBox.nil?)
+            t = widget.class_name.to_sym
+            selfBox = l.genBox t, widget
+        end
+        selfBox
+    }
+
+    function draw(vg)
+    {
+        off_color     = Theme::ButtonInactive
+        on_color      = Theme::ButtonActive
+        outline_color = Theme::ButtonActive
+        text_color1   = Theme::TextActiveColor
+        text_color2   = color("B9CADE")
+        background_color = Theme::VisualBackground
+
+        #TODO check textcolor2 and outline
+        pad = 0.05
+
+        rect_x = (w*pad).round()
+        rect_y = (h*pad).round()
+        rect_w = (w*(1-2*pad)).round()
+        rect_h = (h*(1-2*pad)).round()
+
+        vg.translate(0.5, 0.5)
+
+        vg.path do |v|
+            v.rect(rect_x, rect_y, rect_w, rect_h)
+
+            if(button.value)
+                v.fill_color on_color
+            else
+                v.fill_color off_color
+            end
+            v.fill
+            if(self.enable)
+                v.stroke_color(outline_color)
+                v.stroke_width 1
+                v.stroke
+            end
+        end
+
+        #inner rectangle when enabled
+        if(self.enable)
+            vg.path do |v|
+                    v.stroke_color background_color
+
+                    stroke_width = 1
+                    v.stroke_width = stroke_width
+
+                    v.rect(rect_x + stroke_width, rect_y + stroke_width, rect_w - stroke_width * 2, rect_h - stroke_width * 2)
+                    v.stroke
+            end
+        end
+        vg.translate(-0.5, -0.5)
+
+        vg.font_face("bold")
+        vg.font_size (h*0.65).to_i
+        vg.text_align NVG::ALIGN_CENTER | NVG::ALIGN_MIDDLE
+        if(self.enable)
+            vg.fill_color(text_color1)
+        else
+            vg.fill_color(text_color2)
+        end
+        vg.text(w/2,h/2,button.label.upcase)
+    }
+}

--- a/src/mruby-zest/example/KitButtons.qml
+++ b/src/mruby-zest/example/KitButtons.qml
@@ -1,0 +1,119 @@
+Widget {
+    id: kitbuttons
+    property Int rows: 4
+    property Symbol sym: nil
+    property Array  valueRef: []
+
+    function set_view()
+    {
+        prt  = root.get_view_pos(:part)
+        kid  = root.get_view_pos(:kit)
+
+        self.valueRef.each do |v|
+            v.clean
+        end
+
+        v = []
+        (0...rows).each do |r|
+            [0,1,2,3].each do |c|
+                ii         = (1+c + 4*r)
+                but  = children[ii-1]
+                path = ""
+                path = "/part#{prt}/kit#{ii-1}/Penabled" if self.sym == :kit
+                path = "/part#{ii-1}/Penabled" if self.sym == :part
+                path = "/part#{prt}/kit#{kid}/adpars/VoicePar#{ii-1}/Enabled" if self.sym == :voice
+
+                rr = OSC::RemoteParam.new($remote, path)
+                rr.callback = lambda {|vv| but.set_enable(vv)}
+                v << rr
+            end
+        end
+        self.valueRef = v
+    }
+
+    function onSetup(old=nil)
+    {
+        return if children.length > 0
+        (0...rows).each do |r|
+            [0,1,2,3].each do |c|
+                ii         = (1+c + 4*r)
+                but        = Qml::KitButton.new(db)
+                but.tooltip = "part: use middle mouse to toggle" if self.sym == :part
+                but.tooltip = "kits: use middle mouse to toggle" if self.sym == :kit
+                but.tooltip = "voice: use middle mouse to toggle" if self.sym == :voice
+                but.label  = ii.to_s
+                but.action = lambda {|act|
+                    if(act == :change_view)
+                        kitbuttons.change_active(ii-1)
+                    else
+                        kitbuttons.toggle(ii-1)
+                    end
+                }
+                Qml::add_child(self, but)
+            end
+        end
+
+        set_view
+    }
+
+    function set_kit_enable(ii, val)
+    {
+        return if ii < 0
+        return if ii >= children.length
+        children[ii].set_enable(val)
+    }
+
+    function change_active(ii)
+    {
+        root.set_view_pos(self.sym,ii) if self.sym
+        root.set_view_pos(:view, :add_synth) if self.sym == :voice
+        root.change_view               if self.sym
+
+        children.each_with_index do |ch, i|
+            n = (i == ii)
+            if(n != ch.value)
+                ch.value = n
+                ch.damage_self
+            end
+        end
+    }
+
+    function toggle(ii)
+    {
+        self.valueRef[ii].value = !children[ii].enable
+    }
+
+    function layout(l, selfBox)
+    {
+        cols = 4
+        l.aspect(selfBox, cols, rows)
+
+        b = 0
+        ch = self.children
+        (0...rows).each do |r|
+            (0...cols).each do |c|
+                child = ch[b]
+                b += 1
+                child.fixed(l,     selfBox, 
+                            c/4.0, r*1.0/self.rows,
+                            0.25,  1.0/self.rows)
+            end
+        end
+        selfBox
+    }
+
+    function animate()
+    {
+        return if !self.sym
+        vv = root.get_view_pos self.sym
+        return if(vv == @vv)
+        @vv = vv
+        children.each_with_index do |ch, i|
+            n = (i == vv)
+            if(n != ch.value)
+                ch.value = n
+                ch.damage_self
+            end
+        end
+    }
+}

--- a/src/mruby-zest/example/LabelButton.qml
+++ b/src/mruby-zest/example/LabelButton.qml
@@ -1,0 +1,84 @@
+Button {
+    id: lbut
+    property Object   valueRef: nil
+    property Function action:   nil
+    onExtern: {
+        meta = OSC::RemoteMetadata.new($remote, lbut.extern)
+        lbut.tooltip = meta.tooltip
+        lbut.valueRef = OSC::RemoteParam.new($remote, lbut.extern)
+        lbut.valueRef.callback = lambda {|x| lbut.setValue(x)}
+    }
+    
+    function animate()
+    {
+        if(root.key_widget != self)
+            @next = nil
+            if(@state)
+                @state = nil
+                damage_self
+            end
+            return
+        end
+        now = Time.new
+        if(@next.nil?)
+            @next = now + 0.1
+            return
+        elsif(@next < now)
+            @state = !@state
+            @next = now + 0.7
+            damage_self
+        end
+    }
+    
+    function draw_text(vg)
+    {
+        text_color1   = Theme::TextActiveColor
+        text_color2   = Theme::TextColor
+        vg.font_face("bold")
+        vg.font_size h*self.textScale
+        if(value == true)
+            vg.fill_color(text_color1)
+        else
+            vg.fill_color(text_color2)
+        end
+        vg.text_align NVG::ALIGN_LEFT | NVG::ALIGN_MIDDLE
+        if(@state)
+            vg.text(8,h/2,button.label.upcase + "|")
+        else
+            vg.text(8,h/2,button.label.upcase)
+        end
+    }
+
+    function setValue(x)
+    {
+        self.label = x
+        damage_self
+    }
+
+    function onMousePress(ev) {
+        whenValue.call if whenValue
+    }
+
+    function onMouseEnter(ev)
+    {
+        if(self.tooltip.nil? || self.tooltip.empty?)
+            self.root.log(:tooltip, "extern = <" + self.extern + ">")
+        else
+            self.root.log(:tooltip, self.tooltip)
+        end
+    }
+
+    function onKey(k, mode)
+    {
+        return if mode != "press"
+        if(k.ord == 8)
+            self.label[-1] = "\0" if self.label.length > 0
+            self.label = self.label[0...-1]
+        elsif k.ord >= 32
+            self.label += k
+        end
+        whenValue.call if whenValue
+        valueRef.value = self.label if valueRef
+        damage_self
+    }
+}

--- a/src/mruby-zest/example/LearnButton.qml
+++ b/src/mruby-zest/example/LearnButton.qml
@@ -1,0 +1,20 @@
+Button {
+    label: "learn";
+    layoutOpts: [:no_constraint]
+    
+    function onMousePress(ev) {
+        root.learn_mode = !root.learn_mode
+    }
+
+    function onMousePress(ev) {
+        root.learn_mode = !root.learn_mode
+    }
+
+    function animate()
+    {
+        if(self.value != root.learn_mode)
+            self.value = root.learn_mode
+            damage_self
+        end
+    }
+}

--- a/src/mruby-zest/example/LfoVis.qml
+++ b/src/mruby-zest/example/LfoVis.qml
@@ -1,0 +1,305 @@
+Widget {
+    id: lfo_vis
+
+    property Array  points: []
+    property Symbol type: :triangle
+    property Symbol drag_type: nil
+    property Pos    drag_prev: nil
+
+    property Float    phase:      0.0
+    property Float    depth:      0.5
+    property MilliSec delay_time: 100
+    property MilliSec period:     1000
+
+    property Time     time: nil
+
+    property Object valueRef: nil
+
+    function onSetup(old=nil)
+    {
+        refs = []
+        base = lfo_vis.extern
+        type_var = OSC::RemoteParam.new($remote, base+"PLFOtype")
+        type_var.mode = :options
+
+        type_var.callback = lambda {|x|
+            ntype = [:sine, :triangle, :square, :rampup,
+                :rampdown, :exp1, :exp2, :random][x]
+            return if(ntype == lfo_vis.type)
+            lfo_vis.type = [:sine, :triangle, :square, :rampup,
+                :rampdown, :exp1, :exp2, :random][x]}
+
+        depth_var = OSC::RemoteParam.new($remote, base+"Pintensity")
+        depth_var.callback = lambda {|x|
+            lfo_vis.depth = x
+            lfo_vis.damage_self}
+
+        delay_var = OSC::RemoteParam.new($remote, base+"delay")
+        delay_var.type = "f"
+        delay_var.set_min(0.0)
+        delay_var.set_max(4.0)
+        delay_var.callback = lambda {|x|
+            lfo_vis.delay_time = Math.exp(Math.log(2000)*x)
+            lfo_vis.damage_self}
+
+        freq_var  = OSC::RemoteParam.new($remote, base+"freq")
+        freq_var.type = "f"
+        freq_var.set_min(0)
+        freq_var.set_max(85.25)
+        freq_var.callback = lambda {|x|
+            lfo_vis.period = 20.0 * Math.exp(Math.log(1500/20) * (1 - x))
+            lfo_vis.damage_self}
+
+        phase_var = OSC::RemoteParam.new($remote, base+"Pstartphase")
+        phase_var.callback = lambda {|x|
+            lfo_vis.phase = x
+            lfo_vis.updateType
+            lfo_vis.damage_self}
+
+
+        refs << type_var
+        refs << depth_var
+        refs << freq_var
+        refs << delay_var
+        refs << phase_var
+        self.valueRef = refs
+
+    }
+
+    function class_name()
+    {
+        "LfoVis"
+    }
+
+    //Identify the region of the window used for drag events
+    function onMousePress(ev)
+    {
+        loc_x = ev.pos.x - lfo_vis.global_x
+        if(loc_x < 0.2*lfo_vis.w)
+            lfo_vis.drag_type = :delay
+        else
+            lfo_vis.drag_type = :lfo
+        end
+        lfo_vis.drag_prev = ev.pos
+    }
+
+    function onMouseMove(ev)
+    {
+        if(lfo_vis.drag_prev)
+            dx = ev.pos.x - lfo_vis.drag_prev.x
+            dy = ev.pos.y - lfo_vis.drag_prev.y
+
+            if(lfo_vis.drag_type == :delay)
+                #dv = lfo_vis.phase + dy/100.0
+                #dv_ = [1, [0, dv].max].min
+                #lfo_vis.phase = dv_
+                #lfo_vis.drag_prev.y = ev.pos.y if(dv == dv_)
+                #lfo_vis.updateType
+
+                dt = Math.exp((Math.log(lfo_vis.delay_time)/Math.log(2000) + dx/200.0)*Math.log(2000))
+                dt_ = [2000, [1, dt].max].min
+                lfo_vis.delay_time = dt_
+                lfo_vis.drag_prev.x = ev.pos.x if(dt == dt_)
+                value = Math.log(dt_)/Math.log(2000) 
+                self.valueRef[3].value = value
+                damage_self
+            elsif(lfo_vis.drag_type == :lfo)
+                lfo_vis.drag_prev = ev.pos
+                dv = lfo_vis.depth + dy/300.0
+                dv = [1, [0, dv].max].min
+                lfo_vis.depth = dv
+                self.valueRef[1].value = dv
+
+                dt = 100*Math.exp(Math.log(0.01*lfo_vis.period) + dx/200.0)
+                dt = [1500, [20, dt].max].min
+                lfo_vis.period = dt
+                nval = 1.0 - Math.log(dt/20.0)/Math.log(1500.0/20.0)
+                self.valueRef[2].value = nval
+                damage_self
+            end
+        end
+    }
+
+    function updateType()
+    {
+        shape = case lfo_vis.type
+        when :triangle
+            Proc.new {|phase|
+                if(phase >= 0 && phase < 0.25)
+                    4.0 * phase
+                elsif(phase >= 0.25 && phase < 0.75)
+                    2.0 - 4 * phase
+                else
+                    4.0 * phase - 4;
+                end
+            }
+        when :square
+            Proc.new {|phase|
+                if(phase < 0.5)
+                    -1.0
+                else
+                    1.0
+                end
+            }
+        when :rampup
+            Proc.new {|phase| (phase - 0.5) * 2.0}
+        when :rampdown
+            Proc.new {|phase| (0.5 - phase) * 2.0};
+        when :exp1
+            Proc.new {|phase| (0.05 ** phase) * 2.0 - 1.0}
+        when :exp2
+            Proc.new {|phase| (0.001 ** phase) * 2.0 - 1.0}
+	when :random
+	    Proc.new {|phase| 0 } #TODO: proper RAN LFO display
+        else
+            Proc.new {|x| Math.sin(2*3.14*x) }
+        end
+
+        # root point
+        p = [0,0, 0, 0.2]
+        # func points
+        resolution = 128
+        (0..resolution).each do |i|
+            x = 0.2+0.8*i/resolution
+            phase = i/resolution + lfo_vis.phase
+            phase -= 1 if phase > 1
+
+            y = shape.call(phase)
+            p << y
+            p << x
+        end
+        lfo_vis.points = p
+        damage_self
+    }
+
+    onType: {
+        lfo_vis.updateType
+    }
+
+
+    function draw(vg)
+    {
+        padfactor = 10
+        bb = Draw::indent(Rect.new(0,0,w,h), padfactor, padfactor)
+
+        background Theme::VisualBackground
+
+        dat = lfo_vis.points
+        updateType if dat.empty?
+        dat = lfo_vis.points
+        if(dat.empty?)
+            puts "[Zyn-Zest:ERROR] LfoVis - um, it's empty..."
+            return
+        end
+
+        fill_color   = Theme::VisualBackground
+        stroke_color = Theme::VisualStroke
+        light_fill   = Theme::VisualLightFill
+        light_filll  = color("911515", 20)
+        bright       = Theme::VisualBright
+        dim          = Theme::VisualDim
+        sel_color    = Theme::VisualSelect
+
+        background fill_color
+
+        draw_grid(vg, lfo_vis.depth*16, lfo_vis.period/10,
+                  bb.x+0.2*bb.w, bb.y, 0.8*bb.w, bb.h)
+        draw_grid(vg, lfo_vis.depth*16, lfo_vis.delay_time/100,
+                  bb.x,          bb.y, 0.2*bb.w, bb.h)
+
+        #weak highlight
+        vg.path do |vg|
+            vg.rect(0.2*w, 0, 0.8*w, h)
+            vg.fill_color light_filll
+            vg.fill
+        end
+
+        pts = Draw::toPos(dat)
+
+        #Draw Highlights
+        Draw::WaveForm::under_highlight(vg, bb, pts, light_fill)
+        Draw::WaveForm::over_highlight(vg,  bb, pts, light_fill)
+
+        #Draw Zero Line
+        Draw::WaveForm::zero_line(vg, bb, dim)
+
+        Draw::WaveForm::env_sel_line(vg, bb, 1, pts, dim)
+
+        #Draw Actual Line
+        Draw::WaveForm::lfo_plot(vg, bb, pts, bright)
+
+        vg.fill_color   color(:black)
+        vg.stroke_color bright
+        (0...(dat.length/2)).each do |i|
+            xx = bb.x + bb.w*dat[2*i+1];
+            yy = bb.y + bb.h/2*(1-dat[2*i]);
+            next if(i >= 2)
+            Draw::WaveForm::env_marker(vg, xx, yy, 3)
+        end
+    }
+
+
+    Widget {
+        id: run_view
+        //animation layer
+        layer: 1
+
+        //extern is cloned
+        extern: lfo_vis.extern + "out"
+
+        function class_name()
+        {
+            "LfoVisAnimation"
+        }
+
+        //Workaround due to buggy nested properties
+        function valueRef=(value_ref)
+        {
+            @value_ref = value_ref
+        }
+
+        function valueRef()
+        {
+            @value_ref
+        }
+
+        function runtime_points()
+        {
+            @runtime_points
+        }
+        function runtime_points=(pts)
+        {
+            @runtime_points = pts
+        }
+
+        onExtern: {
+            return if run_view.extern.nil?
+
+            run_view.valueRef = OSC::RemoteParam.new($remote, run_view.extern)
+            run_view.valueRef.set_watch
+            run_view.valueRef.callback = Proc.new {|x|
+                if(run_view.runtime_points != x)
+                    run_view.runtime_points = x;
+                    run_view.damage_self
+                end
+            }
+        }
+
+        function animate() {
+            return if run_view.valueRef.nil?
+            run_view.valueRef.watch run_view.extern
+        }
+
+        function draw(vg)
+        {
+            #Draw the data
+            pts   = @runtime_points
+            pts ||= []
+
+            padfactor = 10
+            bb = Draw::indent(Rect.new(0,0,w,h), padfactor, padfactor)
+
+            Draw::WaveForm::overlay_lfo(vg, bb, pts)
+        }
+    }
+}

--- a/src/mruby-zest/example/MainMenu.qml
+++ b/src/mruby-zest/example/MainMenu.qml
@@ -1,0 +1,137 @@
+Widget {
+    id: menu
+    function layout(l, selfBox) {
+        pad  = 1.0/32
+        pad2 = 0.5-2*pad
+        children[0].fixed(l, selfBox, 0.0+pad, 0.0+pad, pad2, pad2)
+        children[1].fixed(l, selfBox, 0.5+pad, 0.0+pad, pad2, pad2)
+        children[2].fixed(l, selfBox, 0.0+pad, 0.5+pad, pad2, pad2)
+        children[3].fixed(l, selfBox, 0.5+pad, 0.5+pad, pad2, pad2)
+
+        selfBox
+    }
+
+    //0
+    Menu {
+        id: file;
+        label: "file";
+        layoutOpts: [:no_constraint]
+        options: ["load instrument", "save instrument",
+                  "load master", "save master",
+                  "load microtonal", "save microtonal",
+                  "load midi bindings", "save midi bindings",
+                  "clear master", "clear instrument",
+                  "setup record", "quit"]
+        whenValue: lambda {
+            menu.file_sel if file.selected
+        }
+    }
+
+    function setup_widget(w)
+    {
+        w.onSetup()
+        w.children.each do |c|
+            setup_widget(c)
+        end
+    }
+
+    function file_select()
+    {
+        opt = file.options[file.selected]
+        win = window()
+        wid = Qml::FileSelector.new(db)
+        wid.whenValue = lambda { |x| menu.file_value(x)}
+        wid.x = 0#-global_x
+        wid.y = 0#-global_y
+        wid.w = win.w
+        wid.h = win.h
+        wid.ext = ".xiz" if opt == "save instrument"
+        wid.ext = ".xmz" if opt == "save master"
+        wid.ext = ".wav" if opt == "setup record"
+        wid.pat = ".xiz" if opt == "load instrument"
+        wid.pat = ".xmz" if opt == "load master"
+        wid.pat = ".xsz" if opt == "load microtonal"
+        wid.pat = ".xsz" if opt == "save microtonal"
+        wid.pat = ".xlz" if opt == "load midi bindings"
+        wid.pat = ".xlz" if opt == "save midi bindings"
+        Qml::add_child(win, wid)
+        self.db.update_values
+        setup_widget wid
+        self.db.update_values
+
+        if(root)
+            root.smash_layout
+            root.damage_item(win, :all)
+        end
+    }
+
+    function file_sel()
+    {
+        opt = file.options[file.selected]
+        if(["load instrument", "save instrument", "load master", "save master", "setup record",
+            "load microtonal", "save microtonal", "load midi bindings", "save midi bindings"].include? opt)
+            menu.file_select
+        elsif(opt == "clear master")
+            root.set_view_pos(:part, 0)
+            root.set_view_pos(:kit, 0)
+            root.set_view_pos(:voice, 0)
+            root.set_view_pos(:view, :add_synth)
+            root.set_view_pos(:subview, :global)
+            root.change_view
+            $remote.action("/reset_master")
+        elsif(opt == "clear instrument")
+            root.set_view_pos(:voice, 0)
+            root.set_view_pos(:kit, 0)
+            root.set_view_pos(:view, :add_synth)
+            root.set_view_pos(:subview, :global)
+            prt  = root.get_view_pos(:part)
+            root.change_view
+            $remote.action("/part#{prt}/clear")
+        elsif(opt == "quit")
+            $remote.action("/quit")
+            root.quit
+        else
+            puts "[WARNING] Unhandled Option #{opt}"
+        end
+
+    }
+
+    function file_value(val)
+    {
+        return if val == :cancel
+        opt = file.options[file.selected]
+        prt  = root.get_view_pos(:part)
+        if(opt == "load instrument")
+            $remote.action("/load_xiz", prt, val)
+        elsif(opt == "save instrument")
+            $remote.action("/save_xiz", prt, val)
+        elsif(opt == "load master")
+            $remote.action("/load_xmz", val)
+        elsif(opt == "save master")
+            $remote.action("/save_xmz", val)
+        elsif(opt == "save microtonal")
+            $remote.action("/save_xsz", val)
+        elsif(opt == "load microtonal")
+            $remote.action("/load_xsz", val)
+        elsif(opt == "save midi bindings")
+            $remote.action("/save_xlz", val)
+        elsif(opt == "load midi bindings")
+            $remote.action("/load_xlz", val)
+        elsif(opt == "setup record")
+            $remote.action("/HDDRecorder/preparefile", val)
+        end
+    }
+    //1
+    Button {
+        id: learn;
+        label: "midi";
+        tooltip: "use ctrl to enable midi learn"
+        layoutOpts: [:no_constraint]
+    }
+    //2
+    Record {}
+    //3
+    LearnButton { 
+        tooltip: "just click on a widget while in learning mode to start mapping"
+    }
+}

--- a/src/mruby-zest/example/MainWindow.qml
+++ b/src/mruby-zest/example/MainWindow.qml
@@ -1,0 +1,153 @@
+Widget {
+    id: window
+    function class_name() { "MainWindow" }
+
+    //Layout window
+    // l - layout engine
+    // p - constraint solution from parent widget
+    function layout(l, selfBox)
+    {
+        side.fixed(l,        selfBox, 0, 0.1, 0.1025, 0.8025)
+        head1.fixed(l,       selfBox, 0, 0,   1.0, 0.1)
+        footerbox.fixed(l,        selfBox, 0, 0.9, 1.0, 0.1)
+        main_widget.fixed(l, selfBox, 0.102, 0.1, 0.89, 0.80)
+
+        #Layout overlay panel (e.g. file browser)
+        if(children.length == 5)
+            children[4].fixed(l, selfBox, 0, 0, 1, 1)
+        end
+
+        selfBox
+    }
+
+    function draw(vg)
+    {
+        vg.path do |v|
+            v.rect(0, 0, w, h)
+            paint = v.linear_gradient(0,0,0,h,
+            Theme::WindowGrad1, Theme::WindowGrad2)
+            v.fill_paint paint
+            v.fill
+        end
+    }
+
+    function set_content(type)
+    {
+        root.set_view_pos(:view, type)
+        root.change_view
+    }
+
+    function valueRef()
+    {
+        return @refs
+    }
+
+    function onSetup(old=nil)
+    {
+        return if main_widget.content
+        @info = Hash.new
+
+        #Assume parts are active for testing purposes
+        (0...16).each do |prt|
+            (0...16).each do |kit|
+                @info[[prt,kit,:add]] = true
+                @info[[prt,kit,:sub]] = true
+                @info[[prt,kit,:pad]] = true
+            end
+        end
+
+        @refs = []
+        (0...16).each do |prt|
+            (0...16).each do |kit|
+                add = OSC::RemoteParam.new($remote,
+                    "/part#{prt}/kit#{kit}/Padenabled")
+                sub = OSC::RemoteParam.new($remote,
+                    "/part#{prt}/kit#{kit}/Psubenabled")
+                pad = OSC::RemoteParam.new($remote,
+                    "/part#{prt}/kit#{kit}/Ppadenabled")
+                add.callback =
+                    lambda {|x| window.info(prt,kit,:add,x)}
+                sub.callback =
+                    lambda {|x| window.info(prt,kit,:sub,x)}
+                pad.callback =
+                    lambda {|x| window.info(prt,kit,:pad,x)}
+                @refs << add
+                @refs << sub
+                @refs << pad
+            end
+        end
+
+
+        set_view()
+    }
+
+    function info(a,b,c,d)
+    {
+        @info[[a,b,c]] = d
+    }
+
+    function set_view()
+    {
+        prt  = root.get_view_pos(:part)
+        kit  = root.get_view_pos(:kit)
+        type = root.get_view_pos(:view)
+
+        if(type == :add_synth && !@info[[prt,kit,:add]])
+            root.set_view_pos(:view, :kits)
+        elsif(type == :pad_synth && !@info[[prt,kit,:pad]])
+            root.set_view_pos(:view, :kits)
+        elsif(type == :sub_synth && !@info[[prt,kit,:sub]])
+            root.set_view_pos(:view, :kits)
+        end
+
+        type = root.get_view_pos(:view)
+
+        if(type == :add_synth)
+            main_widget.extern  = "/part#{prt}/kit#{kit}/adpars/"
+            main_widget.content = Qml::ZynAddSynth
+        elsif(type == :pad_synth)
+            main_widget.extern  = "/part#{prt}/kit#{kit}/padpars/"
+            main_widget.content = Qml::ZynPadSynth
+        elsif(type == :sub_synth)
+            main_widget.extern  = "/part#{prt}/kit#{kit}/subpars/"
+            main_widget.content = Qml::ZynSubSynth
+        elsif(type == :part)
+            main_widget.extern  = "/part#{prt}/"
+            main_widget.content = Qml::ZynPart
+        elsif(type == :kits)
+            main_widget.extern  = "/part#{prt}/"
+            main_widget.content = Qml::ZynKit
+        elsif(type == :effects)
+            main_widget.extern  = "/"
+            main_widget.content = Qml::ZynEffects
+        elsif(type == :midi_learn)
+            main_widget.extern  = "/"
+            main_widget.content = Qml::ZynMidiLearn
+        elsif(type == :mixer)
+            main_widget.extern  = "/"
+            main_widget.content = Qml::ZynMixer
+        elsif(type == :banks)
+            main_widget.extern  = "/"
+            main_widget.content = Qml::ZynBank
+        elsif(type == :about)
+            main_widget.extern  = "/"
+            main_widget.content = Qml::ZynAbout
+        elsif(type == :automate)
+            main_widget.extern  = "/"
+            main_widget.content = Qml::ZynAutomation
+        elsif(type == :colors)
+            main_widget.extern  = "/"
+            main_widget.content = Qml::ColorScheme
+        elsif(type == :settings)
+            main_widget.extern  = "/"
+            main_widget.content = Qml::ZynSettings
+        else
+            main_widget.content = Qml::Widget
+        end
+    }
+
+    ZynSidebar  { id: side  }
+    ZynHeader   { id: head1 }
+    ZynFooter   { id: footerbox  }
+    Swappable { id: main_widget }
+}

--- a/src/mruby-zest/example/Menu.qml
+++ b/src/mruby-zest/example/Menu.qml
@@ -1,0 +1,101 @@
+Widget {
+    property String extern: ""
+    property Array  options: ["text", "test", "asdf"];
+    property Int    selected: 0
+    property Function whenValue: nil
+
+    function set_value_user(val) {
+        self.selected = val
+        whenValue.call if whenValue
+    }
+
+    function layout(l,selfBox) {
+        if(!layoutOpts.include?(:no_constraint))
+            scale = 100
+            $vg.font_size scale
+            bb = 1
+            self.options.each do |x|
+                x = x[0..8] if x.length > 8
+                bbl  = $vg.text_bounds(0, 0, (x+"    ").upcase)
+                bb   = [bb, bbl].max
+            end
+            scale *= layoutOpts[0] if layoutOpts.include?(:rescale)
+            if(bb != 0)
+                #Width cannot be so small that letters overflow
+                l.sh([selfBox.w, selfBox.h], [-1.0, bb/scale], 0)
+            end
+        end
+        selfBox
+    }
+
+    function class_name()
+    {
+        "Menu"
+    }
+
+    function onMousePress(ev)
+    {
+        create_menu
+    }
+
+    function draw(vg)
+    {
+        text_color = Theme::TextColor
+        pad  = 1.0/64
+        pad2 = (1-2*pad)
+        vg.path do |v|
+            v.rect(w*pad, h*pad, w*pad2, h*pad2)
+            paint = v.linear_gradient(0,0,0,h,
+            Theme::ButtonGrad1, Theme::ButtonGrad2)
+            v.fill_paint paint
+            v.fill
+            v.stroke_width 1
+            v.stroke
+        end
+
+        vg.path do |v|
+            tx = w*pad2-h*pad2
+            tw = h*pad2
+            ty = h*pad
+            th = h*pad2
+
+            v.move_to(tx+0.25*tw, ty+0.3*th)
+            v.line_to(tx+0.50*tw, ty+0.7*th)
+            v.line_to(tx+0.75*tw, ty+0.3*th)
+            v.close_path
+
+            v.fill_color Theme::TextColor
+            v.fill
+        end
+
+        vg.font_face("bold")
+        vg.font_size h*0.8
+        vg.text_align NVG::ALIGN_LEFT | NVG::ALIGN_MIDDLE
+        vg.fill_color text_color
+        vg.text(3+w*pad*2,h/2,label.upcase)
+    }
+
+    function create_menu()
+    {
+        n = options.length
+        n = 1 if options.class != Array
+        return if n < 1
+        widget = Qml::DropDown.new(self.db)
+        widget.w = 3*self.w
+        widget.h = self.h*n
+        widget.x = 0
+        widget.y = 0
+        widget.layer = 2
+        widget.options = options
+        widget.callback = lambda { |v|
+            set_value_user(v)
+        }
+        widget.y = -self.h*(n-1) if(widget.h+global_y > window.h)
+        widget.prime(root())
+
+        Qml::add_child(self, widget)
+        root.smash_draw_seq
+        root.damage_item widget
+    }
+
+}

--- a/src/mruby-zest/example/NumBox.qml
+++ b/src/mruby-zest/example/NumBox.qml
@@ -1,0 +1,38 @@
+ColorBox {
+    id: numBox
+    pad: 0.003
+    bg:  nil
+    property Float height: 0.7
+    property Symbol align: :center
+    property Object valueRef: nil
+    Text {
+        label:      ""
+        height:     numBox.height
+        layoutOpts: [:no_constraint]
+        align:      numBox.align
+    }
+
+    onExtern: {
+        ref = OSC::RemoteParam.new($remote, numBox.extern)
+        ref.mode     = :full
+        ref.callback = lambda {|x|
+            numBox.children[0].label = (((10*x).to_i)/10).to_s;
+            numBox.damage_self
+        }
+        numBox.valueRef = ref
+    }
+    
+    function layout(l, selfBox)
+    {
+        return selfBox if layoutOpts.include?(:free)
+
+        #Assume all digit bounding boxes are roughly the same
+        scale = 100
+        $vg.font_size scale
+        bb = $vg.text_bounds(0, 0, " 0.12 ")
+        l.aspect(selfBox, bb, scale)
+        children[0].fixed(l, selfBox, 0, 0, 1, 1)
+
+        selfBox
+    }
+}

--- a/src/mruby-zest/example/NumberButton.qml
+++ b/src/mruby-zest/example/NumberButton.qml
@@ -1,0 +1,53 @@
+Widget {
+    id: num
+    property Function whenValue: nil
+    property Bool     value:     false
+    property Int      number:       0
+    function class_name() { "NumButton" }
+
+
+    function cb()
+    {
+        whenValue.call if whenValue
+    }
+
+    function onMousePress(ev) {
+        self.value = !self.value
+        damage_self
+        cb()
+    }
+
+    onLabel: {
+        but.label = num.label
+    }
+
+    function layout(l)
+    {
+        selfBox = l.genBox :numButton, self
+        buttBox = l.genBox :numButtont, children[0]
+        numbBox = l.genBox :numButtonn, children[1]
+        l.contains(selfBox, buttBox)
+        l.contains(selfBox, numbBox)
+        l.rightOf(numbBox, buttBox)
+        l.aspect(numbBox, 1.0, 1.0)
+        #l.fixed(buttBox, selfBox, 0, 0, 0.25, 1)
+        #l.fixed(buttBox, selfBox, 0, 0, 0.25, 1)
+        selfBox
+    }
+    Button {
+        id: but
+        pad: 0
+        label: num.label
+        whenValue:  lambda { num.cb }
+        layoutOpts: [:no_constraint]
+    }
+
+    Button {
+        id: pow
+        label: num.number.to_s
+        pad: 0
+        whenValue:  lambda { num.cb }
+        layoutOpts: [:no_constraint]
+    }
+
+}

--- a/src/mruby-zest/example/PasteButton.qml
+++ b/src/mruby-zest/example/PasteButton.qml
@@ -1,0 +1,38 @@
+Button {
+    id: paste_button
+
+    property Int index: nil
+
+    onExtern: {
+        paste_button.tooltip = "paste to " + paste_button.extern.to_s
+    }
+
+    function layout(l, selfBox) {
+        l.aspect(selfBox, 1, 1)
+        selfBox
+    }
+
+    function animate()
+    {
+        return if self.value == 0
+        return if self.value == false
+        return if self.value == true
+        self.value *= 0.9
+        self.value  = 0 if self.value < 0.02
+        damage_self
+    }
+
+    function onMousePress(ev) {
+        return if !self.active
+        self.value = 1.0
+        if($remote && extern && !extern.empty?)
+            if(self.index)
+                $remote.action("/presets/paste", extern, self.index)
+            else
+                $remote.action("/presets/paste", extern)
+            end
+        end
+        damage_self
+    }
+    label: "P"
+}

--- a/src/mruby-zest/example/PlotLabelY.qml
+++ b/src/mruby-zest/example/PlotLabelY.qml
@@ -1,0 +1,40 @@
+Widget {
+    property Array labels: ["-1", "0", "1"]
+
+    function get_width(vg, text)
+    {
+        scale = 100
+        $vg.font_size scale
+        bb = $vg.text_bounds(0, 0, text.upcase)
+
+
+        vg.font_face("bold")
+        return w*scale/bb
+    }
+
+    function draw(vg)
+    {
+        return if labels.class != Array
+        best_height = h/(labels.length+1)
+        xx = []
+        labels.each do |l|
+            tmp = get_width(vg, l)
+            best_height = tmp if tmp < best_height
+            xx << tmp
+        end
+
+        vg.font_size best_height
+        labels.each_index do |i|
+            if(i == 0)
+                vg.text_align NVG::ALIGN_BOTTOM | NVG::ALIGN_LEFT
+                vg.text(0, h, labels[0].upcase)
+            elsif(i == labels.length-1)
+                vg.text_align NVG::ALIGN_TOP | NVG::ALIGN_LEFT
+                vg.text(0, 0, labels[i].upcase)
+            else
+                vg.text_align NVG::ALIGN_MIDDLE | NVG::ALIGN_LEFT
+                vg.text(0, h*i/(labels.length-1), labels[i].upcase)
+            end
+        end
+    }
+}

--- a/src/mruby-zest/example/Record.qml
+++ b/src/mruby-zest/example/Record.qml
@@ -1,0 +1,81 @@
+Widget {
+    function draw(vg)
+    {
+        pad  = 1.0/64
+        pad2 = (1-2*pad)
+        vg.path do |v|
+            v.rect(w*pad, h*pad, w*pad2, h*pad2)
+            paint = v.linear_gradient(0,0,0,h,
+            Theme::ButtonGrad1, Theme::ButtonGrad2)
+            v.fill_paint paint
+            v.fill
+            v.stroke_width 1
+            v.stroke
+        end
+
+        vg.path do |v|
+            v.move_to(w*1.0/3, 0)
+            v.line_to(w*1.0/3, h)
+            v.move_to(w*2.0/3, 0)
+            v.line_to(w*2.0/3, h)
+            v.stroke
+        end
+
+        text_color = Theme::TextColor
+
+        draw_stop(vg, text_color)
+        draw_pause( vg, text_color)
+        draw_play(  vg, text_color)
+    }
+
+    function draw_record(vg, text_color) {
+        r = [1.0/6*w, 1.0/2*h].min*0.4
+        vg.path do |v|
+            v.circle(1.0/6*w, 1.0/2*h, r)
+            v.fill_color text_color
+            v.fill
+        end
+    }
+
+    function draw_stop(vg, text_color) {
+        r = [1.0/6*w, 1.0/2*h].min*0.4
+        vg.path do |v|
+            v.rect(1.0/6*w-r, 1.0/2*h-r, 2*r, 2*r)
+            v.fill_color text_color
+            v.fill
+        end
+    }
+
+    function draw_pause(vg, text_color) {
+        vg.path do |v|
+            v.rect((3.0/6-1.0/18)*w, 0.2*h, 1.0/24*w, 0.6*h)
+            v.rect((3.0/6+1.0/18)*w, 0.2*h, 1.0/24*w, 0.6*h)
+            v.fill_color text_color
+            v.fill
+        end
+    }
+
+    function draw_play(vg, text_color) {
+        vg.path do |v|
+            v.move_to((5.0/6-1.0/18)*w, 0.25*h)
+            v.line_to((5.0/6-1.0/18)*w, 0.75*h)
+            v.line_to((5.0/6+1.0/18)*w, 0.5*h)
+            v.close_path
+            v.fill_color text_color
+            v.fill
+        end
+    }
+
+    function onMousePress(ev)
+    {
+        px = (ev.pos.x-global_x)*1.0/w
+        if(px > 0.666)
+            $remote.action("/HDDRecorder/start")
+        elsif(px > 0.333)
+            $remote.action("/HDDRecorder/pause")
+        else
+            $remote.action("/HDDRecorder/stop")
+        end
+
+    }
+}

--- a/src/mruby-zest/example/ScrollBar.qml
+++ b/src/mruby-zest/example/ScrollBar.qml
@@ -1,0 +1,67 @@
+Valuator {
+    // Relative size of the scroll bar handle to the full length.
+    property Float  bar_size: 0.1
+    property Symbol style: :normal
+
+    function draw(vg)
+    {
+        if(self.style == :overlay)
+            draw_overlay(vg)
+        else
+            draw_normal(vg)
+        end
+    }
+    function draw_overlay(vg)
+    {
+        pad = 1
+        domain = 1.0-bar_size
+        if(vertical)
+            center = 0.5*bar_size + (1-value)*domain
+            self.dragScale = h*(1-bar_size)
+            vg.path do |v|
+                v.rect(pad,pad+@h*(center-0.5*bar_size),
+                    @w-2*pad,@h*bar_size-2*pad)
+                v.fill_color color("56c0a5")
+                v.fill
+            end
+        else
+            center = 0.5*bar_size + value*domain
+            self.dragScale = w*(1-bar_size)
+            vg.path do |v|
+                v.rect(pad+w*(center-0.5*bar_size),pad,
+                w*bar_size-2*pad,h-2*pad)
+                v.fill_color color("56c0a5")
+                v.fill
+            end
+        end
+    }
+    function draw_normal(vg)
+    {
+        pad = 1
+        vg.path do |v|
+            v.rect(pad,pad,w-2*pad,h-2*pad)
+            v.fill_color Theme::ScrollInactive
+            v.fill
+        end
+        domain = 1.0-bar_size
+        if(vertical)
+            center = 0.5*bar_size + (1-value)*domain
+            self.dragScale = h*(1-bar_size)
+            vg.path do |v|
+                v.rect(pad,pad+@h*(center-0.5*bar_size),
+                    @w-2*pad,@h*bar_size-2*pad)
+                v.fill_color Theme::ScrollActive
+                v.fill
+            end
+        else
+            center = 0.5*bar_size + value*domain
+            self.dragScale = w*(1-bar_size)
+            vg.path do |v|
+                v.rect(pad+w*(center-0.5*bar_size),pad,
+                w*bar_size-2*pad,h-2*pad)
+                v.fill_color Theme::ScrollActive
+                v.fill
+            end
+        end
+    }
+}

--- a/src/mruby-zest/example/SearchBox.qml
+++ b/src/mruby-zest/example/SearchBox.qml
@@ -1,0 +1,60 @@
+Widget {
+    property Function whenValue: nil
+
+    function animate()
+    {
+        if(root.key_widget != self)
+            @next = nil
+            if(@state)
+                @state = nil
+                damage_self
+            end
+            return
+        end
+        now = Time.new
+        if(@next.nil?)
+            @next = now + 0.1
+            return
+        elsif(@next < now)
+            @state = !@state
+            @next = now + 0.7
+            damage_self
+        end
+    }
+
+    function draw(vg)
+    {
+        background Theme::GeneralBackground
+        vg.font_face("bold")
+        vg.font_size h*0.8
+        vg.text_align NVG::ALIGN_LEFT | NVG::ALIGN_MIDDLE
+        vg.fill_color = Theme::TextColor
+        l = label
+        if(root.key_widget != self and label.empty?)
+            vg.fill_color = Theme::BackgroundTextColor
+            l = "search..."
+        end
+        vg.text(8,h/2,l.upcase)
+        bnd = vg.text_bounds(0,0,l.upcase)
+        if(@state)
+            vg.text(8+bnd,h/2,"|")
+        end
+    }
+
+    function onKey(k, mode)
+    {
+        return if mode != "press"
+        if(k.ord == 8)
+            self.label = self.label[0...-1]
+        elsif (k.ord >= 32)
+            self.label += k
+        end
+        whenValue.call if whenValue
+        damage_self
+    }
+
+    function onMerge(val)
+    {
+        self.label = val.label
+    }
+}

--- a/src/mruby-zest/example/SelButton.qml
+++ b/src/mruby-zest/example/SelButton.qml
@@ -1,0 +1,57 @@
+Button {
+    property Color bg: nil
+    property Bool  doupcase: true
+    property Symbol style: :normal
+    function draw(vg)
+    {
+        if(self.style == :overlay)
+            draw_overlay(vg)
+        else
+            draw_normal(vg)
+        end
+    }
+
+    function draw_overlay(vg)
+    {
+        vg.font_face("bold")
+        vg.font_size h*self.textScale
+        vg.text_align NVG::ALIGN_LEFT | NVG::ALIGN_MIDDLE
+        vg.fill_color = color("56c0a5")
+
+        ll = self.label.clone
+        ll = ll.upcase if self.doupcase
+        (0...ll.length).each do |i|
+            ll[i] = "?" if ll.getbyte(i) > 127
+        end
+        vg.text(8,h/2,ll)
+    }
+
+    function draw_normal(vg)
+    {
+        on_color      = Theme::ButtonActive
+        vg.path do |v|
+            v.rect(w*pad, h*pad, w*(1-2*pad), h*(1-2*pad))
+            if(button.value)
+                v.fill_color on_color
+            else
+                v.fill_color bg if bg
+            end
+            v.fill
+        end
+
+        vg.font_face("bold")
+        vg.font_size h*self.textScale
+        vg.text_align NVG::ALIGN_LEFT | NVG::ALIGN_MIDDLE
+        vg.fill_color = if(value)
+            Theme::TextActiveColor
+        else
+            Theme::TextColor
+        end
+        ll = self.label.clone
+        ll = ll.upcase if self.doupcase
+        (0...ll.length).each do |i|
+            ll[i] = "?" if ll.getbyte(i) > 127
+        end
+        vg.text(8,h/2,ll)
+    }
+}

--- a/src/mruby-zest/example/SelColumn.qml
+++ b/src/mruby-zest/example/SelColumn.qml
@@ -1,0 +1,254 @@
+Widget {
+    id: col
+    property Object valueRef: nil
+    property Bool number: false
+    property Bool skip:   false
+    property Bool rows:   nil
+    property Int  nrows:  24
+    property Function whenValue: nil
+    property Int  oldOff: 0
+    property Object value_sel: nil
+    property Object value_lab: nil
+    property Bool   clear_on_extern: nil
+    property Bool   doupcase: true
+    property String pattern: nil
+    property Symbol style: :normal
+
+    onExtern: {
+        col.valueRef = OSC::RemoteParam.new($remote, col.extern)
+        col.valueRef.callback = Proc.new {|x|
+            x = [x] if x.class != Array
+            col.clear_sel if col.clear_on_extern
+            col.setValue(col.filter(x)) if !col.skip
+            col.setValue(x)             if  col.skip
+            # Resets the scroll bar to the top.
+            scroll.value = 1.0
+        }
+    }
+
+    ScrollBar {
+        id: scroll
+        style: col.style
+        whenValue: lambda { col.tryScroll }
+    }
+
+    function clear()
+    {
+        clear_sel
+        children.each do |c|
+            c.value = false if c.class != Qml::ScrollBar
+            c.damage_self
+        end
+    }
+
+    function clear_sel()
+    {
+        self.value_sel = nil
+        self.value_lab = nil
+    }
+
+    function onScroll(ev)
+    {
+        return if !scroll.active
+        num_visible_rows = self.rows.length.to_f / getStride()
+        scroll.updatePos(ev.dy.to_f/(self.nrows-num_visible_rows))
+    }
+
+    function draw(vg)
+    {
+        if(self.style == :overlay)
+            draw_overlay(vg)
+        else
+            draw_normal(vg)
+        end
+
+    }
+
+    function draw_overlay(vg)
+    {
+        vg.path do
+            vg.rect(0, 0, w, h)
+            vg.stroke_color  color("56c0a5")
+            vg.stroke_width 1.0
+            vg.stroke
+        end
+        titleH = self.h*1.0/(children.length + 1)
+        vg.fill_color Theme::TextModColor
+        vg.text_align NVG::ALIGN_CENTER | NVG::ALIGN_MIDDLE
+        vg.font_size titleH*0.9
+        vg.text(0.9*w/2,titleH/2,label.upcase)
+    }
+
+    function draw_normal(vg)
+    {
+        titleH = self.h*1.0/(children.length + 1)
+        vg.path do
+            vg.rect(0, 0, 0.9*w, titleH)
+            vg.fill_color Theme::BankOdd
+            vg.fill
+        end
+        vg.fill_color Theme::TextModColor
+        vg.text_align NVG::ALIGN_CENTER | NVG::ALIGN_MIDDLE
+        vg.font_size titleH*0.9
+        vg.text(0.9*w/2,titleH/2,label.upcase)
+    }
+
+    function getStride()
+    {
+        stride = 1
+        stride = 2 if skip
+        stride
+    }
+
+    function onSetup(old=nil)
+    {
+        return if children.length > 10
+        scroll.layer = self.layer
+        (self.nrows).times do |x|
+            ch = if(number)
+                Qml::NumberButton.new(db)
+            else
+                Qml::SelButton.new(db)
+            end
+            if(rows.nil? || rows.empty?)
+                ch.label = ""
+            else
+                stride = getStride()
+                ch.label = if(x>=rows.length/stride)
+                    ""
+                else
+                    rows[x*stride]
+                end
+                ch.tooltip = if(x*stride+1>=rows.length)
+                    ""
+                else
+                    rows[x*stride+1]
+                end
+            end
+            ch.layoutOpts = [:no_constraint]
+            ch.whenValue  = lambda {col.cb ch}
+
+            ch.layer      = col.layer
+            ch.number = x if number
+            ch.style    = self.style    if ch.respond_to? :style
+            ch.doupcase = self.doupcase if ch.respond_to? :doupcase
+            if(!number)
+                ch.pad = 0
+                ch.bg = Theme::BankEven if x%2 == 0
+                ch.bg = Theme::BankOdd if x%2 == 1
+            end
+            Qml::add_child(self, ch)
+        end
+
+    }
+
+    function tryScroll()
+    {
+        return if rows.nil?
+
+        stride = getStride()
+        n = rows.length/stride
+        return if n<nrows
+
+        offset = (1.0-scroll.value)*(n-nrows) + 0.5
+        offset = offset.to_i
+
+        if(offset != self.oldOff)
+            setValue(rows, offset)
+        end
+    }
+
+    function cb(ch)
+    {
+        if(ch.value)
+            self.value_sel = ch.tooltip
+            self.value_lab = ch.label
+        else
+            self.value_sel = nil
+            self.value_lab = nil
+        end
+
+        children[1,99].each do |child|
+            if(ch != child)
+                child.value = false
+            end
+        end
+        whenValue.call if whenValue
+        damage_self
+    }
+
+    function filter(x)
+    {
+        y = []
+        x.each do |x|
+            next if(x != "." && x != ".." && x[0] == ".")
+            next if(x[-1] == "~")
+            next if self.pattern && !self.pattern.match(x)
+            y << x
+        end
+        y
+    }
+
+    function setValue(x,offset=0)
+    {
+        return if(self.rows == x && offset == oldOff)
+        self.oldOff = offset
+        self.rows = x
+        stride = getStride()
+        nn = x.length/stride
+        nsize = [0.05, [1.0, self.nrows*1.0/nn].min].max
+        if(nsize != scroll.bar_size)
+            scroll.bar_size = nsize
+            scroll.damage_self
+        end
+        n = [x.length/stride, children.length-1].min
+        (1..n).each do |i|
+            nv = (children[i].label == self.value_lab &&
+                  children[i].tooltip == self.value_sel)
+            children[i].label   = x[(i-1+offset)*stride]
+            children[i].tooltip = x[(i-1+offset)*stride+1] if stride == 2
+            children[i].value   = nv
+        end
+        ((n+1)...children.length).each do |i|
+            children[i].label   = ""
+            children[i].tooltip = "" if stride == 2
+            children[i].value   = false
+        end
+        damage_self
+    }
+
+    function layout(l, selfBox) {
+        children[0].fixed(l, selfBox, 0.9, 0.0, 0.1, 1.0)
+        miniBox = nil
+        if(selfBox.class != LayoutConstBox)
+            miniBox = l.genBox :selminibox, nil
+            l.fixed(miniBox, selfBox, 0.0, 0.0, 0.9, 1.0)
+        else
+            miniBox = l.genConstBox(0.0, 0.0, 0.9*selfBox.w, selfBox.h)
+        end
+        titleH  = 1.0/(children.length + 1)
+        Draw::Layout::vpack(l, miniBox, children[1,99], 0, 1, 0, titleH, 1.0-titleH)
+        selfBox
+    }
+
+    function selected()
+    {
+        return "" if(value_lab.nil?)
+        return value_lab
+    }
+
+    function selected_val()
+    {
+        return "" if(value_sel.nil?)
+        return value_sel
+    }
+
+    function selected_id()
+    {
+        self.children.each_with_index do |c,i|
+            next       if c.class == Qml::ScrollBar
+            return i-1 if c.value
+        end
+        nil
+    }
+}

--- a/src/mruby-zest/example/SidebarButton.qml
+++ b/src/mruby-zest/example/SidebarButton.qml
@@ -1,0 +1,111 @@
+Widget {
+    id: button
+    property Function whenClick: nil
+    property Bool value: false
+    tooltip: ""
+
+    function onMousePress(ev) {
+        self.value = !self.value
+        damage_self
+        self.whenClick.call if whenClick
+    }
+
+    function draw_button(vg)
+    {
+        pad = 0
+        off_color     = Theme::ButtonInactive
+        on_color      = Theme::ButtonActive
+        cs = 0
+        vg.path do |v|
+            v.rounded_rect(w*pad, h*pad, w*(1-2*pad), h*(1-2*pad), 3)
+            if(button.value == true)
+                cs = 1
+                v.fill_color on_color
+            elsif(button.value.class == Float && button.value != 0)
+                cs = 2
+                t = button.value
+                on = on_color
+                of = Theme::ButtonGrad1
+                v.fill_color(color_rgb(on.r*t + of.r*(1-t),
+                                       on.g*t + of.g*(1-t),
+                                       on.b*t + of.b*(1-t)))
+            else
+                paint = v.linear_gradient(0,0,0,h,
+                Theme::ButtonGrad1, Theme::ButtonGrad2)
+                v.fill_paint paint
+            end
+            v.fill
+            v.stroke_width 1
+            v.stroke
+
+        end
+
+        vg.translate(0.5,0.5)
+
+        vg.path do |v|
+            hh = h/32
+            source_x = 1
+            source_y = (hh).round()
+            dest_x = (w-2).round()
+            dest_y = source_y
+
+            v.move_to(source_x, source_y)
+            v.line_to(dest_x, dest_y)
+
+            if(self.value)
+                v.stroke_color color("16a39c")
+            else
+                v.stroke_color color("5c5c5c")
+            end
+
+            v.stroke_width 1
+            v.stroke
+        end
+
+        vg.translate(-0.5,-0.5)
+    }
+
+    function draw(vg)
+    {
+        #h = button.h
+        #w = button.w
+        ##puts("drawing a button...")
+        #bright_green = color("00AE9C")
+        #dark_green   = color("007368")
+        #grad = vg.linear_gradient(0,0,0,h, bright_green, dark_green)
+        #vg.stroke_color(NVG.rgba(0,0,0,0x80))
+
+        #grey1 = Theme::ButtonGrad1
+        #grey2 = Theme::ButtonGrad2
+        #grad2 = vg.linear_gradient(0,0,0,h, grey1, grey2)
+        #vg.path do |v|
+        #    v.rounded_rect(0,0,w,h,2)
+        #    if(value)
+        #        bright_green = color("00AE9C")
+        #        dark_green   = color("007368")
+        #        grad = vg.linear_gradient(0,0,0,h, bright_green, dark_green)
+        #        v.fill_paint grad
+        #    else
+        #        v.fill_paint grad2
+        #    end
+        #    v.stroke_width 1
+        #    v.fill
+        #    v.stroke
+        #end
+        draw_button(vg)
+
+        text_color1   = color("52FAFE")
+        text_color2   = Theme::TextColor
+        vg.font_face("bold")
+        vg.font_size h*0.55
+        vg.text_align NVG::ALIGN_CENTER | NVG::ALIGN_MIDDLE
+        if(value)
+            vg.fill_color(text_color1)
+        else
+            vg.fill_color(text_color2)
+        end
+        vg.text(w/2,h/2,label.upcase)
+
+    }
+
+}

--- a/src/mruby-zest/example/TabGroup.qml
+++ b/src/mruby-zest/example/TabGroup.qml
@@ -1,0 +1,28 @@
+Widget {
+    function layout(l, selfBox) {
+        selfBox = Draw::Layout::tabpack(l, selfBox, self)
+    }
+
+    function get_tab(wid)
+    {
+        n = children.length
+        selected = 0
+        tab_id = 0
+        (0..n).each do |ch_id|
+            child = children[ch_id]
+            if(child.class == Qml::TabButton)
+                if(wid == child)
+                    child.value = true
+                    selected = tab_id
+                else
+                    if(child.value)
+                        child.value = false
+                        child.damage_self
+                    end
+                end
+                tab_id += 1
+            end
+        end
+        selected
+    }
+}

--- a/src/mruby-zest/example/TextBox.qml
+++ b/src/mruby-zest/example/TextBox.qml
@@ -1,0 +1,28 @@
+ColorBox {
+    id: textBox
+    pad: 0.003
+    bg:  nil
+    property Float height: 0.7
+    property Symbol align: :center
+    property Object valueRef: nil
+    Text {
+        label:      textBox.label
+        height:     textBox.height
+        layoutOpts: [:no_constraint]
+        align:      textBox.align
+    }
+
+    onExtern: {
+        ref = OSC::RemoteParam.new($remote, textBox.extern)
+        ref.callback = lambda {|x|
+            textBox.label = x;
+            textBox.damage_self
+        }
+        textBox.valueRef = ref
+    }
+
+    function layout(l, selfBox) {
+        children[0].fixed(l, selfBox, 0, 0, 1, 1)
+        selfBox
+    }
+}

--- a/src/mruby-zest/example/TextField.qml
+++ b/src/mruby-zest/example/TextField.qml
@@ -1,0 +1,118 @@
+Widget {
+    id: text_field
+    property Object valueRef: nil
+    property Symbol style: :normal
+    property Function whenValue: nil
+    function animate()
+    {
+        if(root.key_widget != self)
+            @next = nil
+            if(@state)
+                @state = nil
+                damage_self
+            end
+            return
+        end
+        now = Time.new
+        if(@next.nil?)
+            @next = now + 0.1
+            return
+        elsif(@next < now)
+            @state = !@state
+            @next = now + 0.7
+            damage_self
+        end
+    }
+
+    function draw(vg)
+    {
+        if(self.style == :overlay)
+            draw_overlay(vg)
+        else
+            draw_normal(vg)
+        end
+
+    }
+
+    function draw_overlay(vg)
+    {
+        background color("1b1c1c")
+        vg.font_face("bold")
+        vg.font_size h*0.8
+        vg.text_align NVG::ALIGN_LEFT | NVG::ALIGN_MIDDLE
+        vg.fill_color = color("56c0a5")
+        l = "..."
+        if(label.class == String && !label.empty?)
+            l = label.clone
+        elsif(label.class == Array)
+            l = label[0].clone
+        end
+
+        (0...l.length).each do |i|
+            l[i] = "?" if l.getbyte(i) > 127
+        end
+
+        bnd = vg.text_bounds(0,0,l+"|")
+        if(bnd+8 > self.w)
+            vg.font_size self.h*self.w/(bnd+8)*0.8
+            bnd = vg.text_bounds(0,0,l)
+        end
+
+        vg.text(8,h/2,l)
+        if(@state)
+            vg.text(8+bnd,h/2,"|")
+        end
+    }
+    function draw_normal(vg)
+    {
+        background Theme::GeneralBackground
+        vg.font_face("bold")
+        vg.font_size h*0.8
+        vg.text_align NVG::ALIGN_LEFT | NVG::ALIGN_MIDDLE
+        vg.fill_color = Theme::TextColor
+        l = label.empty? ? "..." : label.clone
+
+        (0...l.length).each do |i|
+            l[i] = "?" if l.getbyte(i) > 127
+        end
+
+        vg.text(8,h/2,l)
+        bnd = vg.text_bounds(0,0,l)
+        if(@state)
+            vg.text(8+bnd,h/2,"|")
+        end
+    }
+
+    function onKey(k, mode)
+    {
+        return if mode != "press"
+        if(k.ord == 8)
+            self.label = self.label[0...-1]
+        elsif k.ord >= 32
+            self.label += k
+        end
+        whenValue.call if whenValue
+        valueRef.value = self.label if valueRef
+        damage_self
+    }
+
+    //Do nothing, but accept the event
+    function onMousePress(ev) {
+    }
+
+
+
+    function onMerge(val)
+    {
+        self.label = val.label
+    }
+
+    onExtern: {
+        ref = OSC::RemoteParam.new($remote, text_field.extern)
+        ref.callback = lambda {|x|
+            text_field.label = x;
+            text_field.damage_self
+        }
+        text_field.valueRef = ref
+    }
+}

--- a/src/mruby-zest/example/TextLine.qml
+++ b/src/mruby-zest/example/TextLine.qml
@@ -1,0 +1,48 @@
+Widget {
+    id: textedit
+    property Function whenValue: nil
+    property Object   valueRef:  nil
+    property Bool     upcase:    true
+    property String   ext:       nil
+    onExtern: {
+        ref = OSC::RemoteParam.new($remote, textedit.extern)
+        ref.callback = lambda {|x|
+            textedit.label = x;
+            textedit.damage_self
+        }
+        textedit.valueRef = ref
+    }
+    function draw(vg)
+    {
+        background Theme::GeneralBackground
+        vg.font_face("bold")
+        vg.font_size h*0.8
+        vg.text_align NVG::ALIGN_LEFT | NVG::ALIGN_MIDDLE
+        vg.fill_color = Theme::TextColor
+        l = label.empty? ? "..." : label.clone
+        l = l+self.ext if self.ext && !l.end_with?(self.ext)
+        l = l.upcase if self.upcase
+        (0...l.length).each do |i|
+            l[i] = "?" if l.getbyte(i) > 127
+        end
+        vg.text(8,h/2,l)
+    }
+
+    function onKey(k, mode)
+    {
+        return if mode != "press"
+        if(k.ord == 8)
+            self.label = self.label[0...-1]
+        elsif k.ord >= 32
+            self.label += k
+        end
+        whenValue.call if whenValue
+        valueRef.value = self.label if valueRef
+        damage_self
+    }
+
+    function onMerge(val)
+    {
+        self.label = val.label
+    }
+}

--- a/src/mruby-zest/example/TitleBar.qml
+++ b/src/mruby-zest/example/TitleBar.qml
@@ -1,0 +1,17 @@
+Widget {
+    id: title_bar
+    function draw(vg)
+    {
+        vg.path do |v|
+            v.rect(0,0,self.w,self.h)
+            v.fill_color Theme::TitleBar
+            v.fill
+            v.stroke
+        end
+    }
+    Text {
+        id: title
+        label: title_bar.label
+        height: 0.8
+    }
+}

--- a/src/mruby-zest/example/VGroup.qml
+++ b/src/mruby-zest/example/VGroup.qml
@@ -1,0 +1,4 @@
+ColorBox {
+    bg: nil
+    layoutOpts: [:think_of_the_children]
+}

--- a/src/mruby-zest/example/VisEq.qml
+++ b/src/mruby-zest/example/VisEq.qml
@@ -1,0 +1,59 @@
+Widget {
+    id: vis_eq
+    property Object valueRef: nil
+    property Array  coeff: nil
+    property Bool   doUpdate: false
+    onExtern: {
+        vis_eq.valueRef = OSC::RemoteParam.new($remote, vis_eq.extern)
+        vis_eq.valueRef.callback = lambda {|x| vis_eq.update_coeff x}
+    }
+
+    function refresh() {
+        self.valueRef.refresh if valueRef
+    }
+
+    function update_coeff(x)
+    {
+        return if self.coeff == x
+        n2 = x.length/2
+        self.coeff = x
+        self.doUpdate = true
+    }
+
+    function animate()
+    {
+        return if !doUpdate
+        self.doUpdate = false
+        xpts = Draw::DSP::logspace(1, 20000, 256)
+        pts  = eq_response(xpts, coeff)
+        ypts = []
+        pts.each do |pt|
+            ypts << Math.log10(pt)/4
+        end
+        data_view.data = ypts
+        data_view.damage_self
+    }
+
+    function draw(vg)
+    {
+        fixedpad = 5
+        pad  = 0
+        pad2 = (1-2*pad)
+        box = Rect.new(w*pad  + fixedpad,   h*pad  + fixedpad,
+                       w*pad2 - 2*fixedpad, h*pad2 - 2*fixedpad)
+        vg.path do
+            vg.rect(box.x, box.y, box.w, box.h)
+            vg.fill_color Theme::VisualBackground
+            vg.fill
+        end
+        Draw::Grid::log_x(vg, 1, 201, box)
+        Draw::Grid::linear_y(vg, 0, 8, box)
+    }
+    DataView {
+        id: data_view
+        normal: false
+        pad: 0
+        fixedpad: 5
+        under_highlight: true
+    }
+}

--- a/src/mruby-zest/example/VisFilter.qml
+++ b/src/mruby-zest/example/VisFilter.qml
@@ -1,0 +1,75 @@
+Widget {
+    id: vis_filter
+
+    property Object valueRef: nil
+    property Object doUpdate: false
+    property Array  coeff:    nil
+
+    onExtern: {
+        return if vis_filter.extern.nil?
+        vis_filter.valueRef = OSC::RemoteParam.new($remote, vis_filter.extern)
+        vis_filter.valueRef.callback = lambda {|x| vis_filter.update_coeff x}
+    }
+
+    function animate()
+    {
+        return if !doUpdate
+        self.doUpdate = false
+        x = self.coeff
+        b = nil
+        a = nil
+        if(x.length == 7)
+            b = x[1..3]
+            a = x[4..6]
+        elsif(x.length == 5)
+            b = x[1..2]
+            a = x[3..4]
+        end
+        vis_filter.coeff = x;
+        xpts = Draw::DSP::logspace(50, 30000, 256)
+        xnorm = []
+        xpts.each do |pt|
+            xnorm << pt / 48000.0
+        end
+        yy = Draw::opt_magnitude(b, a, xnorm, x[0]+1)
+        ypts = []
+        yy.each do |pt|
+            ypts << Math::log10(pt)/4
+        end
+        #vis_filter.xpoints = xpts
+        data_view.data = ypts
+        data_view.damage_self
+    }
+
+    function update_coeff(x)
+    {
+       return if(x == vis_filter.coeff)
+       self.coeff = x
+       self.doUpdate = true
+    }
+
+    function refresh()
+    {
+        self.valueRef.force_refresh if valueRef
+    }
+
+    function draw(vg)
+    {
+        fixedpad = 5
+        pad  = 0
+        pad2 = (1-2*pad)
+        box = Rect.new(w*pad  + fixedpad,   h*pad  + fixedpad,
+                       w*pad2 - 2*fixedpad, h*pad2 - 2*fixedpad)
+        background Theme::VisualBackground
+        Draw::Grid::log_x(vg, 50, 30000, box)
+        Draw::Grid::linear_y(vg, 1, 10, box)
+    }
+
+    DataView {
+        id: data_view
+        normal: false
+        pad: 0
+        fixedpad: 5
+        under_highlight: true
+    }
+}

--- a/src/mruby-zest/example/VisFormant.qml
+++ b/src/mruby-zest/example/VisFormant.qml
@@ -1,0 +1,123 @@
+Widget {
+    id: vfor
+    property Object valueRef: nil
+    property Object numformants: 4
+    property Object q_value: 1
+    property Object stages: 1
+    property Object gain_value: 1.0
+    property Array  vowels: nil
+    property Bool   pending_damage: false
+    property Bool   refreshing: false
+    property Int    vowel_num: 0
+
+    function change() {
+        self.pending_damage = true
+    }
+
+    function refresh() {
+        self.refreshing = true
+    }
+
+    function onSetup(old=nil) {
+        base = vfor.extern
+        refs = []
+
+        #Vowel data
+        val = OSC::RemoteParam.new($remote, base+"vowels")
+        val.callback = lambda {|x|
+            nvowels   = x[0]
+            nformants = x[1]
+            vs = []
+            (0...nvowels).each do |vv|
+                v = []
+                (0...nformants).each do |f|
+                    ind = 2 + 3*nformants*vv + 3*f
+                    v << Formant.new(x[ind+0], x[ind+1], x[ind+2])
+                end
+                vs << v
+            end
+            vfor.vowels = vs;
+            vfor.change
+        }
+        refs << val
+
+        #num formants
+        val = OSC::RemoteParam.new($remote, base+"Pnumformants")
+        val.mode = :full
+        val.callback = lambda {|x|
+            vfor.numformants = x
+            vfor.change
+        }
+        refs << val
+
+        #q
+        val = OSC::RemoteParam.new($remote, base+"q_value")
+        val.callback = lambda {|x|
+            vfor.q_value = x
+            vfor.change
+        }
+        refs << val
+
+        #stages
+        val = OSC::RemoteParam.new($remote, base+"Pstages")
+        val.callback = lambda {|x|
+            vfor.stages = x + 1
+            vfor.change
+        }
+        refs << val
+
+        #gain
+        val = OSC::RemoteParam.new($remote, base+"Pgain")
+        val.callback = lambda {|x|
+            vfor.gain_value = x
+            vfor.change
+        }
+        refs << val
+        self.valueRef = refs
+    }
+
+    function draw(vg)
+    {
+        padfactor = 10
+        bb = Draw::indent(Rect.new(0,0,w,h), padfactor, padfactor)
+        background Theme::VisualBackground
+        Draw::Grid::log_x(vg, 50, 1000, bb)
+        Draw::Grid::linear_y(vg, 1, 11, bb)
+    }
+
+    function animate()
+    {
+        if(self.refreshing)
+            self.refreshing = false
+            valueRef.each do |r|
+                r.refresh()
+            end
+        end
+        if(self.pending_damage)
+            self.pending_damage = false
+            response(self.vowel_num) if !self.vowels.nil?
+        end
+    }
+
+    function response(nvowel)
+    {
+        xpts = Draw::DSP::logspace(1, 20000, 256)
+        vo   = self.vowels[nvowel]
+        return if vo.nil?
+        fo   = vo
+        fo   = fo[0...numformants] if numformants <= fo.length
+        ypts = formant_filter_response(xpts, fo, q_value, stages,
+               gain_value)
+        data_view.data = ypts
+        data_view.damage_self
+        damage_self
+    }
+
+    DataView {
+        id: data_view
+        normal: true
+        pad: 0
+        fixedpad: 5
+        under_highlight: true
+    }
+}

--- a/src/mruby-zest/example/VisHarmonic.qml
+++ b/src/mruby-zest/example/VisHarmonic.qml
@@ -1,0 +1,82 @@
+Widget {
+    id: hm
+    property Float pad: 1.0/32
+    property Object valueRef: nil
+    property Array  points:   nil
+    property Bool   needRefresh: false
+
+    onExtern: {
+        hm.valueRef = OSC::RemoteParam.new($remote, hm.extern)
+        hm.valueRef.callback = Proc.new {|x| hm.setValue(x)}
+    }
+
+    function setValue(x)
+    {
+        if(x != self.points)
+            self.points = x
+            damage_self
+        end
+    }
+
+    function animate()
+    {
+        if(self.valueRef && self.needRefresh)
+            self.needRefresh = false
+            self.valueRef.refresh
+        end
+    }
+
+    function refresh()
+    {
+        self.needRefresh = true
+    }
+
+    function draw(vg)
+    {
+        pad2 = (1-2*pad)
+        box = Rect.new(w*pad, h*pad, w*pad2, h*pad2)
+
+        background Theme::VisualBackground
+
+        Draw::Grid::linear_x(vg,0,10,box, 1.0)
+        Draw::Grid::linear_y(vg,0,10,box, 1.0)
+
+        xpoints = Draw::DSP::linspace(-2,2,128)
+        ypoints = nil
+        vline   = 0.15
+        if(self.points)
+            ypoints = self.points[1..-1].map {|x| 2*x-1}
+            vline   = self.points[0]/2
+        else
+            ypoints = xpoints.map {|x| 2*Math.exp(-x**2/0.1)-1 }
+        end
+
+        Draw::WaveForm::plot(vg, ypoints, box)
+
+        vg.path do |v|
+            v.move_to(0.5*w+vline*w, h*pad)
+            v.line_to(0.5*w+vline*w, h*pad2)
+            v.move_to(0.5*w-vline*w, h*pad)
+            v.line_to(0.5*w-vline*w, h*pad2)
+            v.stroke_color Theme::VisualStroke
+            v.stroke
+        end
+
+        vg.path do |v|
+            v.rect(0.5*w-vline*w, h*pad, 2*vline*w, h*pad2)
+            v.fill_color Theme::VisualLightFill
+            v.fill
+        end
+        vg.path do |v|
+            v.move_to(pad*w, h*(pad+pad2))
+            n = ypoints.length
+            ypoints.each_with_index do |y, i|
+                v.line_to(pad*w+pad2*w*i*1.0/n, (1.0-y)/2*h)
+            end
+            v.line_to((pad+pad2)*w,(pad+pad2)*h)
+            v.close_path
+            v.fill_color Theme::VisualLightFill
+            v.fill
+        end
+    }
+}

--- a/src/mruby-zest/example/VisResonance.qml
+++ b/src/mruby-zest/example/VisResonance.qml
@@ -1,0 +1,102 @@
+Widget {
+    id: visreson
+    property Int      prev:      nil
+    property Function whenValue: nil
+    property Object   valueRef:   nil
+
+    onExtern: {
+        visreson.valueRef =
+            OSC::RemoteParam.new($remote, visreson.extern)
+        visreson.valueRef.callback = lambda {|x|
+            draw_layer.points = visreson.un_rescale(x)
+            draw_layer.damage_self
+        }
+    }
+
+    function refresh()
+    {
+        valueRef.refresh if valueRef
+    }
+
+    function un_rescale(x)
+    {
+        o = []
+        x.each do |xx|
+            o << 2*xx-1
+        end
+        o
+    }
+
+    function rescale(x)
+    {
+        o = []
+        x.each do |xx|
+            o << (xx+1)/2
+        end
+        o
+    }
+
+    function animate()
+    {
+        if(@send_update)
+            @send_update = false
+            self.valueRef.value = rescale(draw_layer.points)
+        end
+    }
+
+    function draw(vg)
+    {
+        vg.path do |v|
+            v.rect(0,0,w,h)
+            v.fill_color   Theme::VisualBackground
+            v.fill
+        end
+
+        pad = 5
+        bb  = Rect.new(pad,pad,w-2*pad,h-2*pad)
+        Draw::Grid::linear_x(vg, 0, 10, bb)
+        Draw::Grid::linear_y(vg, 0, 10, bb)
+    }
+
+    function runUpdate(pos, type)
+    {
+        rely  = 1 - 2*(pos.y - global_y) / h
+        relx  = (pos.x - global_x) / w
+        return if(relx < 0 || relx > 1)
+        rely  = limit(rely, -0.9999, 0.9999)
+
+        n = draw_layer.points.length
+        sel = (n*relx).to_i
+        draw_layer.points[sel] = rely
+
+        #Check to see if interpolation is needed
+        if(type == :move && ![prev-1, prev, prev+1].include?(sel))
+            srt = [sel,prev].min
+            dst = [sel,prev].max
+            a   = draw_layer.points[srt]
+            b   = draw_layer.points[dst]
+            (srt...dst).each do |i|
+                ri = (i-srt)/(dst-srt)
+                draw_layer.points[i] = a+ri*(b-a) if i >= 0 && i<draw_layer.points.length
+            end
+        end
+        self.prev = sel
+        draw_layer.damage_self
+        @send_update = true
+    }
+
+
+    function onMousePress(ev)
+    {
+        runUpdate(ev.pos, :press)
+    }
+
+    function onMouseMove(ev)
+    {
+        runUpdate(ev.pos, :move)
+    }
+
+    DataViewAlt {
+        id: draw_layer
+    }
+}

--- a/src/mruby-zest/example/VisSubHarmonics.qml
+++ b/src/mruby-zest/example/VisSubHarmonics.qml
@@ -1,0 +1,64 @@
+Widget {
+    id: vis_sub
+    onExtern: {
+        return if vis_sub.extern.nil?
+        #meta = OSC::RemoteMetadata.new($remote, vis_sub.extern)
+
+        vis_sub.valueRef = OSC::RemoteParam.new($remote, vis_sub.extern)
+        vis_sub.valueRef.callback = lambda {|x| vis_sub.update_coeff x}
+    }
+
+    property Object valueRef: nil
+    property Bool   next_coeff: nil
+
+    function refresh()
+    {
+        valueRef.force_refresh if valueRef
+    }
+
+    function update_coeff(x)
+    {
+        x = [x] if x.class != Array
+        self.next_coeff = x
+    }
+
+    function do_update_coeff(x)
+    {
+        now = Time.new
+        xpts = Draw::DSP::logspace(400, 20000, 512)
+        tmp = sub_synth_response(xpts, x)
+        ypts = tmp.map { |x| Math.log10(x)/4 }
+
+        #max  = Draw::DSP::ary_max ypts
+        #ypts = ypts.map { |x| x - max + 1}
+
+        data_view.data = ypts
+        root.damage_item data_view
+        t2 = Time.new
+    }
+
+    function draw(vg)
+    {
+        fixedpad = 5
+        background Theme::VisualBackground
+        box = Rect.new(fixedpad, fixedpad, w-2*fixedpad, h-2*fixedpad)
+        Draw::Grid::log_x(vg, 400, 20000, box)
+        Draw::Grid::linear_y(vg, 1, 10, box, 1, 40)
+    }
+
+    DataView {
+        id: data_view
+        normal: false
+        pad: 0.0
+        fixedpad: 5
+        under_highlight: true
+
+        function animate()
+        {
+            if(vis_sub.next_coeff)
+                vis_sub.do_update_coeff(vis_sub.next_coeff)
+                vis_sub.next_coeff = nil
+            end
+        }
+    }
+}

--- a/src/mruby-zest/example/VuMeter.qml
+++ b/src/mruby-zest/example/VuMeter.qml
@@ -1,0 +1,56 @@
+Widget {
+    id: meter
+    property Object valueRef: nil
+    property Object data: nil
+
+    function animate() {
+        self.valueRef.refresh if(self.valueRef)
+    }
+
+    function rap2dB(x) { 20*Math::log10(x) }
+    function bound(x)  { [0.0, [1.0, x].min].max }
+    function cv(x)     {min_db = -40;bound((min_db-rap2dB(x))/min_db)}
+
+    function draw(vg)
+    {
+        indent_color = Theme::VisualBackground
+        background indent_color
+
+        bar_color = Theme::VisualLine
+        pad  = 3
+        pad2 = (h-2*pad)
+        v1 = 0.3
+        v2 = 0.5
+        if(!data.nil?)
+            v1 = cv(data[0])
+            v2 = cv(data[1])
+        end
+
+        vg.path do |v|
+            v.rect(pad,(1-v1)*pad2, 0.2*w, (v1)*(h-pad))
+            v.fill_color bar_color
+            v.fill
+        end
+
+        vg.path do |v|
+            v.rect(0.8*w-pad,(1-v2)*pad2, 0.2*w, (v2)*(h-pad))
+            v.fill_color bar_color
+            v.fill
+        end
+    }
+
+    function update_data(x)
+    {
+        if(self.data != x)
+            self.data = x
+            self.damage_self
+        end
+    }
+
+    function onSetup(old=nil)
+    {
+        self.valueRef = OSC::RemoteParam.new($remote, "/vu-meter")
+        self.valueRef.callback = lambda {|x| meter.update_data(x) }
+        animate() if self.data
+    }
+}

--- a/src/mruby-zest/example/WaveView.qml
+++ b/src/mruby-zest/example/WaveView.qml
@@ -1,0 +1,107 @@
+Widget {
+    id: wave_view
+    property Bool   grid: true;
+    property Bool   draw_borders: false
+    property Object valueRef: nil
+    property Float  phase: 0.0
+    property String noise: nil
+    property Bool   noise_mode: false
+    property Float pad: 1.0/32
+    function class_name() { "WaveView" }
+
+    onExtern: {
+        data = OSC::RemoteParam.new($remote, wave_view.extern)
+        data.callback = lambda {|x|
+            data_view.data = x if !wave_view.noise_mode
+            data_view.damage_self
+        }
+        noise = nil
+        if(wave_view.noise)
+            noise = OSC::RemoteParam.new($remote, wave_view.noise)
+            noise.callback = lambda {|x|
+                wave_view.set_noise_mode(x != 0)
+            }
+        end
+        if(noise)
+            wave_view.valueRef = [data, noise]
+        else
+            wave_view.valueRef = [data]
+        end
+    }
+
+    onPhase: {
+        return if((data_view.phase*100).to_i == (wave_view.phase*100).to_i)
+        data_view.phase = wave_view.phase
+
+        data_view.damage_self
+    }
+
+    DataView {
+        id: data_view
+        phase: wave_view.phase
+    }
+
+    function set_noise_mode(x)
+    {
+        return if x == self.noise_mode
+        self.noise_mode = x
+        if(self.noise_mode)
+            #Draw a N
+            u = []
+            20.times  { u << 0.0 }
+            10.times  { u << 0.8 }
+            20.times  {|x| u << (x/19)*-1.0+0.8 }
+            10.times  { u << 0.8 }
+            20.times  { u << 0.0 }
+            l = []
+            20.times  { l << 0.0 }
+            10.times   { l << -0.8 }
+            20.times  {|x| l << (x/19)*-1.0+0.2 }
+            10.times   { l << -0.8 }
+            20.times  { l << 0.0 }
+            data_view.ignore_phase = true
+            data_view.data = [u, l]
+            data_view.damage_self
+        else
+            data_view.ignore_phase = false
+            self.valueRef[0].refresh if valueRef
+        end
+    }
+
+
+    function draw(vg)
+    {
+        pad2 = (1-2*pad)
+        box = Rect.new(w*pad, h*pad, w*pad2, h*pad2)
+
+        background Theme::VisualBackground
+
+        if(grid)
+            Draw::Grid::linear_x(vg,0,10,box, 1.0)
+            Draw::Grid::linear_y(vg,0,10,box, 1.0)
+        end
+
+        if(draw_borders)
+            vg.translate(0.5, 0.5)
+            vg.path do |v|
+                v.stroke_width = 1
+                v.stroke_color = Theme::GridLine
+                v.rounded_rect(box.x.round(), box.y.round(), box.w.round(), box.h.round(), 2)
+                v.stroke()
+            end
+            vg.translate(-0.5, -0.5)
+        end
+
+        if(extern.nil? || extern.empty?)
+            Draw::WaveForm::sin(vg, box, 128)
+        end
+    }
+
+    function refresh()
+    {
+        return if self.valueRef.nil?
+        self.valueRef.each do |v|
+            v.refresh
+        end
+    }
+}

--- a/src/mruby-zest/example/ZynAbout.qml
+++ b/src/mruby-zest/example/ZynAbout.qml
@@ -1,0 +1,64 @@
+Widget {
+    TextScroll {
+        label:  {
+            l  = ""
+            l << "ZynAddSubFX is a powerful open source software synthesizer\n"
+            l << "Zyn-Fusion is the completely rewritten interface for ZynAddSubFX's 3.0.0 Release\n"
+            l << "\n"
+            l << "Maintainer (2009-2019):\n"
+            l << "    Mark McCurry\n"
+            l << "\n"
+            l << "Maintainer (2002-2010):\n"
+            l << "    Nasca Octavian Paul\n"
+            l << "\n"
+            l << "3.0.0 UI & Icon Design:\n"
+            l << "    Budislav Stepanov\n"
+            l << "\n"
+            l << "Contributors:\n"
+            l << "    Hans Petter Selasky (BSD Compat)\n"
+            l << "    Christopher Oliver (Unison + presets fix, mousewheel support,\n"
+            l << "                        SUBnote overtones, unison enhancements, ...)\n"
+            l << "    Gerald Folcher (legato, mono notes memory)\n"
+            l << "    Lars Luthman (zombie fix,jack midi, LASH support)\n"
+            l << "    Daniel Clemente (with a workaround of X11 repeated key bug)\n"
+            l << "    Emmanuel Saracco (fix for JACK output)\n"
+            l << "    Achim Settelmeier (QUERTZ keyboard layout for virtual keyboard)\n"
+            l << "    Jérémie Andréi (AZERTY keyboard layout, Array index fix, OSS failsafe)\n"
+            l << "    Alexis Ballier (const char* <-> string mismatch, NULLMidi prototype fix)\n"
+            l << "    Tobias Doerffel (static-instance variables fix, missing include fix)\n"
+            l << "    James Morris (Memory leaks in FLTK GUI)\n"
+            l << "    Alan Calvert (Portions of New IO)\n"
+            l << "    Stephen Parry (DSSI rebuild)\n"
+            l << "    Ryan Billing (APhaser)\n"
+            l << "    Hans Petter Selasky (OSS Midi, FreeBSD support, Bank UI bug fix)\n"
+            l << "    Damien Goutte-Gattat (Bank select midi support)\n"
+            l << "    Lieven Moors (Spike/Circle waveform)\n"
+            l << "    Olaf Schulz (MIDI Aftertouch support)\n"
+            l << "    Jonathan Liles (NSM & NTK support)\n"
+            l << "    Johannes Lorenz (Effect Documentation, PID Files, Testing Extrodanare)\n"
+            l << "    Ilario Glasgo (Italian Doc Translation)\n"
+            l << "    Filipe Coelho (Globals Cleanup, LV2/VST Support)\n"
+            l << "    Andre Sklenar (UI Pixmaps)\n"
+            l << "    Harald Hvaal (General Code Modernization)\n"
+            l << "    Olivier Jolly (DSSI Bank Load Fix)\n"
+            l << "    Daniel Sheeler (Legato Aftertouch Fixes)\n"
+            l << "\n"
+            l << "This is the 3.0.6 version of ZynAddSubFX\n"
+            l << "For more information please see http://zynaddsubfx.sourceforge.net/\n"
+            l
+        }
+    }
+
+    function draw(vg) {
+        vg.path do |v|
+            v.rect(0,0,w,h)
+            paint = v.linear_gradient(0,0,0,h,
+            Theme::InnerGrad1, Theme::InnerGrad2)
+            v.fill_paint paint
+            v.fill
+            v.stroke_color color(:black)
+            v.stroke_width 1.0
+            v.stroke
+        end
+    }
+}

--- a/src/mruby-zest/example/ZynAddGlobal.qml
+++ b/src/mruby-zest/example/ZynAddGlobal.qml
@@ -1,0 +1,206 @@
+Widget {
+    id: addglobal
+
+    property Object valueRef: nil
+    property Symbol filtertype: nil
+
+
+    function layout(l, selfBox)
+    {
+        Draw::Layout::vfill(l, selfBox, children, [0.55, 0.40, 0.05])
+        selfBox
+    }
+
+    Swappable {
+        id: row1
+
+        function setDataVis(type, tab) {
+            root.set_view_pos(:vis, type)
+            root.change_view
+        }
+    }
+
+    Widget {
+        id: row2
+        function layout(l, selfBox) {
+            Draw::Layout::hpack(l, selfBox, children)
+        }
+
+
+        Swappable {
+            id: amp_gen
+            whenSwapped: lambda {
+                if(amp_gen.content == Qml::ZynAnalogFilter)
+                    ch = amp_gen.children[0]
+                    ch.whenClick = lambda {row1.setDataVis(:filter, :filter)}
+                end
+            }
+        }
+        Swappable {
+            id: amp_env
+        }
+        Swappable {
+            id: amp_lfo
+        }
+    }
+    Widget {
+        id: footer
+
+        function layout(l, selfBox) {
+            selfBox = Draw::Layout::tabpack(l, selfBox, self)
+        }
+
+
+        function setTab(id)
+        {
+            (0..2).each do |ch_id|
+                children[ch_id].value = (ch_id == id)
+                children[ch_id].damage_self
+            end
+            mapping = {0 => :amplitude,
+                       1 => :frequency,
+                       2 => :filter}
+            root.set_view_pos(:subsubview, mapping[id])
+            root.change_view
+            #db.update_values
+        }
+
+        TabButton { label: "amplitude"; whenClick: lambda {footer.setTab(0)}; highlight_pos: :top}
+        TabButton { label: "frequency"; whenClick: lambda {footer.setTab(1)}; highlight_pos: :top}
+        TabButton { label: "filter";    whenClick: lambda {footer.setTab(2)}; highlight_pos: :top}
+    }
+
+    function set_view()
+    {
+        subsubview = root.get_view_pos(:subsubview)
+        types = [:amplitude, :frequency, :filter]
+        if(!types.include?(subsubview))
+            subsubview = :amplitude
+            root.set_view_pos(:subsubview, subsubview)
+        end
+        vis = root.get_view_pos(:vis)
+        types = [:envelope, :lfo, :filter, :oscilloscope]
+        if(!types.include?(vis))
+            vis = :envelope
+            root.set_view_pos(:vis, vis)
+        end
+
+        if(subsubview == :amplitude)
+            set_amp(self.extern)
+        elsif(subsubview == :frequency)
+            set_freq(self.extern)
+        elsif(subsubview == :filter)
+            set_filter(self.extern)
+        end
+
+        if(vis == :lfo)
+            set_vis_lfo(self.extern, subsubview)
+        elsif(vis == :envelope)
+            set_vis_env(self.extern, subsubview)
+        elsif(vis == :oscilloscope)
+            set_vis_oscilloscope()
+        elsif(vis == :filter)
+            set_vis_filter(self.extern, subsubview)
+        end
+        db.update_values
+    }
+
+    function set_vis_lfo(ext, tab)
+    {
+        e_  = {:filter    => "FilterLfo/",
+               :amplitude => "AmpLfo/",
+               :frequency => "FreqLfo/"}[tab]
+        return if e_.nil?
+        row1.extern  = ext + e_
+        row1.content = Qml::LfoVis
+        row1.children[0].children[0].extern = amp_lfo.extern+"out"
+    }
+
+    function set_vis_env(ext, tab)
+    {
+        e_  = {:filter    => "FilterEnvelope/",
+               :amplitude => "AmpEnvelope/",
+               :frequency => "FreqEnvelope/"}[tab]
+        return if e_.nil?
+        row1.extern  = ext + e_
+        row1.content = Qml::ZynEnvEdit
+        #self.children[0].children[0].extern = amp_env.extern+"out"
+        amp_env.children[0].whenModified = lambda {
+            elm = row1.children[0]
+            elm.refresh if elm.respond_to? :refresh
+        }
+    }
+
+    function set_vis_filter(ext, dummy)
+    {
+        row1.extern = ext + "GlobalFilter/"
+        if(addglobal.filtertype == :formant)
+            row1.content = Qml::ZynFormant
+        else
+            row1.content = Qml::VisFilter
+            row1.children[0].extern = ext + "GlobalFilter/response"
+        end
+        amp_gen.children[0].whenModified = lambda {
+            elm = row1.children[0]
+            elm.refresh if elm.respond_to? :refresh
+        }
+    }
+
+    function set_amp(base)
+    {
+        footer.children[0].value = true
+        amp_gen.extern  = base
+        amp_env.extern  = base + "AmpEnvelope/"
+        amp_lfo.extern  = base + "AmpLfo/"
+        amp_gen.content = Qml::ZynAmpGeneral
+        amp_env.content = Qml::ZynAmpEnv
+        amp_lfo.content = Qml::ZynLFO
+        amp_env.children[0].whenClick = lambda {row1.setDataVis(:env, :amp)}
+        amp_lfo.children[0].whenClick = lambda {row1.setDataVis(:lfo, :amp)}
+    }
+
+    function set_freq(base)
+    {
+        footer.children[1].value = true
+        amp_gen.extern  = base
+        amp_env.extern  = base + "FreqEnvelope/"
+        amp_lfo.extern  = base + "FreqLfo/"
+        amp_gen.content = Qml::ZynFreqGeneral
+        amp_env.content = Qml::ZynFreqEnv
+        amp_lfo.content = Qml::ZynLFO
+        amp_env.children[0].whenClick = lambda {row1.setDataVis(:env, :freq)}
+        amp_lfo.children[0].whenClick = lambda {row1.setDataVis(:lfo, :freq)}
+    }
+
+    function set_filter(base)
+    {
+        footer.children[2].value = true
+        amp_gen.extern  = base + "GlobalFilter/"
+        amp_env.extern  = base + "FilterEnvelope/"
+        amp_lfo.extern  = base + "FilterLfo/"
+        amp_gen.content = Qml::ZynAnalogFilter
+        amp_env.content = Qml::ZynFilterEnv
+        amp_lfo.content = Qml::ZynLFO
+        amp_env.children[0].whenClick = lambda {row1.setDataVis(:env, :filter)}
+        amp_lfo.children[0].whenClick = lambda {row1.setDataVis(:lfo, :filter)}
+    }
+
+     function set_vis_oscilloscope()
+    {
+        row1.content = Qml::ZynAddOscilloscope
+    }
+
+    function onSetup(old=nil)
+    {
+        return if self.valueRef
+        if(self.valueRef.nil?)
+            path = self.extern + "GlobalFilter/Pcategory"
+            self.valueRef = OSC::RemoteParam.new($remote, path)
+            self.valueRef.mode = :full
+            self.valueRef.callback = lambda {|x|
+                addglobal.filtertype = [:analog, :formant, :statevar][x]
+            }
+        end
+        set_view()
+    }
+}

--- a/src/mruby-zest/example/ZynAddOscilloscope.qml
+++ b/src/mruby-zest/example/ZynAddOscilloscope.qml
@@ -1,0 +1,10 @@
+Group_nocp {
+ZynOscilloscope{
+    options: ["< mixing", "> mixing", "> punch", "> legato"]
+    opt_vals: ["/part0/kit0/adpars/noteout/be4_mix","/part0/kit0/adpars/noteout/after_mix","/part0/kit0/adpars/noteout/punch","/part0/kit0/adpars/noteout/legato"] 
+    }
+ZynOscilloscope{
+    options: ["> mixing", "< mixing", "> punch", "> legato"]
+        opt_vals: ["/part0/kit0/adpars/noteout/after_mix", "/part0/kit0/adpars/noteout/be4_mix", "/part0/kit0/adpars/noteout/punch","/part0/kit0/adpars/noteout/legato"] 
+    }
+}

--- a/src/mruby-zest/example/ZynAddSynth.qml
+++ b/src/mruby-zest/example/ZynAddSynth.qml
@@ -1,0 +1,160 @@
+Widget {
+    id: center
+
+    function layout(l, selfBox)
+    {
+        Draw::Layout::vfill(l, selfBox, children, [0.05, 0.95])
+    }
+    Widget {
+        id: header
+        PowButton {id: vpow}
+        NumEntry  {
+            value:      header.get_voice + 1
+            format:     "VCE "
+            whenValue:  lambda {header.set_voice()}
+            tooltip:    "voice"
+            maximum:    8
+            minimum:    1
+        }
+
+        TabButton { whenClick: lambda {header.setTab(0)}; label: "global"}
+        TabButton { whenClick: lambda {header.setTab(1)}; label: "voice"}
+        TabButton { whenClick: lambda {header.setTab(2)}; label: "oscillator"}
+        TabButton { whenClick: lambda {header.setTab(3)}; label: "mod-osc"}
+        TabButton { whenClick: lambda {header.setTab(4)}; label: "modulation"}
+        TabButton { whenClick: lambda {header.setTab(5)}; label: "voice list"}
+        TabButton { whenClick: lambda {header.setTab(6)}; label: "resonance"}
+
+
+        TriggerButton {
+            id: oscillbutton
+            layoutOpts: [:no_constraint];
+            label: "oscilloscope"
+            whenValue: lambda {
+            root.set_view_pos(:subview, :global)
+            root.set_view_pos(:vis, :oscilloscope)
+            root.change_view
+            center.turn_off_tab()  
+             }
+        }
+
+        CopyButton  {id: cpy_but}
+        PasteButton {id: pst_but}
+
+        function set_voice() {
+            root.set_view_pos(:voice, children[1].value-1)
+            root.change_view
+        }
+        function get_voice() { root.get_view_pos(:voice) }
+
+        function layout(l, selfBox) {
+            selfBox = Draw::Layout::tabpack(l, selfBox, self, oscillbutton)
+        }
+
+
+        function setTab(id)
+        {
+            #Define a mapping from tabs to values
+            mapping = {0 => :global,
+                       1 => :voice,
+                       2 => :oscil,
+                       3 => :modosc,
+                       4 => :modulate,
+                       5 => :vce_list,
+                       6 => :resonance,
+                       7 => :oscilloscope}
+
+            root.set_view_pos(:subview, mapping[id])
+             if(id == 0)
+                root.set_view_pos(:vis, :envelope)
+            end
+            root.change_view
+        }
+
+    }
+
+    function onSetup(old=nil)
+    {
+        return if swap.content
+        set_view
+    }
+
+    function set_view()
+    {
+        vce     = root.get_view_pos(:voice)
+        subview = root.get_view_pos(:subview)
+        extbase = center.extern
+        ext = {:global    => "GlobalPar/",
+               :voice     => "VoicePar#{vce}/",
+               :oscil     => "VoicePar#{vce}/OscilSmp/",
+               :modosc    => "VoicePar#{vce}/FMSmp/",
+               :modulate  => "VoicePar#{vce}/",
+               :vce_list  => "",
+               :resonance => "GlobalPar/Reson/",
+               :oscilloscope => ""}
+        mapping = {:global    => Qml::ZynAddGlobal,
+                   :voice     => Qml::ZynAddVoice,
+                   :oscil     => Qml::ZynOscil,
+                   :modosc    => Qml::ZynOscil,
+                   :modulate  => Qml::ZynOscilMod,
+                   :vce_list  => Qml::ZynAddVoiceList,
+                   :resonance => Qml::ZynResonance,
+                   :oscilloscope => Qml::ZynAddOscilloscope}
+        tabid   = {:global    => 2,
+                   :voice     => 3,
+                   :oscil     => 4,
+                   :modosc    => 5,
+                   :modulate  => 6,
+                   :vce_list  => 7,
+                   :resonance => 8,
+                   :oscilloscope => 9}
+        if(!mapping.include?(subview))
+            subview = :oscil
+            root.set_view_pos(:subview, :oscil)
+        end
+
+        swap.extern  = extbase + ext[subview]
+        swap.content = mapping[subview]
+        header.children.each_with_index do |ch, i|
+            if(ch.class == Qml::TabButton)
+                ch.value = (i == tabid[subview])
+                ch.damage_self
+            end
+        end
+
+        header.children[1].setValue(vce+1)
+
+        cpy_but.index  = nil
+        pst_but.index  = nil
+
+        if([:oscil, :modosc, :resonance].include?(subview))
+            cpy_but.extern = extbase + ext[subview]
+            pst_but.extern = extbase + ext[subview]
+        elsif([:modulate,:voice].include?(subview))
+            cpy_but.extern = extbase
+            pst_but.extern = extbase
+            cpy_but.index  = vce
+            pst_but.index  = vce
+        else
+            cpy_but.extern = extbase
+            pst_but.extern = extbase
+        end
+        vpow.extern    = extbase + "VoicePar#{vce}/Enabled"
+
+    }
+
+    Swappable { id: swap }
+
+    function turn_off_tab()
+    {
+        n = 7
+        (2..n).each do |ch_id|
+            child = header.children[ch_id]
+           
+                if(child.value)
+                    child.value = false
+                    child.damage_self
+                end
+            end
+    }
+}

--- a/src/mruby-zest/example/ZynAddVoice.qml
+++ b/src/mruby-zest/example/ZynAddVoice.qml
@@ -1,0 +1,200 @@
+Widget {
+    id: addbase
+
+    property Object valueRef: nil
+    property Symbol filtertype: nil
+
+    function layout(l, selfBox) {
+        Draw::Layout::vfill(l, selfBox, children, 
+                            [0.55, 0.40, 0.05])
+    }
+
+    Swappable {
+        id: row1
+
+        function setDataVis(type, tab) {
+            root.set_view_pos(:vis, type)
+            root.change_view
+        }
+    }
+
+    Widget {
+        id: row2
+        function layout(l, selfBox) {
+            Draw::Layout::hpack(l, selfBox, children)
+        }
+
+
+        Swappable {
+            id: gen
+        }
+        Swappable {
+            id: env
+        }
+        Swappable {
+            id: lfo
+        }
+    }
+    Widget {
+        id: footer
+
+        function layout(l, selfBox) {
+            Draw::Layout::tabpack(l, selfBox, self)
+        }
+
+
+        function setTab(id)
+        {
+            (0..2).each do |ch_id|
+                children[ch_id].value = (ch_id == id)
+                self.root.damage_item children[ch_id]
+            end
+            mapping = {0 => :amplitude,
+                       1 => :frequency,
+                       2 => :filter}
+            root.set_view_pos(:subsubview, mapping[id])
+            root.change_view
+        }
+
+        TabButton { label: "amplitude"; whenClick: lambda {footer.setTab(0)}; highlight_pos: :top}
+        TabButton { label: "frequency"; whenClick: lambda {footer.setTab(1)}; highlight_pos: :top}
+        TabButton { label: "filter";    whenClick: lambda {footer.setTab(2)}; highlight_pos: :top}
+    }
+
+    function set_amp(base)
+    {
+        footer.children[0].value = true
+        gen.extern  = base
+        env.extern  = base + "AmpEnvelope/"
+        lfo.extern  = base + "AmpLfo/"
+        gen.content = Qml::ZynAmpVoiceGeneral
+        env.content = Qml::ZynAmpEnv
+        lfo.content = Qml::ZynLFO
+        env.children[0].whenClick = lambda {row1.setDataVis(:env, :amp)}
+        lfo.children[0].whenClick = lambda {row1.setDataVis(:lfo, :amp)}
+        env.children[0].toggleable = base + "PAmpEnvelopeEnabled"
+        lfo.children[0].toggleable = base + "PAmpLfoEnabled"
+    }
+
+    function set_freq(base)
+    {
+        footer.children[1].value = true
+        gen.extern  = base
+        env.extern  = base + "FreqEnvelope/"
+        lfo.extern  = base + "FreqLfo/"
+        gen.content = Qml::ZynFreqGeneralVoice
+        env.content = Qml::ZynFreqEnv
+        lfo.content = Qml::ZynLFO
+        env.children[0].whenClick = lambda {row1.setDataVis(:env, :freq)}
+        lfo.children[0].whenClick = lambda {row1.setDataVis(:lfo, :freq)}
+        env.children[0].toggleable = base + "PFreqEnvelopeEnabled"
+        lfo.children[0].toggleable = base + "PFreqLfoEnabled"
+    }
+
+    function set_filter(base)
+    {
+        footer.children[2].value = true
+        gen.extern  = base + "VoiceFilter/"
+        env.extern  = base + "FilterEnvelope/"
+        lfo.extern  = base + "FilterLfo/"
+        gen.content = Qml::ZynAnalogFilter
+        env.content = Qml::ZynFilterEnv
+        lfo.content = Qml::ZynLFO
+        gen.children[0].whenClick = lambda {row1.setDataVis(:filter, :filter)}
+        env.children[0].whenClick = lambda {row1.setDataVis(:env, :filter)}
+        lfo.children[0].whenClick = lambda {row1.setDataVis(:lfo, :filter)}
+        env.children[0].toggleable = base + "PFilterEnvelopeEnabled"
+        gen.children[0].toggleable = base + "PFilterEnabled"
+        lfo.children[0].toggleable = base + "PFilterLfoEnabled"
+    }
+
+    function set_vis_lfo(ext, tab)
+    {
+        e_  = {:filter    => "FilterLfo/",
+               :amplitude => "AmpLfo/",
+               :frequency => "FreqLfo/"}[tab]
+        return if e_.nil?
+        row1.extern  = ext + e_
+        row1.content = Qml::LfoVis
+        row1.children[0].children[0].extern = lfo.extern+"out"
+    }
+
+    function set_vis_env(ext, tab)
+    {
+        e_  = {:filter    => "FilterEnvelope/",
+               :amplitude => "AmpEnvelope/",
+               :frequency => "FreqEnvelope/"}[tab]
+        return if e_.nil?
+        row1.extern  = ext + e_
+        row1.content = Qml::ZynEnvEdit
+        #self.children[0].children[0].extern = env.extern+"out"
+        env.children[0].whenModified = lambda {
+            elm = row1.children[0]
+            elm.refresh if elm.respond_to? :refresh
+        }
+    }
+
+    function set_vis_filter(ext, dummy)
+    {
+        row1.extern = ext + "VoiceFilter/"
+        if(addbase.filtertype == :formant)
+            row1.content = Qml::ZynFormant
+        else
+            row1.content = Qml::VisFilter
+            row1.children[0].extern = ext + "VoiceFilter/response"
+        end
+        gen.children[0].whenModified = lambda {
+            elm = row1.children[0]
+            elm.refresh if elm.respond_to? :refresh
+        }
+    }
+
+    function set_view()
+    {
+        subsubview = root.get_view_pos(:subsubview)
+        types = [:amplitude, :frequency, :filter]
+        if(!types.include?(subsubview))
+            subsubview = :amplitude
+            root.set_view_pos(:subsubview, subsubview)
+        end
+
+        vis = root.get_view_pos(:vis)
+        types = [:envelope, :lfo, :filter]
+        if(!types.include?(vis))
+            vis = :envelope
+            root.set_view_pos(:vis, vis)
+        end
+
+        base = self.extern
+
+        if(subsubview == :amplitude)
+            set_amp base
+        elsif(subsubview == :frequency)
+            set_freq base
+        else
+            set_filter base
+        end
+
+        if(vis == :lfo)
+            set_vis_lfo(base, subsubview)
+        elsif(vis == :envelope)
+            set_vis_env(base, subsubview)
+        elsif(vis == :filter)
+            set_vis_filter(base, subsubview)
+        end
+    }
+
+    function onSetup(old=nil)
+    {
+        return if self.valueRef
+        if(self.valueRef.nil?)
+            path = self.extern + "VoiceFilter/Pcategory"
+            self.valueRef = OSC::RemoteParam.new($remote, path)
+            self.valueRef.mode = :full
+            self.valueRef.callback = lambda {|x|
+                addbase.filtertype = [:analog, :formant, :statevar][x]
+            }
+        end
+        set_view()
+    }
+}

--- a/src/mruby-zest/example/ZynAddVoiceList.qml
+++ b/src/mruby-zest/example/ZynAddVoiceList.qml
@@ -1,0 +1,69 @@
+Widget {
+    id: vce_list
+    property Array weights: [0.05, 0.05, 0.2, 0.2, 0.3, 0.2]
+
+    function draw(vg) {
+        vg.path do |v|
+            v.rect(0,0,w,h)
+            paint = v.linear_gradient(0,0,0,h,
+            Theme::InnerGrad1, Theme::InnerGrad2)
+            v.fill_paint paint
+            v.fill
+            v.stroke_color color(:black)
+            v.stroke_width 1.0
+            v.stroke
+        end
+    }
+
+
+    function onSetup(old=nil)
+    {
+        return if children.length > 2
+        (0...8).each do |r|
+            row        = Qml::ZynAddVoiceListItem.new(db)
+            row.num    = r
+            row.extern = vce_list.extern+"VoicePar#{r}/"
+            Qml::add_child(self, row)
+        end
+    }
+
+    Widget {
+        //0
+        ColorBox {bg: nil }
+        //1
+        ColorBox {bg: nil}
+        //2
+        TextBox  {bg: nil; label: "volume"}
+        //3
+        TextBox  {bg: nil; label: "panning"}
+        //4
+        TextBox  {bg: nil; label: "detune"}
+        //5
+        TextBox  {bg: nil; label: "vib-depth"}
+        function layout(l, selfBox)
+        {
+            chBox   = []
+
+            off = 0.0
+            children.each_with_index do |ch, ind|
+                weight = vce_list.weights[ind]
+                ch.fixed(l, selfBox, off, 0.0, weight, 1.0)
+                off += weight
+            end
+            selfBox
+        }
+    }
+
+    function layout(l, selfBox)
+    {
+        n = children.length
+        off  = 0
+        gap  = 0.040
+        step = (1.0-(n)*gap)/n
+        children.each_with_index do |ch, id|
+            ch.fixed(l, selfBox, 0.01, off, 0.98, step)
+            off += step + gap
+        end
+        selfBox
+    }
+}

--- a/src/mruby-zest/example/ZynAddVoiceListItem.qml
+++ b/src/mruby-zest/example/ZynAddVoiceListItem.qml
@@ -1,0 +1,69 @@
+Widget {
+    id: voice_item
+    property Int   num:     0
+    property Array weights: [0.05, 0.05, 0.05, 0.2, 0.2, 0.3, 0.15]
+
+    //voice ID
+    ToggleButton {
+        extern: voice_item.extern + "Enabled"
+        label: (voice_item.num+1).to_s;
+        layoutOpts: [:no_constraint]
+    }
+    //AA Enabled
+    ToggleButton {
+        extern: voice_item.extern + "PAAEnabled"
+        label: "AA";
+    }
+    //mini wave view
+    WaveView {
+        extern: voice_item.extern + "OscilSmp/waveform"
+        noise:  voice_item.extern + "Type"
+        grid: false;
+    }
+    //volume
+    HSlider {
+        extern: voice_item.extern + "PVolume"
+        label: "20%"
+    }
+    //pan
+    HSlider {
+        extern: voice_item.extern + "PPanning"
+        label: "centered";
+        centered: true;
+        value: 0.5
+    }
+    //detune
+    HSlider {
+        extern: voice_item.extern + "PDetune"
+        label: "+0 cents";
+        centered: true;
+        value: 0.5
+    }
+
+    //vib depth
+    HSlider {
+        extern: voice_item.extern + "FreqLfo/Pintensity"
+        label: "100%"
+    }
+
+    function layout(l, selfBox)
+    {
+        chBox   = []
+
+        off = 0.0
+        hpad = 1.0/128
+        children.each_with_index do |ch, ind|
+            weight = weights[ind]
+            ch.fixed(l, selfBox, off+hpad, 0.0, weight-2*hpad, 1.0)
+            off += weight
+        end
+        selfBox
+    }
+
+    function onSetup(old=nil)
+    {
+        children.each do |x|
+            x.extern()
+        end
+    }
+}

--- a/src/mruby-zest/example/ZynAlienwah.qml
+++ b/src/mruby-zest/example/ZynAlienwah.qml
@@ -1,0 +1,34 @@
+Group {
+    id: wah
+    label: "alienwah"
+    topSize: 0.2
+
+    function refresh() {
+        return if rw.content.nil?
+        return if rw.content.children.length < 4
+        rw.content.children[3..-1].each do |c|
+            c.refresh
+        end
+    }
+
+    ParModuleRow {
+        id: rw
+        layoutOpts: []
+        Selector {
+            extern: wah.extern + "Alienwah/preset"
+            whenValue: lambda { wah.refresh }
+        }
+        Knob { extern: wah.extern + "Pvolume"}
+        Knob { extern: wah.extern + "Ppanning"}
+
+        Knob { extern: wah.extern + "Alienwah/Pfreq"   }
+        Knob { extern: wah.extern + "Alienwah/Pfreqrnd"   }
+        Selector     { extern: wah.extern + "Alienwah/PLFOtype" }
+        Knob { extern: wah.extern + "Alienwah/PStereo" }
+        Knob { extern: wah.extern + "Alienwah/Pdepth" }
+        Knob { extern: wah.extern + "Alienwah/Pfeedback" }
+        Knob { extern: wah.extern + "Alienwah/Pdelay" }
+        Knob { extern: wah.extern + "Alienwah/Plrcross" }
+        Knob { extern: wah.extern + "Alienwah/Pphase" }
+    }
+}

--- a/src/mruby-zest/example/ZynAmpEnv.qml
+++ b/src/mruby-zest/example/ZynAmpEnv.qml
@@ -1,0 +1,39 @@
+Group {
+    id: box
+    label: "Envelope"
+    property Function whenModified: nil
+
+    function cb()
+    {
+        whenModified.call if whenModified
+    }
+
+    ParModuleRow {
+        id: top
+        Knob { 
+            whenValue: lambda { box.cb }; 
+            extern: box.extern+"A_dt"
+            type:   :float
+        }
+        Knob { 
+            whenValue: lambda { box.cb }; 
+            extern: box.extern+"D_dt"
+            type:   :float
+        }
+        Knob { whenValue: lambda { box.cb }; extern: box.extern+"PS_val"}
+    }
+    ParModuleRow {
+        id: bot
+        Knob     { 
+            whenValue: lambda { box.cb }; 
+            extern: box.extern+"R_dt"
+            type:   :float
+        }
+        Knob     { whenValue: lambda { box.cb }; extern: box.extern+"Penvstretch"}
+        Col {
+            ToggleButton   { label: "FRCR"; whenValue: lambda { box.cb }; extern: box.extern+"Pforcedrelease"}
+            ToggleButton   { label: "lin/log"; whenValue: lambda { box.cb }; extern: box.extern+"Plinearenvelope"}
+            ToggleButton   { label: "repeat"; whenValue: lambda { box.cb }; extern: box.extern+"Prepeating"}
+        }
+    }
+}

--- a/src/mruby-zest/example/ZynAmpGeneral.qml
+++ b/src/mruby-zest/example/ZynAmpGeneral.qml
@@ -1,0 +1,27 @@
+Group {
+    id: box
+    label: "General"
+    copyable: false
+    property Function whenModified: nil
+
+    ParModuleRow {
+        id: top
+        Knob { 
+            extern: box.extern+"Volume"
+            type:   :float
+        }
+        Knob { extern: box.extern+"PAmpVelocityScaleFunction"}
+        Knob { extern: box.extern+"PPanning"}
+        Knob { extern: box.extern+"PPunchStretch"}
+
+    }
+    ParModuleRow {
+        id: bot
+        Knob     {extern: box.extern+"PPunchStrength"}
+        Knob     {extern: box.extern+"PPunchTime"}
+        Col {
+            ToggleButton   {label: "stereo"; extern: box.extern+"PStereo"}
+            ToggleButton   {label: "rnd grp"; extern: box.extern+"Hrandgrouping"}
+        }
+    }
+}

--- a/src/mruby-zest/example/ZynAmpMod.qml
+++ b/src/mruby-zest/example/ZynAmpMod.qml
@@ -1,0 +1,16 @@
+Group {
+    id: box
+    label: "General"
+    copyable: false
+
+    ParModuleRow {
+        Knob {
+            type:   :float
+            extern: box.extern + "FMvolume"
+        }
+        Knob { extern: box.extern+"PFMVolumeDamp"}
+        Knob { extern: box.extern+"PFMVelocityScaleFunction"}
+
+    }
+    Widget {}
+}

--- a/src/mruby-zest/example/ZynAmpVoiceGeneral.qml
+++ b/src/mruby-zest/example/ZynAmpVoiceGeneral.qml
@@ -1,0 +1,21 @@
+Group {
+    id: box
+    label: "General"
+    copyable: false
+
+    property Function whenModified: nil
+
+    ParModuleRow {
+        id: top
+        Knob { extern: box.extern+"volume"; type: :float }
+        Knob { extern: box.extern+"PAmpVelocityScaleFunction"}
+        BypassButton { extern: box.extern+"Pfilterbypass" }
+
+    }
+    ParModuleRow {
+        id: bot
+        Knob { extern: box.extern+"PPanning"}
+        Knob { extern: box.extern+"PDelay"}
+        ToggleButton   {label: "reson";  extern: box.extern+"Presonance"}
+    }
+}

--- a/src/mruby-zest/example/ZynAnalogFilter.qml
+++ b/src/mruby-zest/example/ZynAnalogFilter.qml
@@ -1,0 +1,108 @@
+Group {
+    id: box
+    label: "General"
+    property Function whenModified: nil
+    property Bool     type: :analog
+    property Bool     subsynth: false
+
+    onType: {
+        #Changes filter type
+    }
+
+    function cb()
+    {
+        whenModified.call if whenModified
+    }
+
+    function change_cat()
+    {
+        root.change_view()
+        if(cat.selected == 1)
+            typ.active = false
+            typ.damage_self
+            return
+        end
+        dest = self.extern + "Ptype"    if cat.selected == 0
+        dest = self.extern + "type-svf" if cat.selected == 2
+        if(typ.extern != dest)
+            typ.extern = dest
+            typ.extern()
+        end
+        typ.active = true
+        typ.damage_self
+    }
+
+    function remove_sense() {
+        root.ego_death snsa
+        root.ego_death snsb
+    }
+
+    function move_sense() {
+        snsa.extern = path_simp(box.extern + "../PGlobalFilterVelocityScale")
+        snsb.extern = path_simp(box.extern + "../PGlobalFilterVelocityScaleFunction")
+    }
+
+    ParModuleRow {
+        Knob {
+            type:      :float
+            whenValue: lambda { box.cb};
+            extern:    box.extern + "basefreq"
+        }
+        Knob {
+            type:      :float
+            whenValue: lambda { box.cb};
+            extern:    box.extern + "baseq"
+        }
+        Knob {
+            type:      :float
+            whenValue: lambda { box.cb};
+            extern:    box.extern + "freqtracking"
+        }
+        Knob {
+            id: snsa;
+            extern: {
+                ext = "../PFilterVelocityScale"       if !box.subsynth
+                ext = "../PGlobalFilterVelocityScale" if  box.subsynth
+                path_simp(box.extern + ext)
+            }
+        }
+        Knob {
+            id: snsb;
+            extern: {
+                ext = "../PFilterVelocityScaleFunction"       if !box.subsynth
+                ext = "../PGlobalFilterVelocityScaleFunction" if  box.subsynth
+
+                path_simp(box.extern + ext)
+            }
+        }
+    }
+    ParModuleRow {
+        NumEntry {
+            whenValue: lambda { box.cb}
+            extern: box.extern + "Pstages"
+            offset: 1
+            minimum: 1
+            maximum: 5
+        }
+        Selector {
+            id: cat
+            whenValue: lambda { box.change_cat};
+            extern: box.extern + "Pcategory"
+        }
+        Selector {
+            id: typ
+            whenValue: lambda { box.cb};
+            extern: box.extern + "Ptype"
+        }
+        Knob {
+            type:      :float
+            whenValue: lambda { box.cb};
+            extern: box.extern + "gain"
+        }
+    }
+
+    function class_name()
+    {
+        "ZynAnalogFilter"
+    }
+}

--- a/src/mruby-zest/example/ZynAutomation.qml
+++ b/src/mruby-zest/example/ZynAutomation.qml
@@ -1,0 +1,124 @@
+Widget {
+    id: automation_view
+    property Object valueRef: nil
+
+    //Automation Slots
+    Widget {
+        id: slots
+        function onSetup(old=nil)
+        {
+            return if children.length > 5
+            #//Fetch all parameters
+            16.times do |i|
+                slot = Qml::ZynAutomationSlot.new(db)
+                slot.slot_id = i
+                Qml::add_child(self,slot)
+                slot.set_active if(i==root.get_view_pos(:slot))
+            end
+        }
+        function layout(l, selfBox) {
+            Draw::Layout::vpack(l, selfBox, children)
+        }
+        function draw(vg)
+        {
+        }
+    }
+
+    //Detailed View
+    Widget {
+        TabGroup {
+            id: tgrp
+            Button {
+                label: "normal learn"
+                tooltip: "learn parameters to unused slot"
+                whenValue: lambda { automation_view.set_mode(:normal) }
+            }
+            Button {
+                label: "macro learn"
+                tooltip: "learn parameters to the active slot"
+                whenValue: lambda { automation_view.set_mode(:macro) }
+            }
+        }
+        ZynAutomationMidiChan {
+            id: chan
+            label: "MIDI Chan 0 CC 12 - Relearning"
+        }
+        Widget {
+            id: details
+            function onSetup(old=nil)
+            {
+                return if children.length > 2
+                #//Fetch all parameters
+                4.times do |i|
+                    slot = Qml::ZynAutomationParam.new(db)
+                    Qml::add_child(self,slot)
+                    slot.active = false if i!=0
+                end
+            }
+            function layout(l, selfBox) {
+                Draw::Layout::grid(l, selfBox, children, 2, 2, 5, 5)
+            }
+        }
+        function layout(l, selfBox) {
+            Draw::Layout::vfill(l, selfBox, children, [0.05,0.05,0.9])
+        }
+    }
+
+    function layout(l, selfBox) {
+        Draw::Layout::hfill(l, selfBox, children, [0.3,0.7])
+    }
+
+    function set_view() {
+        slot        = root.get_view_pos(:slot)
+        slot_path   = "/automate/slot#{slot}/"
+
+        chan.extern = slot_path
+        (0..3).each do |i|
+            details.children[i].extern = slot_path + "param#{i}/"
+        end
+        (0...slots.children.length).each do |i|
+            slots.children[i].set_active(slot == i)
+            slots.children[i].extern = "/automate/slot#{i}/"
+        end
+    }
+
+    function set_active(slot_id) {
+        if(root.get_view_pos(:slot) != slot_id)
+            root.set_view_pos(:slot, slot_id)
+            root.change_view
+        end
+    }
+
+    function set_mode(mode) {
+        $remote.automation.mode = mode
+        if($remote.automation.mode == :normal)
+            tgrp.children[0].value = true
+            tgrp.children[1].value = false
+        else
+            tgrp.children[0].value = false
+            tgrp.children[1].value = true
+        end
+        tgrp.damage_self
+    }
+
+    function onSetup(old=nil) {
+        details.onSetup
+
+        self.valueRef = OSC::RemoteParam.new($remote, "/automate/active-slot")
+        self.valueRef.type = "i"
+        self.valueRef.mode = :normal_int
+        self.valueRef.callback = lambda {|x| set_active(x)}
+
+        if($remote.automation.mode == :normal)
+            tgrp.children[0].value = true
+            tgrp.children[1].value = false
+        else
+            tgrp.children[0].value = false
+            tgrp.children[1].value = true
+        end
+
+        set_view
+    }
+
+
+}

--- a/src/mruby-zest/example/ZynAutomationMidiChan.qml
+++ b/src/mruby-zest/example/ZynAutomationMidiChan.qml
@@ -1,0 +1,48 @@
+TextBox {
+    id: midi_chan
+    onExtern: {
+        ext  = midi_chan.extern
+
+        learn_ref = OSC::RemoteParam.new($remote, ext + "learning")
+        midi_ref  = OSC::RemoteParam.new($remote, ext + "midi-cc")
+
+        midi_ref.mode  = true
+        learn_ref.mode = true
+
+        learn_ref.callback = lambda {|x| midi_chan.learning = x; update_text()}
+        midi_ref.callback  = lambda {|x| midi_chan.cc = x;       update_text()}
+
+
+        midi_chan.valueRef = [learn_ref, midi_ref]
+    }
+
+    function update_text() {
+        @cc = nil       if(@cc.nil?       || @cc < 0)
+        @learning = nil if(@learning.nil? || @learning < 0)
+
+        new_label = self.label;
+        if(@cc && !@learning)
+            new_label = "MIDI CC #{@cc}"
+        elsif(!@cc && @learning)
+            new_label = "Learning Queue #{@learning}"
+        elsif(@cc && @learning)
+            new_label = "MIDI CC #{@cc} - Relearning Queue #{@learning}"
+        else
+            new_label = "Unbound"
+        end
+
+        if(new_label != self.label)
+            self.label = new_label
+            damage_self
+        end
+    }
+
+    function onSetup(old=nil) {
+        @cc       = nil
+        @learning = nil
+    }
+
+    function cc=(x)       {@cc = x}
+    function learning=(x) {@learning = x}
+
+}

--- a/src/mruby-zest/example/ZynAutomationName.qml
+++ b/src/mruby-zest/example/ZynAutomationName.qml
@@ -1,0 +1,67 @@
+Widget {
+    Text {
+        id: textrender
+        //label: "Ins 1 · Kit 1 · Add · Vce 1 · Vol"
+        label: ""
+        height: 1.0
+    }
+
+    function update_path(path)
+    {
+        textrender.label = path if path.length > 0
+        textrender.label = "Unconnected" if path.length <= 0
+        damage_self
+    }
+
+    function create_menu(options, xx)
+    {
+
+        n = options.length
+        n = 1 if options.class != Array
+        widget = DropDown.new(self.db)
+        widget.w = self.w*0.2
+        widget.h = self.h*n
+        widget.x = xx
+        widget.y = 0
+        widget.layer = 2
+        widget.options = options
+        widget.callback = lambda { |v|
+            #set_value_user(v)
+        }
+        widget.y = -self.h*(n-1) if(widget.h+global_y > window.h)
+        widget.prime(root())
+
+        Qml::add_child(self, widget)
+        root.smash_draw_seq
+        root.damage_item widget
+    }
+
+    function onMousePress(ev)
+    {
+        return
+        ps = (ev.pos.x-global_x)/w
+        opts = []
+        if(ps<0.2)
+            (1..16).each do |i|
+                opts << "Ins #{i}"
+            end
+        elsif(ps < 0.4)
+            (1..16).each do |i|
+                opts << "Kit #{i}"
+            end
+        elsif(ps < 0.6)
+            opts << "ADD"
+            opts << "PAD"
+            opts << "SUB"
+        elsif(ps < 0.8)
+            (1..16).each do |i|
+                opts << "VCE #{i}"
+            end
+        else
+            opts << "Vol"
+            opts << "Freq"
+            opts << "Mod. Type"
+        end
+        create_menu(opts, ev.pos.x-global_x)
+    }
+}

--- a/src/mruby-zest/example/ZynAutomationParam.qml
+++ b/src/mruby-zest/example/ZynAutomationParam.qml
@@ -1,0 +1,125 @@
+Widget {
+    id: param
+    property Bool active: true
+    property Object valueRef: nil
+
+
+    function draw(vg)
+    {
+        background(color("ffffff", 50)) if !param.active
+    }
+
+    function set_gain(gain) {
+        plot.set_gain(gain)
+    }
+
+    function set_offset(offset) {
+        plot.set_offset(offset)
+    }
+
+
+    ZynAutomationName {
+        id: aname
+
+    }
+    Widget{
+        PlotLabelY {
+            id: yaxis
+        }
+        ZynAutomationPlot {id: plot}
+        function layout(l, selfBox) {
+            Draw::Layout::hfill(l, selfBox, children, [0.1, 0.9])
+        }
+    }
+    ParModuleRow {
+        Knob {
+            id: gain
+            label: "gain"
+            value: 0.5
+            type: "f"
+            whenValue: lambda {plot.set_gain(4*(gain.value-0.5))}
+        }
+        Knob {
+            id: offset
+            label: "offset"
+            value: 0.5
+            type: "f"
+            whenValue: lambda {plot.set_offset(offset.value-0.5)}
+        }
+
+        ClearBox {
+            id: clr
+            tooltip: "remove this parameter from the slot"
+            whenValue: lambda {$remote.action(param.extern + "clear")}
+        }
+    }
+
+    function layout(l, selfBox) {
+        Draw::Layout::vfill(l, selfBox, children, [0.1, 0.45, 0.35])
+    }
+
+    function onSetup(old=nil) {
+    }
+
+    function animate() {
+        plot.set_gain(4*(gain.value-0.5))
+        plot.set_offset(offset.value-0.5)
+    }
+
+    function update_path(path) {
+        aname.update_path(path)
+        if(path.empty?)
+            mn   = -1
+            mx   = 1
+            yaxis.labels = [mn, ((mn+mx)/2), mx].map{|x| x.to_s}
+            yaxis.damage_self
+        else
+            meta = OSC::RemoteMetadata.new($remote, path)
+            mn   = meta.min
+            mx   = meta.max
+            if(mn && mx)
+                yaxis.labels = [mn, ((mn+mx)/2), mx].map{|x| x.to_s}
+                yaxis.damage_self
+            end
+        end
+    }
+
+    function update_value(val) {
+        plot.input = 2*val-1
+    }
+
+    function update_active(val) {
+        if(val != self.active)
+            self.active = val
+            damage_self
+        end
+    }
+
+    onExtern: {
+        if(self.valueRef)
+            self.valueRef.each do |v|
+                v.clean
+            end
+        end
+        p = param
+        ext = p.extern
+
+        path_ref   =  OSC::RemoteParam.new($remote, ext + "path")
+        active_ref =  OSC::RemoteParam.new($remote, ext + "active")
+        value_ref  =  OSC::RemoteParam.new($remote, path_simp(ext + "../value"))
+
+        value_ref.set_min(0.0)
+        value_ref.set_max(1.0)
+        value_ref.type = "f"
+
+        path_ref.callback = lambda {|x| param.update_path(x)}
+        active_ref.callback = lambda {|x| param.update_active(x)}
+        value_ref.callback = lambda {|x| param.update_value(x)}
+
+        gain.extern = ext + "mapping/gain"
+        offset.extern = ext + "mapping/offset"
+
+
+        p.valueRef = [path_ref, active_ref, value_ref]
+    }
+}

--- a/src/mruby-zest/example/ZynAutomationPlot.qml
+++ b/src/mruby-zest/example/ZynAutomationPlot.qml
@@ -1,0 +1,139 @@
+Widget {
+    id: au_plot
+    property Float minimum: 0
+    property Float maximum: 0
+
+    function abs(x)
+    {
+        if x > 0
+            x
+        else
+            -x
+        end
+    }
+
+    function recalc()
+    {
+        @gain   ||= 1.0
+        @offset ||= 0.5
+
+        #function is out = @offset + input * @gain
+        #function is over -1..1
+        #function maps to 0..1
+
+        #Calculate x=-1 y value
+        ym = @offset + -1*@gain
+        #Calculate x=1 y value
+        yp = @offset + 1*@gain
+        #Calculate y=0 x value
+        xm = (0-@offset)/@gain
+        #Calculate y=1 x value
+        xp = (1-@offset)/@gain
+
+        @points = []
+
+        if(ym < 0)
+            @points << [0.0, 0.0, (xm+1)/2, 0.0]
+        elsif(ym > 1)
+            @points << [0.0, 1.0, (xp+1)/2, 1.0]
+        else
+            @points << [0.0, ym]
+        end
+
+        if(yp < 0)
+            @points << [(xm+1)/2, 0.0, 1.0, 0.0]
+        elsif(yp > 1)
+            @points << [(xp+1)/2, 1.0, 1.0, 1.0]
+        else
+            @points << [1.0, yp]
+        end
+        @points = @points.flatten
+        damage_self
+    }
+
+    function set_offset(o)
+    {
+        return if o == @offset + 0.5
+        @offset = o + 0.5
+        recalc()
+    }
+
+    function set_gain(g)
+    {
+        return if @gain == g
+        @gain = g
+        recalc()
+    }
+
+    function draw(vg)
+    {
+        @gain   ||= 1.0
+        @offset ||= 0.5
+        recalc() if(@points.nil?)
+        background(color("222222"))
+
+
+        vg.path do
+            vg.move_to(0,h/2)
+            vg.line_to(w,h/2)
+            vg.stroke_color(color("777777"))
+            vg.stroke_width(1)
+            vg.stroke
+        end
+
+        vg.path do
+            vg.move_to(w/2,0)
+            vg.line_to(w/2,h)
+            vg.stroke_color(color("777777"))
+            vg.stroke_width(1)
+            vg.stroke
+        end
+
+        vg.path do
+            vg.move_to(0,0)
+            vg.line_to(w,0)
+            vg.line_to(w,h)
+            vg.line_to(0,h)
+            vg.line_to(0,0)
+            vg.stroke_color(color("aaaaaa"))
+            vg.stroke_width(1)
+            vg.stroke
+        end
+
+        #Draw the actual line
+        n = @points.length/2
+        vg.path do
+            vg.move_to(0,h)
+            vg.move_to(w*@points[0], h*(1-@points[1]))
+            (1...n).each do |p|
+                vg.line_to(w*@points[2*p+0], h*(1-@points[2*p+1]))
+            end
+            vg.stroke_color(color("aaaaaa"))
+            vg.stroke_width(2)
+            vg.stroke
+        end
+
+        #Draw the active point
+        @input ||= 0.3
+        out = @offset + @input * @gain
+        if(out > 0 && out < 1)
+            vg.path do
+                vg.circle((@input+1)/2*w, (1-out)*h, 5)
+                vg.stroke
+            end
+        end
+
+
+
+    }
+
+    property Object valueRef: nil
+
+    function input=(x) {if(@input != x);@input = x;damage_self;end}
+
+    onExtern: {
+        value_ref =  OSC::RemoteParam.new($remote, au_plot.ext + "../value")
+        value_ref.callback = lambda {|x| au_plot.input = x}
+        au_plot.valueRef = [value_ref]
+    }
+}

--- a/src/mruby-zest/example/ZynAutomationSlot.qml
+++ b/src/mruby-zest/example/ZynAutomationSlot.qml
@@ -1,0 +1,66 @@
+Widget {
+    id: slot
+
+    property Int slot_id: 0
+
+    function set_active(active=true)
+    {
+        active_indicator.active = active
+    }
+
+    //Draw the header
+    ClearBox {
+        id: clr
+        tooltip: "clear automation slot"
+        whenValue: lambda {$remote.action(slot.extern + "clear")}
+    }
+    Widget {
+        TextField {
+            id: slot_name
+            label: "slot"
+        }
+        HSlider {
+            id: slide
+            type: "f"
+            value: 0.1
+        }
+        function layout(l, selfBox) {
+            Draw::Layout::vfill(l, selfBox, children, [0.90, 0.10])
+        }
+    }
+    ArrowBox {
+        id: active_indicator
+        whenValue: lambda {
+            $remote.action("/automate/active-slot", slot.slot_id)
+            root.set_view_pos(:slot, slot.slot_id)
+            root.change_view
+        }
+    }
+    function onSetup(old=nil)
+    {
+        #//Fetch parameters
+
+        #//Reallocate total number of child elements if
+    }
+
+    onExtern: {
+        slot_name.extern  = slot.extern + "name"
+        slide.extern = slot.extern + "value"
+    }
+
+    function layout(l, selfBox)
+    {
+        Draw::Layout::hfill(l, selfBox, children, [0.10, 0.8, 0.10])
+    }
+
+    function animate()
+    {
+        cur_time   = Time.new
+        @atime   ||= cur_time
+        old_time   = @atime
+        if((cur_time-old_time) >= 1.0/30.0)
+            @atime = cur_time
+            slide.refresh
+        end
+    }
+}

--- a/src/mruby-zest/example/ZynBandwidthEnv.qml
+++ b/src/mruby-zest/example/ZynBandwidthEnv.qml
@@ -1,0 +1,31 @@
+Group {
+    id: box
+    label: "Envelope"
+    property Function whenModified: nil
+
+    function cb()
+    {
+        whenModified.call if whenModified
+    }
+
+    ParModuleRow {
+        id: top
+        Knob { whenValue: lambda { box.cb }; extern: box.extern+"PA_val" }
+        Knob { 
+            whenValue: lambda { box.cb }; 
+            extern: box.extern+"A_dt"
+            type:   :float
+        }
+        Knob     { 
+            whenValue: lambda { box.cb }; 
+            extern: box.extern+"R_dt"
+            type:   :float
+        }
+        Knob { whenValue: lambda { box.cb }; extern: box.extern+"PR_val"}
+    }
+    ParModuleRow {
+        id: bot
+        Knob     { whenValue: lambda { box.cb }; extern: box.extern+"Penvstretch"}
+        ToggleButton   { label: "FRCR"; whenValue: lambda { box.cb }; extern: box.extern+"Pforcedrelease"}
+    }
+}

--- a/src/mruby-zest/example/ZynBank.qml
+++ b/src/mruby-zest/example/ZynBank.qml
@@ -1,0 +1,196 @@
+Widget {
+    id: bank
+
+    property Symbol mode: :read
+    property Symbol ind_selected: nil
+
+    function doSearch()
+    {
+        search_  = bank_name.selected_val
+        search_ += " " + bank_type.selected
+        search_ += " " + bank_tag.selected
+        search_ += " " + search.label
+        $remote.action("/bank/search", search_)
+    }
+
+    function doBank()
+    {
+        doSearch if self.mode == :read
+        setBank  if self.mode == :write
+    }
+
+    function setBank()
+    {
+        $remote.action("/bank/blist", bank_name.selected_val)
+    }
+
+    function doType()
+    {
+        doSearch if self.mode == :read
+        setType  if self.mode == :write
+    }
+
+    function setType()
+    {
+        part = root.get_view_pos(:part)
+        sel = bank_type.selected_id
+        $remote.action("/part#{part}/info.Ptype", sel)
+    }
+
+    function doLoad()
+    {
+        ins = ins_sel.selected_val
+        self.ind_selected = ins.to_i
+        part = root.get_view_pos(:part)
+        return if part.class != Fixnum
+        $remote.action("/load_xiz", part, ins) if !ins.empty?
+        $remote.damage("/part#{part}/");
+    }
+
+    function doSave()
+    {
+        part = root.get_view_pos(:part)
+        if not ins_sel.selected_val.nil?
+            $remote.action("/bank/save_to_slot", part, ins_sel.selected_val.to_i)
+        else
+            return
+        end
+    }
+    
+    function doSavePart()
+    {
+        part = root.get_view_pos(:part)
+        $remote.action("/part#{part}/savexml")
+    }
+
+    function doInsSelect()
+    {
+        doLoad if self.mode == :read
+        doSave if self.mode == :write
+    }
+    
+    function doRescan()
+    {
+        $remote.action("/bank/rescan")
+    }
+
+    Widget {
+        id: lhs
+        SearchBox {
+            id: search
+            whenValue: lambda { bank.doSearch }
+        }
+        Widget {
+            SelColumn {
+                id: bank_name
+                label:  "bank"
+                skip:   true
+                extern: "/bank/bank_list"
+                whenValue: lambda { bank.doBank }
+            }
+            SelColumn {
+                id: bank_type
+                label: "type"
+                extern: "/bank/types"
+                whenValue: lambda { bank.doType }
+            }
+            SelColumn {
+                id: bank_tag
+                label: "tag"
+                extern: "/bank/tags"
+                whenValue: lambda { bank.doSearch }
+            }
+            function layout(l, selfBox) {
+                Draw::Layout::hfill(l, selfBox, children, [0.3, 0.3, 0.4])
+            }
+        }
+
+        function layout(l, selfBox) {
+            children[0].fixed(l, selfBox, 0, 0.00, 1, 0.05)
+            children[1].fixed(l, selfBox, 0, 0.05, 1, 0.95)
+
+            selfBox
+        }
+    }
+    Widget {
+        id: rhs
+        Widget {
+            id: rwbox
+            TabButton {
+                label: "read"
+                value: true
+                whenClick: lambda { rwbox.setrw(0) }
+                layoutOpts: [:no_constraint]
+            }
+            TabButton {
+                label: "write"
+                whenClick: lambda { rwbox.setrw(1) }
+                layoutOpts: [:no_constraint]
+            }
+            TriggerButton {
+                label: "overwrite"
+                whenValue: lambda { bank.doSavePart() }
+            }
+            TriggerButton {
+                label: "rescan"
+                whenValue: lambda { bank.doRescan() }
+            }
+            function setrw(x)
+            {
+                if(x == 0)
+                    bank.mode = :read
+                    children[0].value = true
+                    children[1].value = false
+                else
+                    bank.mode = :write
+                    children[0].value = false
+                    children[1].value = true
+                end
+                bank_type.clear
+                children[0].damage_self
+                children[1].damage_self
+            }
+
+            function layout(l, selfBox) {
+                Draw::Layout::hpack(l, selfBox, children)
+            }
+        }
+        Widget {
+            SelColumn {
+                id: ins_sel
+                extern: "/bank/search_results"
+                label: "preset"
+                number: false
+                skip:   true
+                whenValue: lambda {bank.doInsSelect}
+            }
+            ZynPatchInfo {}
+
+            function layout(l, selfBox) {
+                children[0].fixed(l, selfBox, 0.0, 0, 0.5, 1)
+                children[1].fixed(l, selfBox, 0.5, 0, 0.5, 1)
+
+                selfBox
+            }
+        }
+        function layout(l, selfBox)
+        {
+            children[0].fixed(l, selfBox, 0, 0.00, 1, 0.05)
+            children[1].fixed(l, selfBox, 0, 0.05, 1, 0.95)
+
+            selfBox
+        }
+    }
+    function layout(l, selfBox)
+    {
+        rhs.fixed(l,  selfBox, 0.5, 0, 0.5, 1)
+        lhs.fixed(l, selfBox, 0.0, 0, 0.5, 1)
+
+        selfBox
+    }
+
+    function setup(old=nil)
+    {
+    }
+
+}

--- a/src/mruby-zest/example/ZynCenter.qml
+++ b/src/mruby-zest/example/ZynCenter.qml
@@ -1,0 +1,201 @@
+Widget {
+    id: center
+    function layout(l)
+    {
+        #Center layout
+        selfBox = l.genBox :zynCenter, center
+        headBox  = header.layout(l)
+        row1Box  = row1.layout(l)
+        row2Box  = row2.layout(l)
+        content  = explore.layout(l)
+        row3Box  = row3.layout(l)
+        #layout the module
+        amplBox  = ampl.layout(l)
+        freqBox  = freq.layout(l)
+        filtBox  = filt.layout(l)
+        amplEBox = ampl_env.layout(l)
+        freqEBox = freq_env.layout(l)
+        filtEBox = filt_env.layout(l)
+        amplLBox = ampl_lfo.layout(l)
+        freqLBox = freq_lfo.layout(l)
+        filtLBox = filt_lfo.layout(l)
+        #module layout done
+        l.contains(selfBox, headBox)
+        l.contains(selfBox, row1Box)
+        l.contains(selfBox, row2Box)
+        l.contains(selfBox, row3Box)
+
+        #Top Row
+        l.contains(row1Box,amplBox)
+        l.contains(row1Box,freqBox)
+        l.contains(row1Box,filtBox)
+
+        l.rightOf(amplBox, freqBox)
+        l.rightOf(freqBox, filtBox)
+
+        #Second Row
+        l.contains(row2Box,amplEBox)
+        l.contains(row2Box,freqEBox)
+        l.contains(row2Box,filtEBox)
+
+        l.rightOf(amplEBox, freqEBox)
+        l.rightOf(freqEBox, filtEBox)
+
+        #Content
+        l.contains(selfBox, content)
+
+        #Third Row
+        l.contains(row3Box,amplLBox)
+        l.contains(row3Box,freqLBox)
+        l.contains(row3Box,filtLBox)
+
+        l.rightOf(amplLBox, freqLBox)
+        l.rightOf(freqLBox, filtLBox)
+
+        l.punish2([selfBox.w], [1.0/3], amplLBox.w)
+        l.punish2([selfBox.w], [1.0/3], freqLBox.w)
+        l.punish2([selfBox.w], [1.0/3], filtLBox.w)
+
+        l.punish2([selfBox.w], [1.0/3], amplEBox.w)
+        l.punish2([selfBox.w], [1.0/3], freqEBox.w)
+        l.punish2([selfBox.w], [1.0/3], filtEBox.w)
+
+        #Global Optimizatoin
+        l.topOf(headBox, row1Box)
+        l.topOf(row1Box, row2Box)
+        l.topOf(row2Box, content)
+        l.topOf(content, row3Box)
+
+        l.sheq([headBox.h, selfBox.h], [1, -0.2*0.2], 0)
+        l.sheq([row1Box.h, row2Box.h], [1, -1], 0)
+        l.sheq([row1Box.h, row3Box.h], [1, -1], 0)
+        l.le([row1Box.h, selfBox.h], [1, -0.2])
+        l.le([content.h, selfBox.h], [1, -0.36])
+        l.punish_difference(amplBox.w,amplEBox.w)
+        l.punish_difference(freqBox.w,freqEBox.w)
+        #Center Layout Done
+
+        selfBox
+    }
+    Widget {
+        id: header
+
+        function measure(text)
+        {
+            bounds = Nanovg::Transform.new
+            $vg.text_bounds(0,0,text,bounds)
+            bw = bounds.c-bounds.a
+            bh = bounds.d-bounds.b
+            return bw,bh
+        }
+
+        function layout(l)
+        {
+            selfBox = l.genBox :zynCenterHeader, header
+            prev = nil
+            header.children.each do |ch|
+                box = ch.layout(l)
+                l.contains(selfBox,box)
+                #bw,bh = measure(ch.label)
+
+                #l.aspect(box, bh, bw)
+                if(prev)
+                    l.rightOf(prev, box)
+                end
+                prev = box
+            end
+            selfBox
+        }
+
+        Button { label: "<"}
+        Button { label: "4"}
+        Button { label: ">"}
+        Button { label: "voice"}
+        Button { label: "global parameters"}
+        Button { label: "voice parameters"}
+        Button { label: "voice & modulator oscillators"}
+        Button { label: "voice list"}
+        Button { label: "resonance"}
+        Button { label: "c"}
+        Button { label: "p"}
+    }
+    Widget {
+        id: row1
+        ParModule {
+            id: ampl
+            label: "amplitude"
+            Knob { label: "vol" }
+            Knob { label: "v.sns" }
+            Knob { label: "pan" }
+            Knob { label: "p.str" }
+            Knob { label: "p.t." }
+            Knob { label: "p.stc." }
+            Knob { label: "p.vel." }
+        }
+        ParModule {
+            id: freq
+            label: "frequency"
+            Knob {label: "detune"}
+            Knob {label: "octave"}
+            Knob {label: "rel.bw"}
+            Knob {label: "coarse det."}
+        }
+        ParModule {
+            id: filt
+            label: "filter"
+            Knob {label: "c.freq"}
+            Knob {label: "q"}
+            Knob {label: "v.sns a."}
+            Knob {label: "freq. tr"}
+            Knob {label: "gain"}
+        }
+    }
+
+    Widget {
+        id: row2
+        ParModule {
+            id: ampl_env
+            label: "amplitude envelope"
+            Knob { label: "a.dt" }
+            Knob { label: "d.dt" }
+            Knob { label: "s.val" }
+            Knob { label: "stretch" }
+            Button { label: "frcr" }
+            Button { label: "L" }
+        }
+        ParModule {
+            id: freq_env
+            label: "frequency envelope"
+            Knob { label: "a.dt" }
+            Knob { label: "d.dt" }
+            Knob { label: "s.val" }
+            Knob { label: "r.dt" }
+            Knob { label: "stretch" }
+        }
+        ParModule {
+            id: filt_env
+            label: "filter envelope"
+            Knob { label: "a.dt" }
+            Knob { label: "d.dt" }
+            Knob { label: "s.val" }
+        }
+    }
+    Envelope {
+        id: explore
+    }
+    Widget {
+        id: row3
+        ZynLFO {
+            id: ampl_lfo
+            label: "amplitude lfo"
+        }
+        ZynLFO {
+            id: freq_lfo
+            label: "frequency lfo"
+        }
+        ZynLFO {
+            id: filt_lfo
+            label: "filter lfo"
+        }
+    }
+}

--- a/src/mruby-zest/example/ZynChorus.qml
+++ b/src/mruby-zest/example/ZynChorus.qml
@@ -1,0 +1,36 @@
+Group {
+    id: chorus
+    label: "chorus"
+    topSize: 0.2
+
+    function refresh() {
+        return if rw.content.nil?
+        return if rw.content.children.length < 4
+        rw.content.children[3..-1].each do |c|
+            c.refresh
+        end
+    }
+
+    ParModuleRow {
+        id: rw
+        layoutOpts: []
+        Selector {
+            extern: chorus.extern + "Chorus/preset"
+            whenValue: lambda { chorus.refresh }
+        }
+        Knob { extern: chorus.extern + "Pvolume"}
+        Knob { extern: chorus.extern + "Ppanning"}
+
+        Knob { extern: chorus.extern + "Chorus/Pfreq" }
+        Knob { extern: chorus.extern + "Chorus/Pfreqrnd" }
+        Selector { extern: chorus.extern + "Chorus/PLFOtype" }
+        Knob { extern: chorus.extern + "Chorus/PStereo" }
+        Knob { extern: chorus.extern + "Chorus/Pdepth" }
+        Knob { extern: chorus.extern + "Chorus/Pdelay" }
+        Knob { extern: chorus.extern + "Chorus/Pfeedback" }
+        Knob { extern: chorus.extern + "Chorus/Plrcross" }
+        ToggleButton { extern: chorus.extern + "Chorus/Pflangemode" }
+        ToggleButton { extern: chorus.extern + "Chorus/Poutsub" }
+    }
+}
+

--- a/src/mruby-zest/example/ZynControllers.qml
+++ b/src/mruby-zest/example/ZynControllers.qml
@@ -1,0 +1,29 @@
+Group {
+    id: ctrl
+    label: "controllers"
+    copyable: false
+    ParModuleRow {
+        Knob   { extern: ctrl.extern+"modwheel.depth"}
+        Knob { extern: ctrl.extern+"filtercutoff.depth"}
+        Knob { extern: ctrl.extern+"filterq.depth"}
+        Knob   { extern: ctrl.extern+"bandwidth.depth"}
+        //TODO fix scaling see Part.fl:489
+        Knob   { extern: ctrl.extern+"pitchwheel.bendrange"}
+        Knob   { extern: ctrl.extern+"panning.depth"}
+    }
+    ParModuleRow {
+        lsize: 0.0
+        Col {
+            ToggleButton { extern: ctrl.extern+"modwheel.exponential"}
+            ToggleButton { extern: ctrl.extern+"bandwidth.exponential"}
+        }
+        Col{
+            ToggleButton { extern: ctrl.extern+"expression.receive"}
+            ToggleButton { extern: ctrl.extern+"volume.receive"}
+        }
+        Col {
+            ToggleButton { extern: ctrl.extern+"fmamp.receive"}
+            ToggleButton { extern: ctrl.extern+"sustain.receive"}
+        }
+    }
+}

--- a/src/mruby-zest/example/ZynDAFilter.qml
+++ b/src/mruby-zest/example/ZynDAFilter.qml
@@ -1,0 +1,14 @@
+Widget {
+    id: dyn
+    VisFilter {
+        id: vis
+        extern: dyn.extern + "filterpars/response"
+    }
+    ZynDyFilter {
+        whenModified: lambda { vis.refresh }
+        extern: dyn.extern + "filterpars/"
+    }
+    function layout(l, selfBox) {
+        Draw::Layout::vfill(l, selfBox, children, [0.5, 0.5])
+    }
+}

--- a/src/mruby-zest/example/ZynDFFilter.qml
+++ b/src/mruby-zest/example/ZynDFFilter.qml
@@ -1,0 +1,6 @@
+Widget {
+    id: dyn
+    ZynFormant {
+        extern: dyn.extern + "filterpars/"
+    }
+}

--- a/src/mruby-zest/example/ZynDistortion.qml
+++ b/src/mruby-zest/example/ZynDistortion.qml
@@ -1,0 +1,105 @@
+Widget {
+    id: dst
+    //label: "distortion"
+    //topSize: 0.2
+    function refresh_recur(x) {
+        #@@recur_level ||= 0
+        #@@recur_level += 1
+        #print " "*@@recur_level
+        #puts "Distort refresh = {#{x.class}} of {#{dst.class}}"
+        x.children.each do |xx|
+            #print " "*(@@recur_level+1)
+            #puts "child = #{xx.class}"
+            xx.refresh() if xx.respond_to? :refresh
+            dst.refresh_recur(xx)
+        end
+        #@@recur_level -= 1
+    }
+    function refresh() {
+        refresh_recur(self)
+    }
+    GroupHeader {
+        label: "Distortion"
+        extern: dst.extern
+        copyable: true
+    }
+    Widget {
+        WaveView {
+            id: wave
+            extern: dst.extern + "Distorsion/waveform"
+        }
+        Widget {
+            ParModuleRow {
+                id: rw
+                layoutOpts: []
+
+                Selector {
+                    extern: dst.extern + "Distorsion/preset"
+                    whenValue: lambda { dst.refresh }
+                    layoutOpts: [:long_mode]
+                }
+                Knob { 
+                    extern: dst.extern + "Pvolume"
+                    whenValue: lambda {wave.refresh};
+                    }
+                Knob { extern: dst.extern + "Ppanning"}
+                Knob {   extern: dst.extern + "Distorsion/Plrcross"; label: "l.rc." }
+                Knob {   extern: dst.extern + "Distorsion/Plpf"}
+                Knob {   extern: dst.extern + "Distorsion/Phpf"}
+
+            }
+            ParModuleRow {
+                id: rw2
+                layoutOpts: []
+                Selector {
+                    extern: dst.extern + "Distorsion/Ptype";
+                    whenValue: lambda {wave.refresh; funcpar.refresh}
+                    layoutOpts: [:long_mode]
+                }
+                Knob {
+                    extern: dst.extern + "Distorsion/Pdrive"; label: "drive";
+                    whenValue: lambda {wave.refresh};
+                    function setValue(v) {
+                        valuator.value = lim(v, 0.0, 1.0);
+                        valuator.whenValue.call;
+                        valuator.damage_self
+                    }
+                }
+                Knob {
+                    extern: dst.extern + "Distorsion/Poffset"; label: "DC";
+                    whenValue: lambda {wave.refresh};
+                    function setValue(v) {
+                        valuator.value = lim(v, 0.0, 1.0);
+                        valuator.whenValue.call;
+                        valuator.damage_self
+                    }
+                }
+                Knob {
+                    extern: dst.extern + "Distorsion/Pfuncpar"; label: "shape";
+                    id: funcpar
+                    whenValue: lambda {wave.refresh};
+                    function setValue(v) {
+                        valuator.value = lim(v, 0.0, 1.0);
+                        valuator.whenValue.call;
+                        valuator.damage_self
+                    }
+                }
+                Knob {   extern: dst.extern + "Distorsion/Plevel"; label: "level" }
+                Col {
+                    ToggleButton { extern: dst.extern + "Distorsion/Pprefiltering"}
+                    ToggleButton { extern: dst.extern + "Distorsion/Pstereo"}
+                }
+            }
+            function layout(l, selfBox) {
+                Draw::Layout::vpack(l, selfBox, children)
+            }
+        }
+
+        function layout(l, selfBox) {
+            Draw::Layout::hpack(l, selfBox, children)
+        }
+    }
+    function layout(l, selfBox) {
+        Draw::Layout::vfill(l, selfBox, children, [0.15, 0.85])
+    }
+}

--- a/src/mruby-zest/example/ZynDyFilter.qml
+++ b/src/mruby-zest/example/ZynDyFilter.qml
@@ -1,0 +1,64 @@
+Group {
+    id: box
+    label: "General"
+    topSize: 0.2
+    property Function whenModified: nil
+    property Bool     type: :analog
+
+    onType: {
+        #Changes filter type
+    }
+
+    function cb()
+    {
+        whenModified.call if whenModified
+    }
+
+    function change_cat()
+    {
+        root.change_view()
+        dest = self.extern + "Ptype"    if cat.selected == 0
+        return                          if cat.selected == 1
+        dest = self.extern + "type-svf" if cat.selected == 2
+        if(typ.extern != dest)
+            typ.extern = dest
+            typ.extern()
+        end
+    }
+
+    ParModuleRow {
+        Knob {
+            type:      :float
+            whenValue: lambda { box.cb};
+            extern:    box.extern + "basefreq"
+        }
+        Knob {
+            type:      :float
+            whenValue: lambda { box.cb};
+            extern:    box.extern + "baseq"
+        }
+
+        NumEntry {
+            whenValue: lambda { box.cb}
+            extern: box.extern + "Pstages"
+            offset: 1
+            minimum: 1
+            maximum: 5
+        }
+        Selector {
+            id: cat
+            //whenValue: lambda { box.change_cat};
+            extern: box.extern + "Pcategory"
+        }
+        Selector {
+            id: typ
+            whenValue: lambda { box.cb};
+            extern: box.extern + "Ptype"
+        }
+        Knob {
+            type:      :float
+            whenValue: lambda { box.cb};
+            extern: box.extern + "gain"
+        }
+    }
+}

--- a/src/mruby-zest/example/ZynDynFilter.qml
+++ b/src/mruby-zest/example/ZynDynFilter.qml
@@ -1,0 +1,59 @@
+Widget {
+    id: dyn
+
+    property Object valueRef: nil
+    property Symbol filtertype: nil
+    
+    onExtern: {
+        dyn.add_cat()
+    }
+
+    function add_cat()
+    {
+        return if self.valueRef
+        if(self.valueRef.nil?)
+            path = self.extern + "filterpars/Pcategory"
+            self.valueRef = OSC::RemoteParam.new($remote, path)
+            self.valueRef.mode = :full
+            self.valueRef.callback = lambda {|x|
+                dyn.filtertype = [:analog, :formant, :statevar][x]
+                swapp.content  = Qml::ZynDAFilter if dyn.filtertype != :formant
+                swapp.content  = Qml::ZynDFFilter if dyn.filtertype == :formant
+            }
+        end
+    }
+
+    Swappable {
+        id: swapp
+        extern: dyn.extern
+        content: Qml::ZynDAFilter
+    }
+    ParModuleRow {
+        Knob { extern: dyn.extern + "Pvolume"}
+        Knob { extern: dyn.extern + "Ppanning"}
+
+        Knob {         extern: dyn.extern + "DynamicFilter/Pfreq" }
+        Knob {         extern: dyn.extern + "DynamicFilter/Pfreqrnd" }
+        Selector {     extern: dyn.extern + "DynamicFilter/PLFOtype" }
+        Knob {         extern: dyn.extern + "DynamicFilter/PStereo" }
+        Knob {         extern: dyn.extern + "DynamicFilter/Pdepth" }
+        Knob {         extern: dyn.extern + "DynamicFilter/Pampsns" }
+        ToggleButton { extern: dyn.extern + "DynamicFilter/Pampsnsinv" }
+        Knob {         extern: dyn.extern + "DynamicFilter/Pampsmooth" }
+        Selector {
+            id: cat
+            //whenValue: lambda { box.change_cat};
+            extern: dyn.extern + "filterpars/Pcategory"
+        }
+    }
+    function draw(vg) {
+        Draw::GradBox(vg, Rect.new(0, 0, w, h))
+    }
+
+    function layout(l, selfBox) {
+        Draw::Layout::vfill(l, selfBox, children, [0.75,0.25])
+    }
+
+    function onSetup(old=nil)
+    {}
+}

--- a/src/mruby-zest/example/ZynEcho.qml
+++ b/src/mruby-zest/example/ZynEcho.qml
@@ -1,0 +1,30 @@
+Group {
+    id: echo
+    label: "echo"
+    topSize: 0.2
+    function refresh() {
+        return if rw.content.nil?
+        return if rw.content.children.length < 4
+        rw.content.children[3..-1].each do |c|
+            c.refresh
+        end
+    }
+
+    ParModuleRow {
+        id: rw
+        layoutOpts: []
+        Selector {
+            layoutOpts: [:long_mode]
+            extern: echo.extern + "Echo/preset"
+            whenValue: lambda { echo.refresh }
+        }
+        Knob { extern: echo.extern + "Pvolume"}
+        Knob { extern: echo.extern + "Ppanning"}
+
+        Knob { extern: echo.extern + "Echo/Pdelay"   }
+        Knob { extern: echo.extern + "Echo/Plrdelay" }
+        Knob { extern: echo.extern + "Echo/Plrcross" }
+        Knob { extern: echo.extern + "Echo/Pfb" }
+        Knob { extern: echo.extern + "Echo/Phidamp" }
+    }
+}

--- a/src/mruby-zest/example/ZynEffectBypass.qml
+++ b/src/mruby-zest/example/ZynEffectBypass.qml
@@ -1,0 +1,10 @@
+Widget {
+    Selector {
+        layoutOpts: [:no_constraint]
+        max_text: 5
+    }
+    ToggleButton {label: "b"; layoutOpts: [:no_constraint]}
+    function layout(l, selfBox) {
+        Draw::Layout::hfill(l, selfBox, children, [0.7, 0.3], 0, 2)
+    }
+}

--- a/src/mruby-zest/example/ZynEffectGroup.qml
+++ b/src/mruby-zest/example/ZynEffectGroup.qml
@@ -1,0 +1,277 @@
+//Scrollable container for Zyn effects
+
+//Vertically packs effects according to type
+//each type is either 1U, 2U, 3U, or 4U and gets space accordingly
+//either a whole effect can fit on the screen or a series of 1U
+//placeholders are put in its place
+
+Widget {
+    id: egrp
+    property Int   nunits: 6
+    property Int   offset: 0
+    property Hash  effects: Hash.new
+    property Int   maxeffects: 8
+    property Int   shownWeights: []
+    property Array valueRef: nil
+    property Bool  needsRegen: false
+
+    function onSetup(old=nil)
+    {
+        v = []
+        (0...maxeffects).each do |i|
+            rf = extern + i.to_s + "/efftype"
+            r  = OSC::RemoteParam.new($remote, rf)
+            r.mode = :options
+            r.callback = lambda {|x|
+                lu = egrp.lookup(x)
+                if(egrp.effects[i] != lu)
+                    egrp.effects[i] = lu
+                    egrp.needsRegen = true
+                end
+            }
+            v << r
+        end
+        self.valueRef = v
+        generate_children #if(egrp.effects.length != 0)
+    }
+
+    function total_len()
+    {
+        total = 0
+        (0...maxeffects).each do |r|
+            if(effects.include?(r) && effects[r] != :none)
+                lu = get_units(effects[r])
+                total += lu
+            else
+                total += 1
+            end
+        end
+        total
+    }
+
+    function max(a,b)
+    {
+        if(a>b)
+            a
+        else
+            b
+        end
+    }
+
+    //Watch the scroll bar and when it changes see if the different
+    //position places the group at a different unit-boundary.
+    //
+    //The for a 5U group with 10U of contents it maps to offsets
+    //0U, 1U, 2U, 3U, 4U, 5U
+    function animate()
+    {
+        v = 1.0-children[0].value
+        range = max(0, total_len-self.nunits)
+        noff = (v*range).to_i
+        if(noff != self.offset)
+            self.offset = noff
+            self.needsRegen = true
+        end
+
+        regen_children if self.needsRegen
+    }
+
+    function rec_del_props(widget, plist=[])
+    {
+        return plist if widget.nil?
+        #Add all properties to the delete list
+        widget.properties.each do |k,v|
+            plist << v
+        end
+        #Add all children properties to the list
+        widget.children.each do |ch|
+            rec_del_props(ch, plist)
+        end
+        plist
+    }
+
+    function rec_clean_cbs(widget)
+    {
+        if(widget.respond_to? :valueRef)
+            v = widget.valueRef
+            if(v.class == Array)
+                v.each do |vv|
+                    vv.clean
+                end
+            else
+                v.clean if v.respond_to? :clean
+            end
+        end
+        widget.children.each do |ch|
+            rec_clean_cbs(ch)
+        end
+    }
+
+    function regen_children()
+    {
+        self.needsRegen = false
+
+        #//Clear children
+        children[1..-1].each do |ch|
+            rec_clean_cbs(ch)
+            del_list = rec_del_props(ch)
+            @db.remove_properties del_list
+        end
+        self.children = [self.children[0]]
+
+        #//Create new children
+        generate_children()
+
+        #//Force layout update
+        if(root)
+            root.smash_layout
+            damage_self :all
+        end
+    }
+
+    function setup_widget(w)
+    {
+        w.onSetup if w.respond_to?(:onSetup)
+        w.children.each do |c|
+            setup_widget c
+        end
+    }
+
+    function find(arr, elm)
+    {
+        return if arr.nil?
+        arr.each_with_index do |x, ind|
+            if(elm == x)
+                return ind
+            end
+        end
+        nil
+    }
+
+    function generate_children()
+    {
+        return if children.length > 1
+
+        #//Calculate offsets that every field exists at
+        @children_locs = []
+
+        begin
+            total = 0
+            (0...maxeffects).each do |r|
+                @children_locs[r] = total
+                if(effects.include?(r) && effects[r] != :none)
+                    lu = get_units(effects[r])
+                    total += lu
+                else
+                    total += 1
+                end
+            end
+            total
+        end
+
+
+        #Box Weight array
+        w = []
+
+
+        running = 0
+        excl    = 0
+
+        (0...self.nunits).each do |r|
+            place = r + self.offset
+            elm = find(@children_locs, place)
+            if(elm && effects[elm] && effects[elm] != :none)
+                uheight = get_units(effects[elm])
+                if(r + uheight <= nunits)
+                    col = make_child(effects[elm])
+                    col.extern = extern + elm.to_s + "/"
+                    Qml::add_child(self, col)
+                    db.update_values
+                    setup_widget(col)
+                    w << uheight
+                    running += uheight
+                    excl     = uheight - 1
+                    next
+                end
+            end
+            if(running < nunits && excl < 1)
+                col = Qml::DummyBox.new(db)
+                Qml::add_child(self, col)
+                w << 1
+                running += 1
+            end
+            excl -= 1
+        end
+        self.shownWeights = w
+    }
+
+    function make_child(type)
+    {
+        if(type == :reverb)
+            return Qml::ZynReverb.new(db)
+        elsif(type == :echo)
+            return Qml::ZynEcho.new(db)
+        elsif(type == :chorus)
+            return Qml::ZynChorus.new(db)
+        elsif(type == :distortion)
+            return Qml::ZynDistortion.new(db)
+        elsif(type == :alienwah)
+            return Qml::ZynAlienwah.new(db)
+        elsif(type == :phaser)
+            return Qml::ZynPhaser.new(db)
+        elsif(type == :eq)
+            return Qml::ZynEqualizer.new(db)
+        elsif(type == :dynamicfilter)
+            return Qml::ZynDynFilter.new(db)
+        else
+            col = Qml::ColorBox.new(db)
+            col.bg = color(:red)
+            return col
+        end
+    }
+
+    function lookup(type) {
+        type = type.to_i
+        mapper = {0=>:none,
+                  1=>:reverb,
+                  2=>:echo,
+                  3=>:chorus,
+                  4=>:phaser,
+                  5=>:alienwah,
+                  6=>:distortion,
+                  7=>:eq,
+                  8=>:dynamicfilter}
+        mapper[type]
+    }
+
+    function get_units(type)
+    {
+        mapper = {:alienwah => 1,
+                  :chorus => 1,
+                  :distortion => 2,
+                  :dynamicfilter => 4,
+                  :eq => 2,
+                  :echo => 1,
+                  :phaser => 2,
+                  :reverb => 1}
+        mapper[type]
+    }
+
+    function layout(l, selfBox)
+    {
+        children[0].fixed(l, selfBox, 0.98, 0, 0.02, 1)
+        padw = 5
+        padh = 3
+        if(children.length > 1 && self.shownWeights.length > 0)
+            off = 0.0
+            children[1..-1].each_with_index do |ch, i|
+                lh = shownWeights[i]
+                ch.fixed_long(l, selfBox, 0, off*1.0/nunits, 0.98,
+                  lh*1.0/nunits, padw, padh, -2*padw, -2*padh)
+                off += lh
+            end
+        end
+        selfBox
+    }
+    ScrollBar {}
+}

--- a/src/mruby-zest/example/ZynEffects.qml
+++ b/src/mruby-zest/example/ZynEffects.qml
@@ -1,0 +1,47 @@
+Widget {
+    TabGroup {
+        TabButton {value: true; label: "system" }
+        TabButton {label: "insertion" }
+        TabButton {label: "part insertion" }
+        
+        function set_tab(wid)
+        {
+            selected = get_tab wid
+            if(selected == 0)
+                root.set_view_pos(:subview, :sysefx)
+            elsif(selected == 1)
+                root.set_view_pos(:subview, :insefx)
+            elsif(selected == 2)
+                root.set_view_pos(:subview, :prtefx)
+            end
+            root.change_view
+        }
+    }
+    Swappable {
+        id: swap
+        content: Qml::ZynEffectsSystem
+    }
+
+    function layout(l, selfBox) {
+        Draw::Layout::vfill(l, selfBox, children, [0.05, 0.95])
+    }
+
+    function set_view()
+    {
+        sub = root.get_view_pos(:subview)
+        if(![:sysefx, :insefx, :prtefx].include?(sub))
+            sub = :sysefx
+            root.set_view_pos(:subview, sub)
+        end
+
+        if(sub == :sysefx)
+            swap.content = Qml::ZynEffectsSystem
+        elsif(sub == :insefx)
+            swap.content = Qml::ZynEffectsInsert
+        elsif(sub == :prtefx)
+            prt = root.get_view_pos(:part)
+            swap.extern = "/part#{prt}/"
+            swap.content = Qml::ZynEffectsPart
+        end
+    }
+}

--- a/src/mruby-zest/example/ZynEffectsInsert.qml
+++ b/src/mruby-zest/example/ZynEffectsInsert.qml
@@ -1,0 +1,35 @@
+Widget {
+    ColorBox {
+        bg: Theme::GeneralBackground
+
+        function onSetup()
+        {
+            num_eff = 8
+            (0...num_eff).each do |i|
+                but = Qml::Selector.new(db)
+                but.extern = "/insefx#{i}/efftype"
+                but.active = false
+                sel = Qml::Selector.new(db)
+                sel.whenValue = lambda { but.active = sel.selected != 1; but.damage_self }
+                sel.extern = "/Pinsparts#{i}"
+                Qml::add_child(self, but)
+                Qml::add_child(self, sel)
+            end
+        }
+
+        function layout(l, selfBox) {
+            Draw::Layout::vstack(l, selfBox, children, 5)
+        }
+        function draw(vg) {
+            Draw::GradBox(vg, Rect.new(0,0,w,h))
+        }
+    }
+    ZynEffectGroup {
+        maxeffects: 8
+        extern: "/insefx"
+    }
+    function layout(l, selfBox)
+    {
+        Draw::Layout::hfill(l, selfBox, children, [0.1, 0.9], 0, 3)
+    }
+}

--- a/src/mruby-zest/example/ZynEffectsPart.qml
+++ b/src/mruby-zest/example/ZynEffectsPart.qml
@@ -1,0 +1,35 @@
+Widget {
+    id: base
+    Widget {
+        function onSetup()
+        {
+            num_eff = 3
+            (0...num_eff).each do |i|
+                #TODO part id
+                sel = Qml::Selector.new(db)
+                sel.extern = base.extern+"partefx#{i}/efftype"
+                but = Qml::ZynEffectBypass.new(db)
+                but.children[1].extern = base.extern+"Pefxbypass#{i}"
+                but.children[0].extern = base.extern+"Pefxroute#{i}"
+                Qml::add_child(self, sel)
+                Qml::add_child(self, but)
+            end
+        }
+
+        function layout(l, selfBox) {
+            Draw::Layout::vstack(l, selfBox, children)
+        }
+
+        function draw(vg) {
+            Draw::GradBox(vg, Rect.new(0,0,w,h))
+        }
+    }
+    ZynEffectGroup {
+        maxeffects: 3
+        extern: base.extern + "partefx"
+    }
+
+    function layout(l, selfBox) {
+        Draw::Layout::hfill(l, selfBox, children, [0.1, 0.9], 0, 3)
+    }
+}

--- a/src/mruby-zest/example/ZynEffectsSystem.qml
+++ b/src/mruby-zest/example/ZynEffectsSystem.qml
@@ -1,0 +1,53 @@
+Widget {
+    ColorBox {
+        bg: Theme::GeneralBackground
+
+        function onSetup(old=nil)
+        {
+            return if children.length > 1
+            num_eff = 4
+            prt = root.get_view_pos(:part)
+            (0...num_eff).each do |i|
+                but = Qml::Selector.new(db)
+                but.extern = "/sysefx#{i}/efftype"
+                sld = Qml::HSlider.new(db)
+                sld.extern = "/Psysefxvol#{i}/part#{prt}"
+                Qml::add_child(self, but)
+                Qml::add_child(self, sld)
+            end
+        }
+
+        function layout(l, selfBox) {
+            Draw::Layout::vstack(l, selfBox, self.children)#, 0.05, 0.9, 20)
+        }
+        function draw(vg) {
+            Draw::GradBox(vg, Rect.new(0,0,w,h))
+        }
+    }
+    Widget {
+        ZynEffectGroup {
+            maxeffects: 4
+            nunits:     4
+            extern: "/sysefx"
+        }
+        ZynSendToGrid {}
+        function class_name() { "effvert" }
+        function layout(l, selfBox) {
+            Draw::Layout::vfill(l, selfBox, children, [0.666, 0.333])
+        }
+    }
+    function class_name() { "eff" }
+    function layout(l, selfBox) {
+        Draw::Layout::hfill(l, selfBox, children, [0.1, 0.9], 0, 3)
+    }
+
+    function set_view()
+    {
+        prt = root.get_view_pos(:part)
+        ch = children[0].children
+        n  = ch.length/2
+        (0...n).each do |i|
+            ch[2*i+1].extern = "/Psysefxvol#{i}/part#{prt}"
+        end
+    }
+}

--- a/src/mruby-zest/example/ZynEnvEdit.qml
+++ b/src/mruby-zest/example/ZynEnvEdit.qml
@@ -1,0 +1,106 @@
+Widget {
+    id: enveditor
+
+    function add_point()
+    {
+        return if self.extern.empty?
+        return if env.selected == nil
+        return if !free.value
+        path = self.extern + "addPoint"
+        $remote.action(path, env.selected)
+        env.refresh
+    }
+    function del_point()
+    {
+        return if self.extern.empty?
+        return if env.selected == nil
+        return if !free.value
+        path = self.extern + "delPoint"
+        $remote.action(path, env.selected)
+        env.refresh
+    }
+
+    //proxy method
+    function refresh()
+    {
+        env.refresh()
+    }
+
+    function update_time()
+    {
+        t = 0.0;
+        env.xpoints.each_with_index do |pt, idx|
+            next if idx > env.points
+            t += pt
+        end
+
+        ll = (t/1000).to_s[0..4] + "  sec" if(t > 1000)
+        ll = (t).to_s[0..4]      + " msec" if(t < 1000)
+        total_len.label = ll
+        total_len.damage_self
+    }
+
+    function set_free()
+    {
+        add.active = free.value
+        del.active = free.value
+        sus.active = free.value
+        add.damage_self
+        del.damage_self
+        sus.damage_self
+        refresh
+    }
+
+    Envelope {
+        id: env
+        extern: enveditor.extern
+        whenTime: lambda { enveditor.update_time }
+    }
+    Col {
+        spacer: 8
+        ConfirmButton   {
+            id: free;
+            whenValue: lambda {enveditor.set_free()}
+            extern: enveditor.extern + "Pfreemode";
+            label: "free"
+        }
+        TriggerButton  {
+            id: add
+            active: false
+            whenValue: lambda {enveditor.add_point()};
+            label: "add"
+        }
+        TriggerButton  {
+            id: del
+            active: false
+            whenValue: lambda {enveditor.del_point()};
+            label: "delete"
+        }
+        Text {
+            height: 0.9; label: "sustain pt"
+        }
+        NumEntry {
+            id: sus
+            active: false
+            extern: enveditor.extern + "Penvsustain";
+        }
+        Text {
+            id: total_len;
+            height: 0.9;
+            label: "1.47 sec"
+        }
+    }
+
+    function layout(l, selfBox) {
+        main_width = 0.9
+        main_width = layoutOpts[:main_width] if layoutOpts.include?(:main_width)
+        Draw::Layout::hfill(l, selfBox, children,
+        [main_width, 1-main_width], 0, 3)
+    }
+
+    //Activate Envelope
+    function onSetup(old=nil)
+    {
+        env.extern()
+    }
+}

--- a/src/mruby-zest/example/ZynEqFilter.qml
+++ b/src/mruby-zest/example/ZynEqFilter.qml
@@ -1,0 +1,41 @@
+Widget {
+    id: fil
+    property Function whenValue: nil
+    ParModuleRow {
+        Selector {
+            id: selector
+            extern: fil.extern + "Ptype"
+            whenValue: lambda() {
+                fil.gain.active = (selector.selected >= 7)
+                fil.gain.damage_self
+                fil.gain.refresh()
+                fil.cb # parent callback
+            }
+        }
+        Knob {
+            extern: fil.extern + "Pfreq"
+            whenValue: lambda { fil.cb }
+        }
+        Knob     {
+            id: gain
+            extern: fil.extern + "Pgain"
+            whenValue: lambda { fil.cb }
+        }
+        Knob     {
+            extern: fil.extern + "Pq"
+            whenValue: lambda { fil.cb }
+        }
+        NumEntry {
+            extern: fil.extern + "Pstages"
+            whenValue: lambda { fil.cb }
+        }
+    }
+    function cb() {
+        whenValue.call if whenValue
+    }
+    function onSetup(old=nil) {
+        children[0].children.each do |ch|
+            ch.whenValue = lambda {fil.cb} if(ch.respond_to?(:whenValue) && ch.whenValue.nil?)
+        end
+    }
+}

--- a/src/mruby-zest/example/ZynEqualizer.qml
+++ b/src/mruby-zest/example/ZynEqualizer.qml
@@ -1,0 +1,62 @@
+Widget {
+    id: eq
+    GroupHeader {
+        label: "Equalizer"
+        extern: eq.extern
+        copyable: true
+    }
+    Widget {
+        VisEq {
+            id: vis
+            extern: eq.extern + "EQ/coeff"
+        }
+        Widget {
+            ParModuleRow {
+                Knob {
+                    extern: eq.extern + "Pvolume"
+                    label: "vol"
+                }
+                NumEntry {
+                    id: fil_sel
+                    whenValue: lambda {eq.change_filter}
+                    label: "filter id"
+                    minimum: 1
+                    maximum: 8
+                    offset:  1
+                    value:   1
+                }
+            }
+            Swappable {
+                id: filter
+            }
+            function layout(l, selfBox) {
+                Draw::Layout::vpack(l, selfBox, children)
+            }
+
+        }
+        function draw(vg) {
+            Draw::GradBox(vg, Rect.new(0, 0, w, h))
+        }
+
+        function layout(l, selfBox) {
+            Draw::Layout::hpack(l, selfBox, children)
+        }
+    }
+
+    function layout(l, selfBox) {
+        Draw::Layout::vfill(l, selfBox, children, [0.15, 0.85])
+    }
+
+    function change_filter()
+    {
+        filter.extern  = eq.extern + "EQ/filter#{fil_sel.value-1}/"
+        filter.content = Qml::ZynEqFilter
+        filter.children[0].whenValue = lambda { vis.refresh }
+    }
+
+    function onSetup(old=nil)
+    {
+        change_filter
+    }
+
+}

--- a/src/mruby-zest/example/ZynFilterEnv.qml
+++ b/src/mruby-zest/example/ZynFilterEnv.qml
@@ -1,0 +1,41 @@
+Group {
+    id: box
+    label: "Envelope"
+    property Function whenModified: nil
+    extern: ""
+
+    function cb()
+    {
+        whenModified.call if whenModified
+    }
+
+    ParModuleRow {
+        id: top
+        Knob { 
+            whenValue: lambda { box.cb }; 
+            extern: box.extern+"A_dt"
+            type:   :float
+        }
+        Knob { 
+            whenValue: lambda { box.cb }; 
+            extern: box.extern+"D_dt"
+            type:   :float
+        }
+        Knob { 
+            whenValue: lambda { box.cb }; 
+            extern: box.extern+"R_dt"
+            type:   :float
+        }
+        Col {
+            ToggleButton { label: "FRCR"; whenValue: lambda { box.cb }; extern: box.extern+"Pforcedrelease"}
+            ToggleButton   { label: "repeat"; whenValue: lambda { box.cb }; extern: box.extern+"Prepeating"}
+        }
+    }
+    ParModuleRow {
+        id: bot
+        Knob { whenValue: lambda { box.cb }; extern: box.extern+"PA_val"}
+        Knob { whenValue: lambda { box.cb }; extern: box.extern+"PD_val"}
+        Knob { whenValue: lambda { box.cb }; extern: box.extern+"PR_val"}
+        Knob { whenValue: lambda { box.cb }; extern: box.extern+"Penvstretch"}
+    }
+}

--- a/src/mruby-zest/example/ZynFooter.qml
+++ b/src/mruby-zest/example/ZynFooter.qml
@@ -1,0 +1,91 @@
+Widget {
+    id: foot
+    function class_name() {"ZynFooter"}
+    Indent {
+        id: wheelwell
+        ModWheel {
+            id: wheel
+            value: 0
+            label: "wheel"
+            tooltip: "modulation wheel"
+            whenValue: lambda {
+                $remote.action("/setController", 0, 1, (wheelwell.children[0].value*127).to_i)
+            }
+
+        }
+
+        function layout(l, selfBox) {
+            wheel.fixed(l, selfBox, 0.1, 0.1, 0.8, 0.8)
+            selfBox
+        }
+    }
+
+    Keyboard {
+        id: key
+        velocity: 0.7*127
+        velrnd:   0.2*127
+    }
+
+    ParModuleRow {
+        id: ctrl
+        layoutOpts: []
+        Knob {
+            id: vel
+            whenValue: lambda { key.velocity = vel.value*127 }
+            value: 0.7;
+            label: "velocity"
+            tooltip: "velocity of virtual keyboard notes"
+        }
+        Knob {
+            id: rnd
+            whenValue: lambda { key.velrnd = rnd.value*127 }
+            value: 0.2;
+            label: "vrnd"
+            tooltip: "velocity randomness of virtual keyboard notes"
+        }
+        Knob {
+            id: oct
+            value: 0.5; label: "octave"
+            tooltip: "by-octave keyboard key shift"
+            whenValue: lambda { key.octave = (4*(oct.value-0.5)).to_i }
+        }
+        Knob     {
+            id: cc
+            label: "c.val"
+            whenValue: lambda { foot.set_cc((cc.value*127).to_i) }
+            tooltip: "midi CC control"
+        }
+        Selector {
+            id: cctype
+            label: "MIDI CC"
+            tooltip: "midi CC selector"
+            layoutOpts: {:weight=>2.0, :long_mode=>true}
+            options: [ "01: Mod.Wheel",
+                       "07: Volume",
+                       "10: Panning",
+                       "11: Expression",
+                       "64: Sustain",
+                       "65: Portamento",
+                       "71: Filter Q",
+                       "74: Filter Freq.",
+                       "75: Bandwidth",
+                       "76: FM Gain",
+                       "77: Res. c. freq",
+                       "78: Res. bw."]
+        }
+    }
+
+    function set_cc(x)
+    {
+        cc_num =  cctype.options[cctype.selected].to_i
+        $remote.action("/setController", 0, cc_num, x)
+
+    }
+
+    function layout(l, selfBox) {
+        wheelwell.fixed(l,  selfBox, 0.010, 0.15, 0.017, (1-2*0.15))
+        key.fixed(l,        selfBox, 0.032, 0.10, 0.536, 0.8)
+        ctrl.fixed(l,       selfBox, 0.600, 0.05, 0.400, 0.9)
+        selfBox
+    }
+}

--- a/src/mruby-zest/example/ZynFormant.qml
+++ b/src/mruby-zest/example/ZynFormant.qml
@@ -1,0 +1,159 @@
+Widget {
+    id: fbase
+    VisFormant {
+        id: vis
+        extern: fbase.extern
+    }
+    Widget {
+        Widget {
+            id: total
+            Text    { label:  "formants" }
+            NumEntry {
+                format: "PKs "
+                extern: fbase.extern + "Pnumformants";
+            }
+            HSlider { extern: fbase.extern + "Pformantslowness"; }
+            HSlider { extern: fbase.extern + "Pvowelclearness"; }
+            //space
+            HSlider { extern: fbase.extern + "Pcenterfreq" }
+            HSlider { extern: fbase.extern + "Poctavesfreq" }
+            function layout(l, selfBox) {
+                Draw::Layout::vpack(l, selfBox, children, 0.1, 0.8, 12)
+            }
+            function onSetup(old=nil) {
+                lm = lambda { vis.refresh() }
+                children.each do |ch|
+                    ch.whenValue = lm if ch.respond_to? :whenValue
+                end
+            }
+            function draw(vg) {
+                Draw::GradBox(vg, Rect.new(0,0,w,h))
+            }
+        }
+        Widget {
+            Group {
+                id:    vgrp
+                label: "vowel"
+                topSize: 0.2
+                extern: fbase.extern + "Pvowels0/Pformants0/"
+                function update_pos()
+                {
+                    vis.vowel_num = vow_num.value-1
+                    vis.change()
+                    rt = fbase.extern + "Pvowels#{vow_num.value-1}/Pformants#{for_num.value-1}/"
+                    slide_freq.extern = rt + "freq"
+                    slide_q.extern    = rt + "q"
+                    slide_amp.extern  = rt + "amp"
+                    db.update_values
+                }
+                Widget {
+                    NumEntry {
+                        id: vow_num
+                        label: "v. num"
+                        format: "VW "
+                        tooltip: "vowel number - each formant filter is composed of one or more vowels"
+                        minimum: 1
+                        maximum: 6
+                        value: 1
+                        whenValue: lambda {vgrp.update_pos}
+                    }
+                    HSlider {
+                        id: slide_freq
+                        extern: vgrp.extern + "freq";
+                        label: "freq"
+                        whenValue: lambda { vis.refresh() }
+                    }
+                    NumEntry {
+                        id: for_num;
+                        label: "formant"
+                        format: "PK "
+                        tooltip: "formant peak - each formant vowel is composed of one or more peaks"
+                        minimum: 1
+                        maximum: 12
+                        value: 1
+                        whenValue: lambda {vgrp.update_pos}
+                    }
+                    HSlider {
+                        id: slide_q
+                        extern: vgrp.extern + "q";
+                        label: "q"
+                        whenValue: lambda { vis.refresh() }
+                    }
+                    Widget {}
+                    Widget {}
+                    Widget {}
+                    HSlider {
+                        id: slide_amp
+                        extern: vgrp.extern + "amp";
+                        label: "amp"
+                        whenValue: lambda { vis.refresh() }
+                    }
+                    function layout(l, selfBox) {
+                        Draw::Layout::grid(l, selfBox, children, 4, 2, 2, 2)
+                    }
+                    //grid(l, selfBox, children, rows, cols, padw=0, padh=0)
+                }
+            }
+            Group {
+                label: "sequence"
+                topSize: 0.2
+                copyable: false
+                Widget {
+                    NumEntry {
+                        extern: fbase.extern + "Psequencesize";
+                        format: "LEN "
+                        label: "seqsize"
+                        whenValue: lambda { vis.refresh() }
+                    }
+                    NumEntry {
+                        id: pos_id
+                        format: "POS "
+                        value:  1
+                        minimum: 1
+                        maximum: 8
+                        label: "s.pos"
+                        whenValue: lambda {
+                            pos_vowel.extern = 
+                            fbase.extern + "vowel_seq#{pos_id.value-1}"
+                        }
+                    }
+                    HSlider {
+                        extern: fbase.extern + "Psequencestretch";
+                        label: "strch"
+                        whenValue: lambda { vis.refresh() }
+                    }
+                    Widget {}
+                    NumEntry {
+                        id: pos_vowel
+                        format: "VW "
+                        label: "vowel"
+                        offset: 1
+                        minimum: 1
+                        maximum: 8
+                        extern: fbase.extern + "vowel_seq0"
+                    }
+                    Button {
+                        extern: fbase.extern + "Psequencereversed";
+                        label: "neg. input";
+                        layoutOpts: [:no_constraint]
+                    }
+
+                    function layout(l, selfBox) {
+                        Draw::Layout::grid(l, selfBox, children, 3, 2, 2, 4)
+                    }
+                }
+            }
+            function layout(l, selfBox) {
+                Draw::Layout::vpack(l, selfBox, children)
+            }
+        }
+        function layout(l, selfBox) {
+            Draw::Layout::hfill(l, selfBox, children, [0.3, 0.7], 0, 2)
+        }
+    }
+    function layout(l, selfBox) {
+        Draw::Layout::hfill(l, selfBox, children, [0.7, 0.3], 0, 2)
+    }
+
+
+}

--- a/src/mruby-zest/example/ZynFreqEnv.qml
+++ b/src/mruby-zest/example/ZynFreqEnv.qml
@@ -1,0 +1,32 @@
+Group {
+    id: box
+    label: "Envelope"
+    property Function whenModified: nil
+    extern: ""
+
+    function cb()
+    {
+        whenModified.call if whenModified
+    }
+
+    ParModuleRow {
+        id: top
+        Knob { 
+            whenValue: lambda { box.cb }; 
+            extern: box.extern+"A_dt"
+            type:   :float
+        }
+        Knob     { 
+            whenValue: lambda { box.cb }; 
+            extern: box.extern+"R_dt"
+            type:   :float
+        }
+        ToggleButton { label: "FRCR"; whenValue: lambda { box.cb }; extern: box.extern+"Pforcedrelease"}
+    }
+    ParModuleRow {
+        id: bot
+        Knob { whenValue: lambda { box.cb }; extern: box.extern+"PA_val"}
+        Knob { whenValue: lambda { box.cb }; extern: box.extern+"PR_val"}
+        Knob { whenValue: lambda { box.cb }; extern: box.extern+"Penvstretch" }
+    }
+}

--- a/src/mruby-zest/example/ZynFreqGeneral.qml
+++ b/src/mruby-zest/example/ZynFreqGeneral.qml
@@ -1,0 +1,15 @@
+Group {
+    id: box
+    label: "General"
+    property Function whenModified: nil
+    ParModuleRow {
+        Knob { extern: box.extern + "PDetune" }
+        NumEntry { extern: box.extern + "octave" }
+        Knob { extern: box.extern + "PBandwidth" }
+    }
+
+    ParModuleRow {
+        Selector { extern: box.extern + "PDetuneType" }
+        Knob { extern: box.extern + "PCoarseDetune" }
+    }
+}

--- a/src/mruby-zest/example/ZynFreqGeneralVoice.qml
+++ b/src/mruby-zest/example/ZynFreqGeneralVoice.qml
@@ -1,0 +1,16 @@
+Group {
+    id: box
+    label: "General"
+    property Function whenModified: nil
+    ParModuleRow {
+        Knob { extern: box.extern + "PDetune" }
+        NumEntry { extern: box.extern + "octave" }
+        Knob { extern: box.extern + "PfixedfreqET" }
+    }
+
+    ParModuleRow {
+        Selector { extern: box.extern + "PDetuneType" }
+        Knob { extern: box.extern + "coarsedetune" }
+        ToggleButton { extern: box.extern + "Pfixedfreq" }
+    }
+}

--- a/src/mruby-zest/example/ZynFreqMod.qml
+++ b/src/mruby-zest/example/ZynFreqMod.qml
@@ -1,0 +1,14 @@
+Group {
+    id: box
+    label: "General"
+    ParModuleRow {
+        Knob { extern: box.extern + "PFMDetune" }
+        NumEntry { extern: box.extern + "FMoctave" }
+        ToggleButton { extern: box.extern + "PFMFixedFreq" }
+    }
+
+    ParModuleRow {
+        Selector { extern: box.extern + "PFMDetuneType" }
+        Knob { extern: box.extern + "PFMCoarseDetune" }
+    }
+}

--- a/src/mruby-zest/example/ZynHeader.qml
+++ b/src/mruby-zest/example/ZynHeader.qml
@@ -1,0 +1,59 @@
+Widget {
+    id: head
+    function class_name() {"ZynHeader"}
+    ZynLogo {id: logo}
+    MainMenu {
+        id: menuIndent
+    }
+
+    Indent {
+        pad: 0.01
+        id: status
+
+        LogWidget {
+            label: "console log"
+        }
+    }
+
+    ZynHeaderParams {
+        id: shortcuts
+    }
+
+    VuMeter {
+        id: vumeter
+    }
+
+    PanicButton {
+        id: panic
+        layoutOpts: [:no_constraint]
+    }
+
+    Widget { id: close }
+    Widget { id: minimize }
+
+    //Button {
+    //    id: close
+    //    label: "x"
+    //    layoutOpts: [:no_constraint]
+    //}
+
+    //Button {
+    //    id: minimize
+    //    label: "-"
+    //    layoutOpts: [:no_constraint]
+    //    textScale: 1.2
+    //}
+
+    function layout(l, selfBox) {
+        logo.fixed(l,       selfBox, 0.016, 0.22,  0.070, 0.56)
+        menuIndent.fixed(l, selfBox, 0.100, 0.15, 0.112, 0.7)
+        status.fixed(l,     selfBox, 0.220, 0.15, 0.520, 0.7)
+        shortcuts.fixed(l,  selfBox, 0.745, 0.15, 0.160, 0.7)
+        vumeter.fixed(l,    selfBox, 0.910, 0.15, 0.015, 0.7)
+        panic.fixed(l,      selfBox, 0.930, 0.15, 0.040, 0.7)
+        close.fixed(l,      selfBox, 0.975, 0.15, 0.015, 0.3)
+        minimize.fixed(l,   selfBox, 0.975, 0.54, 0.015, 0.3)
+
+        selfBox
+    }
+}

--- a/src/mruby-zest/example/ZynHeaderParams.qml
+++ b/src/mruby-zest/example/ZynHeaderParams.qml
@@ -1,0 +1,31 @@
+Widget {
+    ToggleButton {
+        id: fn
+        label: "fine"
+        layoutOpts: [:no_constraint];
+
+        function animate()
+        {
+            if(fn.value != root.fine_mode)
+                fn.value = root.fine_mode
+                fn.damage_self
+            end
+        }
+    }
+    HSlider {type: :float; extern: "/Volume"; height: 0.8; label: "volume"; }
+    Button  {layoutOpts: [:no_constraint]; label: "nrpn" }
+    HSlider {extern: "/Pkeyshift"; height: 0.8; label: "key shift" }
+
+    function layout(l, selfBox) {
+        padw  = 1.0/256
+        padw2 = 0.5-2*padw
+        padh = 1.0/32
+        padh2 = 0.5-2*padh
+        children[0].fixed(l, selfBox, 0.0+padw, 0.0+padh, padw2, padh2)
+        children[1].fixed(l, selfBox, 0.5+padw, 0.0+padh, padw2, padh2)
+        children[2].fixed(l, selfBox, 0.0+padw, 0.5+padh, padw2, padh2)
+        children[3].fixed(l, selfBox, 0.5+padw, 0.5+padh, padw2, padh2)
+
+        selfBox
+    }
+}

--- a/src/mruby-zest/example/ZynInstrumentSettings.qml
+++ b/src/mruby-zest/example/ZynInstrumentSettings.qml
@@ -1,0 +1,58 @@
+Group {
+    label: "instrument settings"
+    copyable: false
+    id: insset
+    Widget {
+        ParModuleRow {
+            whitespace: 2
+            Knob {
+                type: :float
+                extern: insset.extern + "Volume"
+            }
+            Knob { extern: insset.extern + "Ppanning"}
+            Knob {
+                id: minkey
+                extern: insset.extern + "Pminkey"
+            }
+            Knob {
+                id: maxkey
+                extern: insset.extern + "Pmaxkey"
+            }
+        }
+        ParModuleRow {
+            whitespace: 3
+            outer: :none
+            layoutOpts: []
+            Knob {extern: insset.extern + "Pvelsns"}
+            Knob {extern: insset.extern + "Pveloffs"}
+            Knob {extern: insset.extern + "Pkeyshift"}
+            ZynKitKeyButton {
+                layoutOpts: [:aspect]
+                extern: insset.extern
+                whenValue: lambda {
+                    minkey.refresh
+                    maxkey.refresh
+                }
+            }
+        }
+        ParModuleRow {
+            lsize: 0.0
+            Selector     {
+                extern: insset.extern + "Prcvchn";
+                label: "midi chan"
+            }
+            ToggleButton {
+                extern: insset.extern + "ctl/portamento.portamento";
+                label: "portamento"
+            }
+            Selector {
+                extern: insset.extern + "polyType";
+                label: "mode";
+                layoutOpts: [:no_constraint, :long_mode]
+            }
+        }
+        function layout(l, selfBox) {
+            Draw::Layout::vfill(l, selfBox, children, [0.40, 0.40,0.2],0,2)
+        }
+    }
+}

--- a/src/mruby-zest/example/ZynKit.qml
+++ b/src/mruby-zest/example/ZynKit.qml
@@ -1,0 +1,62 @@
+Widget {
+    id: kit
+    property Object valueRef: nil
+
+    onExtern: {
+        kit.valueRef = OSC::RemoteParam.new($remote, kit.extern + "Pkitmode")
+        kit.valueRef.mode = :options
+        kit.valueRef.callback = lambda {|x| kit.get_mode(x) }
+
+    }
+
+    function get_mode(x)
+    {
+        (0..2).each do |i|
+            children[0].children[i].value = i == x
+            children[0].children[i].damage_self
+        end
+        any_kit = (x != 0)
+        if(any_kit)
+            children[1].set_active_kit()
+        else
+            children[1].set_non_kit()
+        end
+    }
+
+    function set_mode(x)
+    {
+        kit.valueRef.value = x
+        get_mode(x)
+    }
+
+    Widget {
+        Button {
+            label: "No Kits";
+            whenValue: lambda { kit.set_mode(0) }
+        }
+        Button {
+            label: "Multi-Kit";
+            whenValue: lambda { kit.set_mode(1) }
+        }
+        Button {
+            label: "Single-Kit";
+            whenValue: lambda { kit.set_mode(2) }
+        }
+        ToggleButton {
+            id: drum;
+            extern: kit.extern + "Pdrummode"
+            label: "drum mode"
+        }
+        function layout(l, selfBox) {
+            Draw::Layout::tabpack(l, selfBox, self, drum)
+        }
+    }
+
+    ZynKitTable {
+        extern: kit.extern
+    }
+
+    function layout(l, selfBox) {
+        Draw::Layout::vfill(l, selfBox, children, [0.05,0.95], 0, 2)
+    }
+}

--- a/src/mruby-zest/example/ZynKitKeyButton.qml
+++ b/src/mruby-zest/example/ZynKitKeyButton.qml
@@ -1,0 +1,86 @@
+Widget {
+    property Function whenValue: nil
+    function draw(vg)
+    {
+        pad  = 1.0/64
+        pad2 = (1-2*pad)
+        vg.path do |v|
+            v.rect(w*pad, h*pad, w*pad2, h*pad2)
+            paint = v.linear_gradient(0,0,0,h,
+            Theme::ButtonGrad1, Theme::ButtonGrad2)
+            v.fill_paint paint
+            v.fill
+            v.stroke_width 1
+            v.stroke
+        end
+
+        vg.path do |v|
+            v.move_to(w*1.0/3, 0)
+            v.line_to(w*1.0/3, h)
+            v.move_to(w*2/3, 0)
+            v.line_to(w*2/3, h)
+            v.stroke
+        end
+
+        text_color = Theme::TextColor
+        if self.layoutOpts.include? :aspect
+            vg.font_size h*0.5 
+        else
+            vg.font_size h*0.8 
+        end
+        vg.fill_color text_color
+        vg.path do |v|
+            v.text_align NVG::ALIGN_CENTER | NVG::ALIGN_MIDDLE
+            v.text(1.0/6.0*w,h/2,"Mn")
+        end
+        
+        #Pause Icon
+        vg.path do |v|
+            v.text_align NVG::ALIGN_CENTER | NVG::ALIGN_MIDDLE
+            v.text(3/6.0*w,h/2,"R")
+        end
+        
+        #Play Icon
+        vg.path do |v|
+            v.text_align NVG::ALIGN_CENTER | NVG::ALIGN_MIDDLE
+            v.text(5/6.0*w,h/2,"Mx")
+        end
+    }
+
+    function onMouseHover(ev)
+    {
+        rel = (ev.pos.x-global_x)/w
+        if(rel < 1.0/3.0)
+            self.root.log(:tooltip, 
+            "Capture minimum key")
+        elsif(rel < 2/3.0)
+            self.root.log(:tooltip, 
+            "Reset key range")
+        else
+            self.root.log(:tooltip, 
+            "Capture maximum key")
+        end
+    }
+
+    function onMousePress(ev)
+    {
+        rel = (ev.pos.x-global_x)/w
+        if(rel < 1.0/3.0)
+            $remote.action(extern + "captureMin")
+        elsif(rel < 2/3.0)
+            $remote.action(extern + "Pminkey", 0)
+            $remote.action(extern + "Pmaxkey", 127)
+        else
+            $remote.action(extern + "captureMax")
+        end
+        whenValue.call if whenValue
+    }
+
+    function layout(l, selfBox)
+    {
+        if(self.layoutOpts.include? :aspect)
+            l.aspect(selfBox, 3.0, 1.0)
+        end
+        selfBox
+    }
+}

--- a/src/mruby-zest/example/ZynKitRow.qml
+++ b/src/mruby-zest/example/ZynKitRow.qml
@@ -1,0 +1,101 @@
+Widget {
+    id: kit_item
+    property Array weights: [0.05, 0.10, 0.10, 0.10, 0.05, 0.10, 0.10, 0.10, 0.30]
+    property Int   kitnum: 0
+
+    function set_active(a)
+    {
+        minkey.active = a
+        maxkey.active = a
+        damage_self
+    }
+
+    ToggleButton {
+        extern: kit_item.extern + "Penabled"
+        label: kit_item.label;
+        layoutOpts: [:no_constraint]
+    }
+    TextLine {
+        extern: kit_item.extern + "Pname"
+        label: "kit name"
+    }
+    HSlider {
+        id: minkey
+        extern: kit_item.extern + "Pminkey"
+        value_label: true
+    }
+    ZynKitKeyButton {
+        extern: kit_item.extern
+        whenValue: lambda {
+            minkey.refresh
+            maxkey.refresh
+        }
+    }
+    HSlider {
+        id: maxkey
+        extern: kit_item.extern + "Pmaxkey"
+        value_label: true
+    }
+    FancyButton {
+        id: add
+        extern: kit_item.extern + "Padenabled"
+        layoutOpts: [:no_constraint];
+        label: "edit"
+        whenClick: lambda {
+            if(!add.children[0].value)
+                $remote.action(add.extern, true)
+            end
+            rt = kit_item.root
+            rt.set_view_pos(:view, :add_synth)
+            rt.set_view_pos(:kit, kit_item.kitnum)
+            rt.change_view
+        }
+    }
+    FancyButton {
+        id: sub
+        extern: kit_item.extern + "Psubenabled"
+        layoutOpts: [:no_constraint];
+        label: "edit"
+        whenClick: lambda {
+            if(!sub.children[0].value)
+                $remote.action(sub.extern, true)
+            end
+            rt = kit_item.root
+            rt.set_view_pos(:view, :sub_synth)
+            rt.set_view_pos(:kit, kit_item.kitnum)
+            rt.change_view
+        }
+    }
+    FancyButton {
+        id: pad_but
+        extern: kit_item.extern + "Ppadenabled"
+        layoutOpts: [:no_constraint];
+        label: "edit"
+        whenClick: lambda {
+            if(!pad_but.children[0].value)
+                $remote.action(pad_but.extern, true)
+            end
+            rt = kit_item.root
+            rt.set_view_pos(:view, :pad_synth)
+            rt.set_view_pos(:kit, kit_item.kitnum)
+            rt.change_view
+        }
+    }
+    Selector {
+        extern: kit_item.extern + "Psendtoparteffect"
+        layoutOpts: [:no_constraint];
+        label: "off"
+    }
+
+    function class_name() { "kitrow" }
+    function layout(l, selfBox) {
+        Draw::Layout::hfill(l, selfBox, children, kit_item.weights, 0, 3)
+    }
+
+    function onSetup(old=nil)
+    {
+        children.each do |ch|
+            ch.extern()
+        end
+    }
+}

--- a/src/mruby-zest/example/ZynKitTable.qml
+++ b/src/mruby-zest/example/ZynKitTable.qml
@@ -1,0 +1,69 @@
+Widget {
+    id: kittable
+    //0.2
+    //                       0     1     2     3     4     5     6     7     8
+    property Array weights: [0.05, 0.19, 0.15, 0.10, 0.15, 0.07, 0.07, 0.07, 0.15]
+    property Bool  active: true
+
+    function onSetup(old=nil)
+    {
+        return if children.length > 2
+        (0...16).each do |r|
+            row         = Qml::ZynKitRow.new(db)
+            row.label   = (r+1).to_s
+            row.kitnum  = r
+            row.weights = self.weights
+            row.extern  = kittable.extern + "kit#{r}/"
+            row.extern()
+            row.set_active(false) if !self.active && r != 0
+            Qml::add_child(self, row)
+        end
+    }
+
+    Widget {
+        //0 - kit sel button
+        ColorBox {bg: Theme::TitleBar}
+        //1 - text field
+        TextBox  {bg: Theme::TitleBar; label: "kit name"}
+        //2
+        TextBox  {bg: Theme::TitleBar; label: "min. key"}
+        //3
+        TextBox  {bg: Theme::TitleBar; label: "last note"}
+        //4
+        TextBox  {bg: Theme::TitleBar; label: "max. key"}
+        //5
+        TextBox  {bg: Theme::TitleBar; label: "add"}
+        //6
+        TextBox  {bg: Theme::TitleBar; label: "sub"}
+        //7
+        TextBox  {bg: Theme::TitleBar; label: "pad"}
+        //8
+        TextBox  {bg: Theme::TitleBar; label: "effect route"}
+        function layout(l, selfBox) {
+            Draw::Layout::hfill(l, selfBox, children, kittable.weights, 0, 3)
+        }
+    }
+
+    function class_name() { "kittable" }
+    function layout(l, selfBox) {
+        Draw::Layout::vpack(l, selfBox, children, 0, 1, 2)
+    }
+
+    function set_active_kit()
+    {
+        self.active = true
+        return if children.length < 3
+        children[2..-1].each do |c|
+            c.set_active(true)
+        end
+    }
+
+    function set_non_kit()
+    {
+        self.active = false
+        return if children.length < 3
+        children[2..-1].each do |c|
+            c.set_active(false)
+        end
+    }
+}

--- a/src/mruby-zest/example/ZynLFO.qml
+++ b/src/mruby-zest/example/ZynLFO.qml
@@ -1,0 +1,26 @@
+Group {
+    id: box
+    label: "LFO"
+    extern: ""
+    copyable: true
+
+    ParModuleRow {
+        id: top
+        Knob { type: :float; extern: box.extern+"freq" }
+        Knob { extern: box.extern+"Pintensity"}
+        Knob { extern: box.extern+"Pcutoff"}
+        Knob { extern: box.extern+"Pstartphase"}
+        Knob { extern: box.extern+"Pstretch"}
+
+    }
+    ParModuleRow {
+        id: bot
+        Knob     { type: :float; extern: box.extern+"delay"}
+        Knob     {extern: box.extern+"Prandomness"}
+        Knob     {extern: box.extern+"Pfreqrand"}
+        Col {
+            Selector {extern: box.extern+"PLFOtype"}
+            ToggleButton   { label: "sync"; extern: box.extern+"Pcontinous"}
+        }
+    }
+}

--- a/src/mruby-zest/example/ZynLLFO.qml
+++ b/src/mruby-zest/example/ZynLLFO.qml
@@ -1,0 +1,16 @@
+ParModule {
+    w: 500*4
+    h: 300*4
+    extern: "/part0/kit0/adpars/GlobalPar/FreqLfo/"
+    label:  "generic lfo"
+    id:    lfo_mod
+    Knob     {extern: lfo_mod.extern+"Pfreq"}
+    Knob     {extern: lfo_mod.extern+"Pintensity"}
+    Knob     {extern: lfo_mod.extern+"Pcutoff"}
+    Knob     {extern: lfo_mod.extern+"Pstartphase"}
+    Knob     {extern: lfo_mod.extern+"Pstretch"}
+    Knob     {extern: lfo_mod.extern+"Prandomness"}
+    Knob     {extern: lfo_mod.extern+"Pfreqrand"}
+    Selector {extern: lfo_mod.extern+"PLFOtype"}
+    Button   {extern: lfo_mod.extern+"Pcontinous"; label: "C"}
+}

--- a/src/mruby-zest/example/ZynLogo.qml
+++ b/src/mruby-zest/example/ZynLogo.qml
@@ -1,0 +1,113 @@
+Widget {
+    function draw_placeholder(vg)
+    {
+        #background color("123456")
+        #vg.path do |v|
+        #    v.rect(0, 0, w, h)
+        #    v.fill_color(NVG.rgba(0xaa, 0xaa, 0xaa, 255))
+        #    v.fill
+        #end
+        logo_top = color("4DC3C7")
+        logo_bot = color("56C0A5")
+
+        vg.path do |v|
+            l = 0.4*w
+            v.move_to(0,0)
+            v.line_to(l,      0.1*h)
+            v.line_to(l*0.75, 0.6*h)
+            v.close_path
+            v.fill_color logo_top
+            v.fill
+        end
+
+        vg.path do |v|
+            l = 0.4*w
+            v.move_to(l,h)
+            v.line_to(0,      0.9*h)
+            v.line_to(l*0.25, 0.4*h)
+            v.close_path
+            v.fill_color logo_bot
+            v.fill
+        end
+
+        vg.font_face("bold")
+        vg.font_size h*0.8
+        vg.text_align NVG::ALIGN_LEFT | NVG::ALIGN_MIDDLE
+        vg.fill_color logo_top
+        vg.text(w/2,h/2,"ZYN")
+    }
+
+    function draw_path(vg, path, co)
+    {
+        wscale = 80.0
+        hscale = 35.0
+        n = path.length/2
+        xmin = 64
+        ymin = 60
+        vg.path do
+            xx = (w*(path[2*0+0]-xmin)/wscale).round
+            yy = (h*(path[2*0+1]-ymin)/hscale).round
+            vg.move_to(xx, yy)
+            (1...n).each do |i|
+                xx = (w*(path[2*i+0]-xmin)/wscale).round
+                yy = (h*(path[2*i+1]-ymin)/hscale).round
+                vg.line_to(xx,yy)
+            end
+            vg.close_path
+            vg.fill_color co
+            vg.fill
+            #vg.stroke_color color("2E3239")
+            #vg.stroke_width 2.0
+            #vg.stroke
+        end
+    }
+
+    function draw_new(vg)
+    {
+        st0 = color("686868")
+        st1 = color("2E3239")
+        st2 = color("50C3C7")
+        st3 = color("57C1A6")
+
+        st1
+        path_1 = [97,64,64,61,67.3,63.3,64,63,87,79,97,66,95.6,65.9]
+        path_2 = [97,90,74,74,64,87,65.4,87.1,64,89,97,92,93.7,89.7]
+        path_3 = [103,69,103.7,71,103,71,104,74,107.5,74,103,80,103,82.1,103,83,103,85,115,85,115,83,115,81.4,115,80,110.3,80,115,74,115,72,115,71,115,69]
+        path_4 = [129,69,124,69,123,74,122,69,117,69,117.8,71,117,71,121,81,121,83,121,85,125,85,125,83,125,81,129,71,128.2,71]
+        path_5 = [131,69,135,69,138.5,74,138.8,75,139,75,139,69,143,69,143,85,139,85,135.5,80,135.8,79,135,79,135,85,131,85]
+        draw_path(vg, path_1, st1)
+        draw_path(vg, path_2, st1)
+        draw_path(vg, path_3, st1)
+        draw_path(vg, path_4, st1)
+        draw_path(vg, path_5, st1)
+
+        st2 
+        path_6 = [64,62,97,65,87,78]
+        path_7 = [115,84,103,84,103,81,109,73,109,73,104,73,103,70,115,70,115,73,109,81,109,81,115,81,115,84]
+        path_8 = [122,70,123,75,123,75,124,70,129,70,125,80,125,84,121,84,121,80,117,70]
+        path_9 = [131,70,135,70,138.5,75,138.8,76,139,76,139,70,143,70,143,84,139,84,135.5,79,135.8,78,135,78,135,84,131,84]
+        draw_path(vg, path_6, st2)
+        draw_path(vg, path_7, st2)
+        draw_path(vg, path_8, st2)
+        draw_path(vg, path_9, st2)
+
+        st3
+        path_10 = [97,91,64,88,74,75]
+        draw_path(vg, path_10, st3)
+    }
+
+
+    function draw(vg)
+    {
+        #draw_placeholder(vg)
+        draw_new(vg)
+    }
+
+    function onMousePress(m)
+    {
+        view = root.get_view_pos(:view)
+        root.set_view_pos(:view, :about)    if(view != :about)
+        root.set_view_pos(:view, :settings) if(view == :about)
+        root.change_view
+    }
+}

--- a/src/mruby-zest/example/ZynMidiLearn.qml
+++ b/src/mruby-zest/example/ZynMidiLearn.qml
@@ -1,0 +1,93 @@
+Widget {
+    id: vce_list
+    property Array  weights: [0.05, 0.05, 0.05, 0.75, 0.05, 0.05]
+    property Object valueRef: nil
+
+    function draw(vg) {
+        vg.path do |v|
+            v.rect(0,0,w,h)
+            paint = v.linear_gradient(0,0,0,h,
+            Theme::InnerGrad1, Theme::InnerGrad2)
+            v.fill_paint paint
+            v.fill
+            v.stroke_color color(:black)
+            v.stroke_width 1.0
+            v.stroke
+        end
+    }
+
+    function onSetup(old=nil)
+    {
+        return if children.length > 3
+        (0...16).each do |r|
+            row = Qml::ZynMidiLearnRow.new(db)
+            row.label = r.to_s
+            row.weights = self.weights
+            row.whenValue = lambda { vce_list.refresh }
+            Qml::add_child(self, row)
+        end
+
+        self.valueRef = OSC::RemoteParam.new($remote, "/midi-learn-values")
+        self.valueRef.callback = lambda {|x| vce_list.handle(x) }
+        self.valueRef.refresh
+    }
+
+    function handle(x)
+    {
+        n = x.length/4
+        m = children.length-1
+        (0...n).each do |i|
+            row = children[i+1]
+            row.children[1].label = "*"
+            row.children[2].label = x[i*4+0].to_s
+            row.children[3].label = x[i*4+1].to_s
+            row.children[4].label = x[i*4+2].to_s
+            row.children[5].label = x[i*4+3].to_s
+        end
+        (n...m).each do |i|
+            row = children[i+1]
+            row.children[1].label = "X"
+            row.children[2].label = "X"
+            row.children[3].label = ""
+            row.children[4].label = "X"
+            row.children[5].label = "X"
+        end
+        damage_self
+    }
+
+    Widget {
+        //0
+        ColorBox {bg: nil}
+        //1
+        TextBox  {bg: nil; label: "ch"}
+        //2
+        TextBox  {bg: nil; label: "ctrl"}
+        //3
+        TextBox  {bg: nil; label: "acquired controls"}
+        //4
+        TextBox  {bg: nil; label: "min"}
+        //5
+        TextBox  {bg: nil; label: "max"}
+        function class_name() { "zavlh" }
+        function layout(l, selfBox) {
+            Draw::Layout::hfill(l, selfBox, children, vce_list.weights)
+        }
+    }
+
+    function layout(l, selfBox) {
+        n    = children.length
+        off  = 0
+        gap  = 0.005
+        step = (1.0-(n)*gap)/n
+        children.each_with_index do |ch, id|
+            ch.fixed(l, selfBox, 0.01, off, 0.98, step)
+            off += step + gap
+        end
+        selfBox
+    }
+
+    function refresh()
+    {
+        valueRef.refresh if valueRef
+    }
+}

--- a/src/mruby-zest/example/ZynMidiLearnRow.qml
+++ b/src/mruby-zest/example/ZynMidiLearnRow.qml
@@ -1,0 +1,40 @@
+Widget {
+    id: voice_item
+    property Array weights: [0.05, 0.05, 0.2, 0.2, 0.3, 0.2]
+    property Function whenValue: nil
+
+    function unlearn() {
+        return if ctrl.label.empty?
+        $remote.action("/unlearn", ctrl.label)
+        whenValue.call if whenValue
+    }
+
+    //voice ID
+    TriggerButton {
+        tooltip: "unlearn midi control"
+        label: voice_item.label;
+        layoutOpts: [:no_constraint]
+        whenValue: lambda { voice_item.unlearn }
+    }
+    //channel
+    TextBox { bg: Theme::GeneralBackground;}
+    //control
+    TextBox { bg: Theme::GeneralBackground;}
+    //address
+    TextBox { id: ctrl; bg: Theme::GeneralBackground;  pad: 0; align: :left;}
+    //min
+    TextBox { bg: Theme::GeneralBackground; }
+    //max
+    TextBox { bg: Theme::GeneralBackground; }
+
+    function layout(l, selfBox) {
+        off = 0.0
+        hpad = 1.0/128
+        children.each_with_index do |ch, ind|
+            weight = weights[ind]
+            ch.fixed(l, selfBox, off+hpad, 0.0, weight-2*hpad, 1.0)
+            off += weight
+        end
+        selfBox
+    }
+}

--- a/src/mruby-zest/example/ZynMixer.qml
+++ b/src/mruby-zest/example/ZynMixer.qml
@@ -1,0 +1,56 @@
+Widget {
+    id: mixer
+    property Object valueRef: nil
+    property Object data: nil
+
+    function animate() {
+        #self.valueRef.refresh if(self.valueRef)
+
+        if(self.data)
+            children[0].set_level(data[0], data[1])
+            (0..15).each do |i|
+            children[i+1].set_level(data[6+2*i], data[6+2*i+1])
+            end
+        end
+    }
+
+    function update_data(x)
+    {
+        self.data = x
+    }
+
+    function draw(vg) {
+        vg.path do |v|
+            v.rect(0,0,w,h)
+            paint = v.linear_gradient(0,0,0,h,
+            Theme::InnerGrad1, Theme::InnerGrad2)
+            v.fill_paint paint
+            v.fill
+            v.stroke_color color(:black)
+            v.stroke_width 1.0
+            v.stroke
+        end
+    }
+    function onSetup(old=nil)
+    {
+        return if children.length > 3
+        col = Qml::ZynMixerMasterCol.new(db)
+        Qml::add_child(self, col)
+        (0...16).each do |r|
+            col = Qml::ZynMixerCol.new(db)
+            col.label  = (1+r).to_s
+            col.idx    = r
+            col.extern = "/part#{r}/"
+            Qml::add_child(self, col)
+        end
+
+        self.valueRef = OSC::RemoteParam.new($remote, "/vu-meter")
+        self.valueRef.callback = lambda {|x| mixer.update_data(x) }
+        animate() if self.data
+    }
+
+    function class_name() { "mixer" }
+    function layout(l, selfBox) {
+        Draw::Layout::hpack(l, selfBox, children, 0.02, 0.96, 4)
+    }
+}

--- a/src/mruby-zest/example/ZynMixerCol.qml
+++ b/src/mruby-zest/example/ZynMixerCol.qml
@@ -1,0 +1,86 @@
+Widget {
+    id: col
+    property Array weights: [0.05, 0.1, 0.70, 0.05, 0.05, 0.05]
+    property Int   idx: 0
+
+    function rap2dB(x) {20*Math::log10(x) }
+    function bound(x)  { [0.0, [1.0, x].min].max }
+    function cv(x)     {min_db = -40;bound((min_db-rap2dB(x))/min_db)}
+
+    function set_level(l,r)
+    {
+        #workaround for mruby bug
+        return if l.nil? || r.nil?
+        old = children[2].children[0].value
+        if(old != cv(l))
+            children[2].children[0].value = cv(l)
+            children[2].children[0].damage_self
+        end
+
+        old = children[2].children[1].value
+        if(old != cv(r))
+            children[2].children[1].value = cv(r)
+            children[2].children[1].damage_self
+        end
+
+    }
+
+    ToggleButton {
+        extern: col.extern + "Penabled"
+        label: col.label
+        layoutOpts: [:no_constraint]
+    }
+    TextEdit {
+        extern: col.extern + "Pname"
+        height: 0.333333
+        label: "synth"
+    }
+    ColorBox {
+        bg: Theme::GeneralBackground
+        Slider {visual: true; centered: false; pad: 0.01}
+        Slider {visual: true; centered: false; pad: 0.01}
+        Slider {
+            type: :float
+            extern: col.extern + "Volume"
+            centered: false
+            pad: 0.01
+        }
+        function class_name() { "mixbox" }
+        function layout(l, selfBox) {
+            Draw::Layout::hpack(l, selfBox, children)
+        }
+    }
+    HSlider {
+        extern: col.extern + "Ppanning"
+        centered: true;
+        label: "pan"
+    }
+    Selector {
+        extern: col.extern + "Prcvchn"
+        layoutOpts: [:no_constraint]
+    }
+    TriggerButton {
+        layoutOpts: [:no_constraint];
+        label: "edit"
+        whenValue: lambda { col.root.set_view_pos(:part, idx) }
+    }
+
+    function layout(l, selfBox) {
+        off = 0.0
+        fixed_pad = 2
+        children.each_with_index do |ch, ind|
+            weight = weights[ind]
+            l.fixed_long(ch, selfBox, 0, off, 1.0, weight,
+                         0, fixed_pad, 0, -2*fixed_pad)
+            off += weight
+        end
+        selfBox
+    }
+
+    function onSetup(old=nil)
+    {
+        children.each do |ch|
+            ch.extern()
+        end
+    }
+}

--- a/src/mruby-zest/example/ZynMixerMasterCol.qml
+++ b/src/mruby-zest/example/ZynMixerMasterCol.qml
@@ -1,0 +1,59 @@
+Widget {
+    id: col
+    property Array weights: [0.05, 0.95, 0.05, 0.05, 0.05]
+
+    function rap2dB(x) { 20*Math::log10(x) }
+    function bound(x)  { [0.0, [1.0, x].min].max }
+    function cv(x)     {min_db = -40;bound((min_db-rap2dB(x))/min_db)}
+
+    function set_level(l,r)
+    {
+        oldl = children[1].children[0].value
+        oldr = children[1].children[1].value
+        if(oldl != cv(l) || oldr != cv(r))
+            children[1].children[0].value = cv(l)
+            children[1].children[1].value = cv(r)
+            children[1].children[0].damage_self
+            children[1].children[1].damage_self
+        end
+    }
+
+    TextBox {
+        label: "Master"
+    }
+
+    ColorBox {
+        bg: Theme::GeneralBackground
+        Slider {visual: true; centered: false; pad: 0.01}
+        Slider {visual: true; centered: false; pad: 0.01}
+        Slider {
+            type: :float
+            extern: "/Volume"
+            centered: false
+            pad: 0.01
+        }
+        function class_name() { "mixbox" }
+        function layout(l,selfBox) {
+            Draw::Layout::hpack(l, selfBox, children)
+        }
+    }
+
+    function layout(l, selfBox) {
+        off = 0.0
+        fixed_pad = 2
+        children.each_with_index do |ch, ind|
+            weight = weights[ind]
+            l.fixed_long(ch, selfBox, 0, off, 1.0, weight,
+                         0, fixed_pad, 0, -2*fixed_pad)
+            off += weight
+        end
+        selfBox
+    }
+
+    function onSetup(old=nil)
+    {
+        children.each do |ch|
+            ch.extern()
+        end
+    }
+}

--- a/src/mruby-zest/example/ZynModAmpEnv.qml
+++ b/src/mruby-zest/example/ZynModAmpEnv.qml
@@ -1,0 +1,32 @@
+Group {
+    id: box
+    label: "Envelope"
+    property Function whenModified: nil
+    extern: ""
+
+    function cb()
+    {
+        whenModified.call if whenModified
+    }
+
+    ParModuleRow {
+        Knob { 
+            whenValue: lambda { box.cb }; 
+            extern: box.extern+"A_dt"
+            type:   :float
+        }
+        Knob { 
+            whenValue: lambda { box.cb }; 
+            extern: box.extern+"D_dt"
+            type:   :float
+        }
+        
+        Knob { whenValue: lambda { box.cb }; extern: box.extern+"PS_val"}
+        Knob     { 
+            whenValue: lambda { box.cb }; 
+            extern: box.extern+"R_dt"
+            type:   :float
+        }
+        Knob { whenValue: lambda { box.cb }; extern: box.extern+"Penvstretch"}
+    }
+}

--- a/src/mruby-zest/example/ZynModFreqGeneral.qml
+++ b/src/mruby-zest/example/ZynModFreqGeneral.qml
@@ -1,0 +1,11 @@
+Group {
+    id: box
+    extern: ""
+    ParModuleRow {
+        Knob { extern: box.extern + "PFMDetune" }
+        NumEntry { extern: box.extern + "FMoctave" }
+        Knob { extern: box.extern + "PFMrelbw" }
+        Selector { extern: box.extern + "PFMdetuneType" }
+        NumEntry { extern: box.extern + "PFMcoarseDetune" }
+    }
+}

--- a/src/mruby-zest/example/ZynOscil.qml
+++ b/src/mruby-zest/example/ZynOscil.qml
@@ -1,0 +1,263 @@
+Widget {
+    id: base_osc
+    property Bool doRefresh: false
+    property Object delayRefresh: nil
+
+    function animate()
+    {
+        if(doRefresh)
+            self.doRefresh = false
+            base.refresh
+            full.refresh
+            base_harm.refresh
+            full_harm.refresh
+            self.delayRefresh = Time.new + 0.1
+        end
+
+        #Super hacky workaround for data race in adsynth oscillators
+        if(delayRefresh && Time.new > delayRefresh)
+            base.refresh
+            base_harm.refresh
+            self.delayRefresh = nil
+        end
+    }
+
+    function clear()
+    {
+        (0...128).each do |i|
+            mval = 64
+            pval = 64
+            mval = 127 if i == 0
+            $remote.seti(base_osc.extern + "magnitude" + i.to_s, mval)
+            $remote.seti(base_osc.extern + "phase" + i.to_s,     pval)
+        end
+        refresh
+    }
+
+    function refresh()
+    {
+        self.doRefresh = true
+    }
+
+    TitleBar {
+        id: base_title
+        label: "base waveform"
+    }
+
+    HarmonicView {
+        id: base_harm
+        extern: base_osc.extern + "base-spectrum"
+    }
+
+    WaveView {
+        id: base
+        extern: base_osc.extern + "base-waveform"
+    }
+
+    TitleBar {
+        id: full_title
+        label: "full oscillator"
+    }
+
+    HarmonicView {
+        id: full_harm
+        extern: base_osc.extern + "spectrum"
+    }
+
+    WaveView {
+        id: full
+        extern: base_osc.extern + "waveform"
+    }
+
+    HarmonicEdit {
+        extern: base_osc.extern
+        whenValue: lambda {base_osc.refresh}
+        id: hedit
+    }
+
+    ScrollBar {
+        id: scroll
+        vertical: false
+        value: 0
+        whenValue: lambda {hedit.set_scroll scroll.value}
+    }
+
+    //Button {
+    //    id: voice_button
+    //    layoutOpts: [:no_constraint]
+    //    label: "voice"
+    //}
+
+    //Button {
+    //    id: mod_button
+    //    layoutOpts: [:no_constraint]
+    //    label: "mod"
+    //}
+
+    Widget {
+        id: middle_panel
+
+        Widget {
+            //COL 1
+            //base
+            TextBox { label: "base func."}
+            Selector { extern: base_osc.extern + "Pcurrentbasefunc"}
+            HSlider  { extern: base_osc.extern + "Pbasefuncpar"}
+            Widget {}
+
+            //modulation
+            TextBox { label: "BF mod."}
+            Selector { id: modsel; extern: base_osc.extern + "Pbasefuncmodulation"}
+            HSlider  { extern: modsel.extern + "par1"}
+            HSlider  { extern: modsel.extern + "par2"}
+            HSlider  { extern: modsel.extern + "par3"}
+
+            //bot
+            TriggerButton {
+                label: "as base"
+                tooltip: "use combined waveform as base waveform"
+                whenValue: lambda {
+                    $remote.action(base_osc.extern+"use-as-base")
+                }
+            }
+
+            //COL 2
+            //shape
+            TextBox  { label: "waveshaping"}
+            Selector { extern: base_osc.extern + "Pwaveshapingfunction"}
+            HSlider  { extern: base_osc.extern + "Pwaveshaping"}
+
+            //pad
+            Widget   {}
+
+            //filter
+            TextBox { label: "filter" }
+            Selector { extern: base_osc.extern + "Pfiltertype";}
+            HSlider  { extern: base_osc.extern + "Pfilterpar1";}
+            HSlider  { extern: base_osc.extern + "Pfilterpar2";}
+            Widget {}
+
+            //bot
+            ToggleButton   {
+                extern: base_osc.extern + "Pfilterbeforews";
+                label: "pre/post"
+            }
+
+            //COL 3
+
+            //mag type
+            TextBox { label: "mag. type"}
+            Selector {extern: base_osc.extern + "Phmagtype" }
+            HSlider {extern: base_osc.extern + "Pharmonicshift"}
+            Widget {
+                TriggerButton  {
+                    label: "R"
+                    tooltip: "Reset harmonic shift"
+                    whenValue: lambda {
+                        $remote.action(base_osc.extern + "Pharmonicshift", 0.to_i)
+                        base_osc.refresh
+                    }
+                }
+                ToggleButton  {extern: base_osc.extern + "Pharmonicshiftfirst"; label: "pre/post"}
+                function layout(l, selfBox) {
+                    Draw::Layout::hpack(l, selfBox, children)
+                }
+
+            }
+
+            //pad
+            TextBox {label: "adapt. harm."}
+
+            //adapt
+            Selector {extern: base_osc.extern + "Padaptiveharmonics"}
+            HSlider  {extern: base_osc.extern + "Padaptiveharmonicspower"}
+            HSlider  {extern: base_osc.extern + "Padaptiveharmonicsbasefreq"}
+            HSlider  {extern: base_osc.extern + "Padaptiveharmonicspar"}
+
+            //bot
+            TriggerButton   {
+                whenValue: lambda {base_osc.clear}
+                label: "clear all"
+                tooltip: "clear all harmonics"
+            }
+
+            //COL 4
+
+            //modulation
+            TextBox { label: "modulation" }
+            Selector { extern: base_osc.extern + "Pmodulation"}
+            HSlider  { extern: base_osc.extern + "Pmodulationpar1"}
+            HSlider  { extern: base_osc.extern + "Pmodulationpar2"}
+            HSlider  { extern: base_osc.extern + "Pmodulationpar3"}
+
+            //pad
+            Widget {}
+
+
+            //spectrum adj
+            TextBox {label: "spectrum adj."}
+            Selector { extern: base_osc.extern + "Psatype"}
+            HSlider  { extern: base_osc.extern + "Psapar"}
+
+            //bot
+            TriggerButton {
+                label: "to sine"
+                tooltip: "convert full waveform to sinasoidal components"
+                whenValue: lambda {
+                    $remote.action(base_osc.extern+"convert2sine")
+                }
+            }
+
+            function onSetup(old=nil)
+            {
+                lam = lambda {base_osc.refresh}
+                children.each do |ch|
+                    ch.layoutOpts  = [:no_constraint]
+                    ch.whenValue ||= lam if(ch.respond_to? :whenValue)
+                end
+            }
+
+            function class_name() { "oscgrid" }
+            function layout(l, selfBox) {
+                pad = 3
+                Draw::Layout::gridt(l, selfBox, children, 10, 4, pad, pad)
+            }
+
+        }
+
+        function draw(vg) {
+            Draw::GradBox(vg, Rect.new(0,0,w,h))
+        }
+
+
+        function layout(l, selfBox)
+        {
+            pad = 6
+            l.fixed_long(children[0], selfBox, 0, 0, 1, 1,
+                                pad, pad, -2*pad, -2*pad)
+            selfBox
+        }
+    }
+
+    function layout(l, selfBox)
+    {
+        base.fixed(l,           selfBox, 0.00, 0.15, 0.30, 0.38)
+        full.fixed(l,           selfBox, 0.70, 0.15, 0.30, 0.38)
+        base_harm.fixed(l,      selfBox, 0.00, 0.05, 0.30, 0.12)
+        full_harm.fixed(l,      selfBox, 0.70, 0.05, 0.30, 0.12)
+        base_title.fixed(l,     selfBox, 0.00, 0.00, 0.30, 0.05)
+        full_title.fixed(l,     selfBox, 0.70, 0.00, 0.30, 0.05)
+        hedit.fixed(l,          selfBox, 0.00, 0.53, 1.00, 0.42)
+        scroll.fixed(l,         selfBox, 0.00, 0.95, 1.00, 0.05)
+        middle_panel.fixed(l,   selfBox, 0.30, 0.0,  0.40, 0.53)
+
+        #voceBox = voice_button.layout(l)
+        #modbBox = mod_button.layout(l)
+        #l.fixed(scrlBox, selfBox, 0.10, 0.95, 0.80, 0.05)
+        #l.fixed(voceBox, selfBox, 0.00, 0.95, 0.10, 0.05)
+        #l.fixed(modbBox, selfBox, 0.90, 0.95, 0.10, 0.05)
+
+        selfBox
+    }
+
+}

--- a/src/mruby-zest/example/ZynOscilMod.qml
+++ b/src/mruby-zest/example/ZynOscilMod.qml
@@ -1,0 +1,103 @@
+Widget {
+    id: basemod
+    Widget {
+        Widget {
+            Widget {
+                Swappable { id: vis }
+            }
+            Widget {
+                Swappable { id: gen }
+                Swappable { id: env }
+                function layout(l, selfBox) {
+                    Draw::Layout::hpack(l, selfBox, children)
+                }
+            }
+            function layout(l, selfBox) {
+                Draw::Layout::vfill(l, selfBox, children, [0.6,0.4])
+            }
+        }
+        ZynOscilModRight {
+            extern: basemod.extern
+        }
+
+        function layout(l, selfBox)
+        {
+            Draw::Layout::hfill(l, selfBox, children, [0.6,0.4])
+        }
+    }
+    TabGroup {
+        id: footer
+
+        TabButton {
+            label: "amplitude";
+            highlight_pos: :top;
+        }
+        TabButton {
+            label: "frequency";
+            highlight_pos: :top
+        }
+
+        function set_tab(wid)
+        {
+            id = get_tab wid
+            vs = [:amplitude, :frequency]
+            root.set_view_pos(:subsubview, vs[id])
+            root.change_view
+        }
+    }
+
+    function layout(l, selfBox)
+    {
+        Draw::Layout::vfill(l, selfBox, children,
+        [0.95,0.05])
+    }
+
+    function set_view()
+    {
+        subsubview = root.get_view_pos(:subsubview)
+        vs = [:amplitude, :frequency]
+        if(!vs.include?(subsubview))
+            subsubview = :amplitude
+            root.set_view_pos(:subsubview, subsubview)
+        end
+        if(subsubview == :amplitude)
+            footer.children[0].value = true
+            gen.extern  = basemod.extern
+            env.extern  = basemod.extern + "FMAmpEnvelope/"
+            vis.extern  = basemod.extern + "FMAmpEnvelope/"
+            gen.content = Qml::ZynAmpMod
+            env.content = Qml::ZynAmpEnv
+            vis.content = Qml::ZynEnvEdit
+            vis.children[0].layoutOpts = Hash.new
+            vis.children[0].layoutOpts[:main_width] = 0.8
+
+            env.children[0].toggleable   = basemod.extern + "PFMAmpEnvelopeEnabled"
+            env.children[0].whenModified = lambda {
+                elm = vis.children[0]
+                elm.refresh if elm.respond_to? :refresh
+            }
+        else
+            footer.children[1].value = true
+            gen.extern  = basemod.extern
+            env.extern  = basemod.extern + "FMFreqEnvelope/"
+            vis.extern  = basemod.extern + "FMFreqEnvelope/"
+            gen.content = Qml::ZynFreqMod
+            env.content = Qml::ZynFreqEnv
+            vis.content = Qml::ZynEnvEdit
+            vis.children[0].layoutOpts = Hash.new
+            vis.children[0].layoutOpts[:main_width] = 0.8
+
+            env.children[0].toggleable   = basemod.extern + "PFMFreqEnvelopeEnabled"
+            env.children[0].whenModified = lambda {
+                elm = vis.children[0]
+                elm.refresh if elm.respond_to? :refresh
+            }
+        end
+        db.update_values
+    }
+
+    function onSetup(old=nil)
+    {
+        set_view
+    }
+}

--- a/src/mruby-zest/example/ZynOscilModRight.qml
+++ b/src/mruby-zest/example/ZynOscilModRight.qml
@@ -1,0 +1,166 @@
+Widget {
+    id: base
+    Indent {
+        pad: 10
+        ParModuleRow {
+            Selector {
+                extern: base.extern + "PFMEnabled";
+                layoutOpts: [:no_constraint]
+            }
+            Selector {
+                id: extmod;
+                label: "external modulator";
+            }
+        }
+        function draw(vg) {
+            Draw::GradBox(vg, Rect.new(0,0,w,h))
+        }
+    }
+    Group {
+        label: "unison"
+        topSize: 0.2
+        copyable: false
+        ParModuleRow {
+            NumEntry {
+                extern: base.extern + "Unison_size"
+            }
+            Knob {
+                extern: base.extern + "Unison_frequency_spread"
+            }
+            Knob {
+                extern: base.extern + "Unison_stereo_spread"
+            }
+            Knob {
+                extern: base.extern + "Unison_vibratto"
+            }
+            Knob {
+                extern: base.extern + "Unison_vibratto_speed"
+            }
+            Selector {
+                extern: base.extern + "Unison_invert_phase"
+            }
+        }
+    }
+    Widget {
+        Widget {
+            Group {
+                label: "vce osc"
+                topSize: 0.15
+                copyable: false
+                ParModuleRow {
+                    layoutOpts: []
+                    lsize: 0.4
+                    Selector {
+                        id: ext
+                        whenValue: lambda {
+                            off  = ext.opt_vals[ext.selected]
+                            off  = root.get_view_pos(:voice) if off == -1
+                            off  = root.get_view_pos(:voice) if off.nil?
+                            ext1 = "/VoicePar#{off}/OscilSmp/waveform"
+                            ext2 = "/VoicePar#{off}/Type"
+                            osc_wave.noise  = path_simp(base.extern+"../") + ext2
+                            osc_wave.extern = path_simp(base.extern+"../") + ext1
+                            osc_wave.damage_self
+                        }
+                        extern: base.extern + "Pextoscil"
+                    }
+                    Knob {
+                        id: phase_osc
+                        extern: base.extern + "Poscilphase"
+                        whenValue: lambda {osc_wave.phase = phase_osc.value}
+                    }
+                }
+                ParModuleRow {
+                    lsize: 0.4
+                    Selector {
+                        extern: base.extern + "Type"
+                    }
+                }
+            }
+            WaveView {
+                id: osc_wave
+                draw_borders: true
+                pad: 0.0225
+                noise:  base.extern + "Type"
+                extern: base.extern + "OscilSmp/waveform"
+                grid: false
+            }
+            function layout(l, selfBox) {
+                Draw::Layout::vfill(l, selfBox, children,
+                    [0.4,0.6])
+            }
+        }
+        Widget {
+            Group {
+                label: "mod osc"
+                topSize: 0.15
+                copyable: false
+                ParModuleRow {
+                    Selector {
+                        id: extfm
+                        whenValue: lambda {
+                            off = extfm.opt_vals[extfm.selected]
+                            off = root.get_view_pos(:voice) if off == -1
+                            off = root.get_view_pos(:voice) if off.nil?
+                            ext = "/VoicePar#{off}/FMSmp/waveform"
+                            mod_wave.extern = path_simp(base.extern+"../") + ext
+                            mod_wave.damage_self
+                        }
+                        extern: base.extern + "PextFMoscil"
+                    }
+                    Knob {
+                        id: phase_mod
+                        extern: base.extern+"PFMoscilphase"
+                        whenValue: lambda {
+                            mod_wave.phase = phase_mod.value
+                        }
+                    }
+                }
+                Widget {}
+            }
+            WaveView {
+                id: mod_wave
+                grid: false
+                pad: 0.0225
+                draw_borders: true
+                extern: base.extern + "FMSmp/waveform"
+            }
+            function layout(l, selfBox) {
+                Draw::Layout::vfill(l, selfBox, children,
+                    [0.4,0.6])
+            }
+        }
+        function layout(l, selfBox) {
+            Draw::Layout::hpack(l, selfBox, children)
+        }
+    }
+    function layout(l, selfBox)
+    {
+        Draw::Layout::vfill(l, selfBox, children,
+            [0.15,0.2,0.65])
+    }
+
+    function onSetup(old=nil)
+    {
+        vce     = root.get_view_pos(:voice)
+        mapper  = [-1]
+        names   = ["Normal"]
+        names2  = ["Normal"]
+        (0...vce).each do |i|
+            mapper << i
+            names  << "Oscil #{i+1}"
+            names2 << "Mod   #{i+1}"
+        end
+
+        extfm.opt_vals = mapper
+        extfm.options  = names
+        extfm.extern   = base.extern + "PextFMoscil"
+        ext.opt_vals   = mapper
+        ext.options    = names
+        ext.extern     = base.extern + "Pextoscil"
+        extmod.opt_vals = mapper
+        extmod.options  = names2
+        extmod.extern   = base.extern + "PFMVoice"
+
+    }
+}

--- a/src/mruby-zest/example/ZynOscilloscope.qml
+++ b/src/mruby-zest/example/ZynOscilloscope.qml
@@ -1,0 +1,116 @@
+Widget {
+    id: oscill 
+    extern: "/part0/kit0/adpars/"
+    property Array  opt_vals: []
+    property Array  options: []
+    property Int width: 0.9
+    property Int xc: 0
+    property Int yc: 0
+    function draw(vg){   
+        fill_color    = Theme::VisualBackground
+        dim           = Theme::VisualDim
+        padfactor = 12
+        bb = Draw::indent(Rect.new(xc,yc,w,h), padfactor, padfactor)
+        background(fill_color)
+        Draw::WaveForm::zero_line(vg, bb, dim)
+        vg.translate(0.5, 0.5)
+        vg.path do |v|
+            v.stroke_width = 1
+            v.stroke_color = Theme::GridLine
+            v.rounded_rect(bb.x.round(), bb.y.round(), bb.w.round(), bb.h.round(), 2)
+            v.stroke()
+        end
+        vg.translate(-0.5, -0.5)   
+    }
+    
+         onExtern: {
+            selector.options = oscill.options
+            selector.opt_vals = oscill.opt_vals
+            }
+
+    Widget {
+        id: run_view
+        //animation layer
+        layer: 1 
+        extern: oscill.extern + "out"
+        //Workaround due to buggy nested properties
+
+        function valueRef=(value_ref){
+            @value_ref = value_ref
+        }
+
+        function valueRef(){
+            @value_ref
+        }
+
+        function runtime_points=(x){
+            @runtime_points = x
+        }
+
+        onExtern: {
+            selector.options = oscill.options
+            selector.opt_vals = oscill.opt_vals
+            return if run_view.extern.nil?
+            puts oscill.opt_vals[selector.selected]
+            run_view.valueRef = OSC::RemoteParam.new($remote, oscill.opt_vals[selector.selected])
+            run_view.valueRef.set_watch
+            run_view.valueRef.callback = Proc.new {|x|
+                run_view.runtime_points = x;
+                run_view.damage_self
+            }
+        }
+
+        function update_points(xx)
+        {
+            self.runtime_points = xx
+            damage_self
+            @last = Time.new
+        }
+
+        function animate(){
+            return if run_view.valueRef.nil?
+            run_view.valueRef.watch run_view.extern
+            now     = Time.new
+            @last ||= now
+            #default = [10] * 200
+            #update_points(default) if((now-@last)>0.1)
+        }
+
+        function draw(vg){
+            padfactor = 12
+            bb = Draw::indent(Rect.new(oscill.xc,oscill.yc,w,h), padfactor, padfactor) 
+            return if  @runtime_points.nil?
+            pts = @runtime_points
+            Draw::WaveForm::plot(vg,pts,bb)
+        }
+    }
+
+    function layout(l, selfBox) {
+        main_width = oscill.width
+        main_width = layoutOpts[:main_width] if layoutOpts.include?(:main_width)
+        Draw::Layout::hfill(l, selfBox, children,
+        [main_width, 1-main_width], 0, 2)
+    }
+
+    Widget{
+        ParModuleRow {
+            lsize: 0.02
+            Selector{
+                id: selector
+                label: "change watch point"
+                whenValue: lambda {    
+                run_view.valueRef = OSC::RemoteParam.new($remote, oscill.opt_vals[selector.selected])
+                run_view.valueRef.set_watch
+                run_view.valueRef.callback = Proc.new {|x|
+                run_view.runtime_points = x;
+                run_view.damage_self
+                    }
+                }
+            }
+        }
+        
+    function draw(vg) {
+            Draw::GradBox(vg, Rect.new(oscill.xc,oscill.yc,w,h))
+        }
+    }
+} 

--- a/src/mruby-zest/example/ZynPadAmp.qml
+++ b/src/mruby-zest/example/ZynPadAmp.qml
@@ -1,0 +1,26 @@
+Group {
+    id: box
+    label: "General"
+    copyable: false
+
+    property Function whenModified: nil
+
+    ParModuleRow {
+        id: top
+        Knob { extern: box.extern+"PVolume" }
+        Knob { extern: box.extern+"PAmpVelocityScaleFunction"}
+        Knob { extern: box.extern+"PPanning"}
+        Knob { extern: box.extern+"Fadein_adjustment"}
+
+    }
+    ParModuleRow {
+        id: bot
+        Knob     {extern: box.extern+"PPunchStretch"}
+        Knob     {extern: box.extern+"PPunchStrength"}
+        Knob     {extern: box.extern+"PPunchTime"}
+        Col {
+            Button   {label: "stereo"; extern: box.extern+"Pstereo"}
+            Button   {label: "rnd grp"}
+        }
+    }
+}

--- a/src/mruby-zest/example/ZynPadFreq.qml
+++ b/src/mruby-zest/example/ZynPadFreq.qml
@@ -1,0 +1,17 @@
+Group {
+    id: box
+    label: "General"
+    property Function whenModified: nil
+    ParModuleRow {
+        Knob { extern: box.extern + "PDetune" }
+        NumEntry { extern: box.extern + "octave" }
+        Knob { extern: box.extern + "Pbandwidth" }
+    }
+
+    ParModuleRow {
+        ToggleButton {extern: box.extern + "Pfixedfreq" }
+        Knob { extern: box.extern + "PfixedfreqET" }
+        Selector { extern: box.extern + "PDetuneType" }
+        NumEntry { extern: box.extern + "PCoarseDetune" }
+    }
+}

--- a/src/mruby-zest/example/ZynPadGlobal.qml
+++ b/src/mruby-zest/example/ZynPadGlobal.qml
@@ -1,0 +1,192 @@
+Widget {
+    id: padglobal
+
+    property Object valueRef: nil
+    property Symbol filtertype: nil
+
+
+    function layout(l, selfBox) {
+        Draw::Layout::vfill(l, selfBox, children, [0.55, 0.4, 0.05])
+    }
+
+    Swappable {
+        id: row1
+        content: Qml::LfoVis
+
+        function setDataVis(type, tab) {
+            root.set_view_pos(:vis, type)
+            root.change_view
+        }
+    }
+
+    Widget {
+        id: row2
+        function layout(l, selfBox) {
+            Draw::Layout::hpack(l, selfBox, children)
+        }
+
+
+        Swappable { id: amp_gen }
+        Swappable { id: amp_env }
+        Swappable { id: amp_lfo }
+    }
+    Widget {
+        id: footer
+
+        function layout(l, selfBox) {
+            Draw::Layout::tabpack(l, selfBox, self)
+        }
+
+        function setTab(id)
+        {
+            (0..2).each do |ch_id|
+                children[ch_id].value = (ch_id == id)
+                children[ch_id].damage_self
+            end
+            mapping = {0 => :amplitude,
+                       1 => :frequency,
+                       2 => :filter}
+            root.set_view_pos(:subsubview, mapping[id])
+            root.change_view
+        }
+
+        TabButton { label: "amplitude"; whenClick: lambda {footer.setTab(0)}; highlight_pos: :top}
+        TabButton { label: "frequency"; whenClick: lambda {footer.setTab(1)}; highlight_pos: :top}
+        TabButton { label: "filter";    whenClick: lambda {footer.setTab(2)}; highlight_pos: :top}
+    }
+
+    function set_view()
+    {
+        subsubview = root.get_view_pos(:subsubview)
+        types = [:amplitude, :frequency, :filter]
+        if(!types.include?(subsubview))
+            subsubview = :amplitude
+            root.set_view_pos(:subsubview, subsubview)
+        end
+        vis = root.get_view_pos(:vis)
+        types = [:envelope, :lfo, :filter, :oscilloscope]
+        if(!types.include?(vis))
+            vis = :envelope
+            root.set_view_pos(:vis, vis)
+        end
+
+        if(subsubview == :amplitude)
+            set_amp(self.extern)
+        elsif(subsubview == :frequency)
+            set_freq(self.extern)
+        elsif(subsubview == :filter)
+            set_filter(self.extern)
+        end
+
+        if(vis == :lfo)
+            set_vis_lfo(self.extern, subsubview)
+        elsif(vis == :envelope)
+            set_vis_env(self.extern, subsubview)
+        elsif(vis == :filter)
+            set_vis_filter(self.extern, subsubview)
+         elsif(vis == :oscilloscope)
+            set_vis_oscilloscope()
+        end
+        db.update_values
+    }
+
+    function set_vis_lfo(ext, tab)
+    {
+        e_  = {:filter    => "FilterLfo/",
+               :amplitude => "AmpLfo/",
+               :frequency => "FreqLfo/"}[tab]
+        return if e_.nil?
+        row1.extern  = ext + e_
+        row1.content = Qml::LfoVis
+        row1.children[0].children[0].extern = amp_lfo.extern+"out"
+    }
+
+    function set_vis_env(ext, tab)
+    {
+        e_  = {:filter    => "FilterEnvelope/",
+               :amplitude => "AmpEnvelope/",
+               :frequency => "FreqEnvelope/"}[tab]
+        return if e_.nil?
+        row1.extern  = ext + e_
+        row1.content = Qml::ZynEnvEdit
+        #self.children[0].children[0].extern = amp_env.extern+"out"
+        amp_env.children[0].whenModified = lambda {
+            elm = row1.children[0]
+            elm.refresh if elm.respond_to? :refresh
+        }
+    }
+
+    function set_vis_oscilloscope()
+    {
+        row1.content = Qml::ZynPadOscilloscope
+    }
+
+
+    function set_vis_filter(ext, dummy)
+    {
+        row1.extern = ext + "GlobalFilter/"
+        if(self.filtertype == :formant)
+            row1.content = Qml::ZynFormant
+        else
+            row1.content = Qml::VisFilter
+            row1.children[0].extern = ext + "GlobalFilter/response"
+        end
+        amp_gen.children[0].whenModified = lambda {
+            elm = row1.children[0]
+            elm.refresh if elm.respond_to? :refresh
+        }
+    }
+
+    function set_amp(base)
+    {
+        footer.children[0].value = true
+        amp_gen.extern  = base
+        amp_env.extern  = base + "AmpEnvelope/"
+        amp_lfo.extern  = base + "AmpLfo/"
+        amp_gen.content = Qml::ZynPadAmp
+        amp_env.content = Qml::ZynAmpEnv
+        amp_lfo.content = Qml::ZynLFO
+        amp_env.children[0].whenClick = lambda {row1.setDataVis(:env, :amp)}
+        amp_lfo.children[0].whenClick = lambda {row1.setDataVis(:lfo, :amp)}
+    }
+
+    function set_freq(base)
+    {
+        footer.children[1].value = true
+        amp_gen.extern  = base
+        amp_env.extern  = base + "FreqEnvelope/"
+        amp_lfo.extern  = base + "FreqLfo/"
+        amp_gen.content = Qml::ZynPadFreq
+        amp_env.content = Qml::ZynFreqEnv
+        amp_lfo.content = Qml::ZynLFO
+        amp_env.children[0].whenClick = lambda {row1.setDataVis(:env, :freq)}
+        amp_lfo.children[0].whenClick = lambda {row1.setDataVis(:lfo, :freq)}
+    }
+
+    function set_filter(base)
+    {
+        footer.children[2].value = true
+        amp_gen.extern  = base + "GlobalFilter/"
+        amp_env.extern  = base + "FilterEnvelope/"
+        amp_lfo.extern  = base + "FilterLfo/"
+        amp_gen.content = Qml::ZynAnalogFilter
+        amp_env.content = Qml::ZynFilterEnv
+        amp_lfo.content = Qml::ZynLFO
+        amp_gen.children[0].whenClick = lambda {row1.setDataVis(:filter, :filter)}
+        amp_env.children[0].whenClick = lambda {row1.setDataVis(:env,    :filter)}
+        amp_lfo.children[0].whenClick = lambda {row1.setDataVis(:lfo,    :filter)}
+    }
+
+    function onSetup(old=nil)
+    {
+        if(padglobal.valueRef.nil?)
+            path = padglobal.extern + "GlobalFilter/Pcategory"
+            padglobal.valueRef = OSC::RemoteParam.new($remote, path)
+            padglobal.valueRef.mode = :full
+            padglobal.valueRef.callback = lambda {|x|
+                padglobal.filtertype = [:analog, :formant, :statevar][x]
+            }
+        end
+        set_view()
+    }
+}

--- a/src/mruby-zest/example/ZynPadHarmonics.qml
+++ b/src/mruby-zest/example/ZynPadHarmonics.qml
@@ -1,0 +1,83 @@
+Widget {
+    id: base
+    extern: "/part0/kit0/padpars/"
+    Widget {
+        HarmonicView {
+            id: nhr
+            type:   :pad
+            extern: base.extern
+        }
+        ZynPadOvertone {
+            extern: base.extern
+            whenValue: lambda { nhr.refresh }
+        }
+        function layout(l, selfBox) {
+            children[0].fixed(l, selfBox, 0.0, 0.0, 0.6, 1.0)
+            children[1].fixed(l, selfBox, 0.6, 0.0, 0.4, 1.0)
+            selfBox
+        }
+    }
+    Widget {
+        VisHarmonic {
+            id: visharm
+            extern: base.extern + "harmonic_profile"
+        }
+        Group {
+            label: "harmonic profile"
+            topSize: 0.09
+            copyable: false
+
+            ZynPadProfile {
+                extern: base.extern
+                whenValue: lambda { visharm.refresh }
+            }
+        }
+        function layout(l, selfBox) {
+            children[0].fixed(l, selfBox, 0.0, 0.0, 0.7, 1.0)
+            children[1].fixed(l, selfBox, 0.7, 0.0, 0.3, 1.0)
+            selfBox
+        }
+    }
+    Widget {
+        WaveView {
+            extern: base.extern + "oscilgen/waveform"
+        }
+        Group {
+            topSize: 0.15
+            label: "harmonic content"
+            copyable: false
+            ParModuleRow {
+                lsize: 0.4
+                Selector {
+                    extern: base.extern + "Pquality.basenote"
+                }
+                Selector {
+                    extern: base.extern + "Pquality.smpoct"
+                }
+                NumEntry {
+                    extern: base.extern + "Pquality.oct"
+                    label: "octaves"
+                }
+            }
+            Col{
+                Selector {
+                    extern: base.extern + "Pquality.samplesize"
+                    layoutOpts: [:long_mode]
+                }
+                Text {label: "sample size"}
+            }
+        }
+        function layout(l, selfBox) {
+            children[0].fixed(l, selfBox, 0.0, 0.0, 0.7, 1.0)
+            children[1].fixed(l, selfBox, 0.7, 0.0, 0.3, 1.0)
+            selfBox
+        }
+    }
+
+    function layout(l, selfBox) {
+        children[0].fixed(l, selfBox, 0.0, 0.00, 1.0, 0.17)
+        children[1].fixed(l, selfBox, 0.0, 0.17, 1.0, 0.50)
+        children[2].fixed(l, selfBox, 0.0, 0.67, 1.0, 0.33)
+        selfBox
+    }
+}

--- a/src/mruby-zest/example/ZynPadOscilloscope.qml
+++ b/src/mruby-zest/example/ZynPadOscilloscope.qml
@@ -1,0 +1,11 @@
+Group_nocp {
+    ZynOscilloscope{
+        options: ["> interpo", "> punch", "> amp_interpo", "> legato"]
+        opt_vals: ["/part0/kit0/padpars/noteout/after_interpolation","/part0/kit0/padpars/noteout/after_punch", "/part0/kit0/padpars/noteout/after_amp_interpolation", "/part0/kit0/padpars/noteout/after_legato"] 
+    }
+
+    ZynOscilloscope{
+        options: ["> interpo", "> punch", "> amp_interpo", "> legato"]
+        opt_vals: ["/part0/kit0/padpars/noteout/after_interpolation","/part0/kit0/padpars/noteout/after_punch", "/part0/kit0/padpars/noteout/after_amp_interpolation", "/part0/kit0/padpars/noteout/after_legato"] 
+    }
+}

--- a/src/mruby-zest/example/ZynPadOvertone.qml
+++ b/src/mruby-zest/example/ZynPadOvertone.qml
@@ -1,0 +1,77 @@
+Widget {
+    id: overtone
+    property Function whenValue: nil
+
+    function cb()
+    {
+        whenValue.call if whenValue
+    }
+
+    function draw(vg) {
+        vg.path do |v|
+            v.rect(0,0,w,h)
+            paint = v.linear_gradient(0,0,0,h,
+            Theme::InnerGrad1, Theme::InnerGrad2)
+            v.fill_paint paint
+            v.fill
+            v.stroke_color color(:black)
+            v.stroke_width 1.0
+            v.stroke
+        end
+    }
+    Widget {
+        //row 1
+        TextBox  {label: "overtone pos."; height: 0.9}
+        HSlider  {extern: overtone.extern + "Pbandwidth";  height: 0.8}
+        HSlider  {extern: overtone.extern + "Phrpos.par3"; height: 0.8}
+
+        //row 2
+        Selector {
+            extern: overtone.extern + "Phrpos.type";
+            layoutOpts: [:no_constraint]
+        }
+        Widget {}
+        Widget {}
+
+        //row 3
+        TextBox  {label: "spectral mode"; height: 0.9}
+        TextBox  {label: "bw. scale"; height: 0.9}
+        HSlider {extern: overtone.extern + "Phrpos.par1"; height: 0.8}
+
+        //row 4
+        Selector {
+            layoutOpts: [:no_constraint];
+            extern: overtone.extern + "Pmode"
+        }
+        Selector {
+            layoutOpts: [:no_constraint]
+            extern: overtone.extern + "Pbwscale"
+        }
+        HSlider {extern: overtone.extern + "Phrpos.par2"; height: 0.8}
+
+        //1    2    3
+        //4
+        //5    6    7
+        //8    9   10
+
+        function class_name() { "overtone" }
+        function layout(l, selfBox) {
+            Draw::Layout::grid(l, selfBox, children, 4, 3, 1, 2)
+        }
+
+        function onSetup(old=nil)
+        {
+            cb_ = lambda {overtone.cb}
+            children.each do |ch|
+                ch.whenValue = cb_ if ch.respond_to? :whenValue
+            end
+        }
+    }
+    function layout(l, selfBox)
+    {
+        pad = 4
+        l.fixed_long(children[0], selfBox, 0, 0, 1, 1,
+            pad, pad, -2*pad, -2*pad)
+        selfBox
+    }
+}

--- a/src/mruby-zest/example/ZynPadProfile.qml
+++ b/src/mruby-zest/example/ZynPadProfile.qml
@@ -1,0 +1,59 @@
+Widget {
+    id: padprofile
+    property Function whenValue: nil
+    function cb()
+    {
+        whenValue.call if whenValue
+    }
+    Widget {
+        function onSetup() {
+            cb_ = lambda {padprofile.cb}
+            children.each do |x|
+                x.layoutOpts = [:no_constraint]
+                x.whenValue  = cb_ if x.respond_to? :whenValue
+            end
+        }
+
+
+        //row 1
+        TextBox { label: "base type"}
+        HSlider { extern: padprofile.extern + "Php.modulator.par1"}
+        //row 2
+        Selector {extern: padprofile.extern + "Php.base.type"}
+        HSlider { extern: padprofile.extern + "Php.modulator.freq"}
+        //row 3
+        Selector {extern: padprofile.extern + "Php.onehalf"}
+        HSlider { extern: padprofile.extern + "Php.width"}
+        //row 4
+        ToggleButton {
+            label: "autoscale"
+            extern: padprofile.extern + "Php.autoscale"
+        }
+        HSlider { extern: padprofile.extern + "Php.base.par1"}
+        //row 5
+        TextBox { label: "amp. mlt."}
+        HSlider { extern: padprofile.extern + "Php.freqmult"}
+        //row 6
+        Selector {extern: padprofile.extern + "Php.amp.type"}
+        Widget {}
+        //row 7
+        TextBox { bg: nil; label: "amp. mode"}
+        HSlider { extern: padprofile.extern + "Php.amp.par1"}
+        //row 8
+        Selector {extern: padprofile.extern + "Php.amp.mode"}
+        HSlider { extern: padprofile.extern + "Php.amp.par2"}
+
+        function class_name() { "overtone" }
+        function layout(l, selfBox) {
+            Draw::Layout::grid(l, selfBox, children, 8, 2, 1, 2)
+        }
+    }
+    function layout(l, selfBox)
+    {
+        pad = 4
+        children[0].fixed_long(l, selfBox, 0, 0, 1, 1,
+            pad, pad, -2*pad, -2*pad)
+        selfBox
+    }
+
+}

--- a/src/mruby-zest/example/ZynPadSynth.qml
+++ b/src/mruby-zest/example/ZynPadSynth.qml
@@ -1,0 +1,118 @@
+Widget {
+    id: center
+
+    function layout(l, selfBox) {
+        Draw::Layout::vfill(l, selfBox, children, [0.05, 0.95])
+    }
+
+    function apply() {
+        $remote.action(center.extern+"prepare")
+    }
+
+    TabGroup {
+        id: header
+        TabButton { label: "harmonic structure";}
+        TabButton { label: "oscillator";}
+        TabButton { label: "envelopes & lfos"; whenClick: lambda {root.set_view_pos(:vis, :envelope)};}
+
+        ApplyButton {
+            id: appl
+            layoutOpts: [:no_constraint];
+            label: "   apply"
+            extern: center.extern + "needPrepare"
+            whenValue: lambda {center.apply() }
+        }
+        TriggerButton {
+            id: oscillbutton
+            layoutOpts: [:no_constraint];
+            label: "   oscilloscope"
+            whenValue: lambda {
+            root.set_view_pos(:subview, :global_pad)
+            root.set_view_pos(:vis, :oscilloscope)
+            root.change_view
+            center.turn_off_tab()  
+             }
+        }
+
+        CopyButton {
+            id: copy
+            extern: center.extern
+        }
+        PasteButton {
+            id: paste
+            extern: center.extern
+        }
+
+        function layout(l, selfBox) {
+            selfBox = Draw::Layout::tabpack(l, selfBox, self, appl)
+        }
+
+        function set_tab(wid)
+        {
+            selected = get_tab wid
+
+            #Define a mapping from tabs to values
+            mapping = {0 => :harmonics,
+                       1 => :oscil,
+                       2 => :global_pad,
+                       3 => :oscilloscope}
+            root.set_view_pos(:subview, mapping[selected])
+            root.change_view
+        }
+
+    }
+    function get_voice() { root.get_view_pos(:voice) }
+    function get_part()  { root.get_view_pos(:part)  }
+    function get_kit()   { root.get_view_pos(:kit)   }
+
+    function onSetup(old=nil)
+    {
+        return if swap.content.nil?
+        set_view
+    }
+
+    function set_view()
+    {
+        subview = root.get_view_pos(:subview)
+
+        mapping = {:harmonics   => Qml::ZynPadHarmonics,
+                   :oscil       => Qml::ZynOscil,
+                   :global_pad  => Qml::ZynPadGlobal,
+                   :oscilloscope => Qml::ZynPadOscilloscope}
+        base = center.extern
+        ext     = {:harmonics  => "",
+                   :oscil      => "oscilgen/",
+                   :global_pad => "",
+                   :oscilloscope => ""}
+        tabid   = {:harmonics  => 0,
+                   :oscil      => 1,
+                   :global_pad => 2,
+                   :oscilloscope => 3}
+        if(!mapping.include?(subview))
+            subview = :oscil
+            root.set_view_pos(:subview, :oscil)
+        end
+
+
+        copy.extern  = base + ext[subview]
+        paste.extern = base + ext[subview]
+        swap.extern  = base + ext[subview]
+        swap.content = mapping[subview]
+        header.children[tabid[subview]].value = true
+    }
+
+    Swappable { id: swap }
+
+    function turn_off_tab()
+    {
+        n = 2
+        (0..n).each do |ch_id|
+            child = header.children[ch_id]
+           
+                if(child.value)
+                    child.value = false
+                    child.damage_self
+                end
+            end
+    }
+}

--- a/src/mruby-zest/example/ZynPart.qml
+++ b/src/mruby-zest/example/ZynPart.qml
@@ -1,0 +1,56 @@
+Widget {
+    id: pset
+    Widget {
+        function onSetup(old=nil)
+        {
+            return if !children.empty?
+            (1..16).each do |i|
+                but = Qml::ToggleButton.new(self.db)
+                but.label = i.to_s
+                but.pad   = 1.0/512
+                but.layoutOpts = [:no_constraint]
+                but.textScale  = 0.5
+                but.extern = "/part#{i-1}/Penabled"
+                Qml::add_child(self, but)
+            end
+            (1..16).each do |i|
+                but = Qml::LabelButton.new(self.db)
+                but.label = "None"
+                but.pad   = 1.0/512
+                but.layoutOpts = [:no_constraint, :left_text]
+                but.textScale  = 0.5
+                but.extern = "/part#{i-1}/Pname"
+                but.whenValue = lambda { but.root.set_view_pos(:part, i-1); but.root.change_view}
+                Qml::add_child(self, but)
+            end
+        }
+
+        function layout(l, selfBox) {
+            Draw::Layout::vpack(l, selfBox, children[0..15],  0.0, 0.2)
+            Draw::Layout::vpack(l, selfBox, children[16..31], 0.2, 0.8)
+        }
+    }
+    Widget {
+        function class_name() { "part" }
+        function layout(l, selfBox) {
+            Draw::Layout::vfill(l, selfBox, children, [0.4,0.3,0.3])
+        }
+        ZynInstrumentSettings {
+            extern: pset.extern
+        }
+        ZynControllers {
+            extern: pset.extern + "ctl/"
+        }
+        ZynPortamento  {
+            extern: pset.extern + "ctl/"
+        }
+    }
+    ZynScale {
+        extern: "/microtonal/"
+    }
+
+    function class_name() { "part" }
+    function layout(l, selfBox) {
+        Draw::Layout::hfill(l, selfBox, children, [0.2,0.4,0.4])
+    }
+}

--- a/src/mruby-zest/example/ZynPatchInfo.qml
+++ b/src/mruby-zest/example/ZynPatchInfo.qml
@@ -1,0 +1,43 @@
+Widget {
+    id: info_box
+    //Name Header       1-line
+    //Namebox           1-line
+    //Author Header     1-line
+    //Author            4-line
+    //Comments Header   1-line
+    //Comments          8-line
+    TextBox {label: "name"}
+    TextLine {
+        id: namebox
+    }
+    TextBox {label: "author"}
+    TextEdit {
+        id: authbox
+        height: 0.25
+    }
+    TextBox {label: "comments"}
+    TextEdit {
+        id: commbox
+        height: 1.0/8.0
+    }
+
+    function layout(l, selfBox)
+    {
+        weights = Draw::DSP::norm_sum([1,1,1,4,1,8])
+
+        Draw::Layout::vfill(l, selfBox, children, weights)
+    }
+
+    function set_view()
+    {
+        prt = root.get_view_pos(:part)
+        namebox.extern = "/part#{prt}/Pname"
+        authbox.extern = "/part#{prt}/info.Pauthor"
+        commbox.extern = "/part#{prt}/info.Pcomments"
+    }
+
+    function onSetup(old=nil)
+    {
+        set_view()
+    }
+}

--- a/src/mruby-zest/example/ZynPhaser.qml
+++ b/src/mruby-zest/example/ZynPhaser.qml
@@ -1,0 +1,69 @@
+Group {
+    id: phaser
+    label: "phaser"
+    topSize: 0.2
+
+    function refresh() {
+        return if rw.content.nil?
+        return if rw.content.children.length < 4
+        rw.content.children[3..-1].each do |c|
+            c.refresh
+        end
+        rw2.content.children.each do |c|
+            c.refresh
+        end
+    }
+
+    function changeAnalog(value) {
+        knobWidth.active = value
+        knobPhase.active = !value
+        knobOffset.active = value
+        knobLRcross.active = !value
+        knobWidth.damage_self
+        knobPhase.damage_self
+        knobOffset.damage_self
+        knobLRcross.damage_self
+        refresh()
+    }
+
+    ParModuleRow {
+        id: rw
+        layoutOpts: []
+        Selector {
+            extern: phaser.extern + "Phaser/preset"
+            whenValue: lambda { phaser.refresh }
+        }
+
+        Knob { extern: phaser.extern + "Pvolume"}
+        Knob { extern: phaser.extern + "Ppanning"}
+
+        Knob { extern: phaser.extern + "Phaser/lfo.Pfreq" }
+        Knob { extern: phaser.extern + "Phaser/lfo.Prandomness" }
+        Selector { extern: phaser.extern + "Phaser/lfo.PLFOtype" }
+        Knob { extern: phaser.extern + "Phaser/lfo.Pstereo" }
+        Knob { extern: phaser.extern + "Phaser/Pdepth" }
+        Knob { extern: phaser.extern + "Phaser/Pfb" }
+    }
+
+    ParModuleRow {
+        id: rw2
+        layoutOpts: []
+        NumEntry { extern: phaser.extern + "Phaser/Pstages" }
+        Knob { id: knobLRcross
+            extern: phaser.extern + "Phaser/Plrcross" }
+        Knob { id: knobOffset
+            extern: phaser.extern + "Phaser/Poffset" }
+        ToggleButton { extern: phaser.extern + "Phaser/Poutsub" }
+        Knob { id: knobPhase
+            extern: phaser.extern + "Phaser/Pphase" }
+        Knob { id: knobWidth
+            extern: phaser.extern + "Phaser/Pwidth" }
+        ToggleButton { extern: phaser.extern + "Phaser/Phyper" }
+        Knob { extern: phaser.extern + "Phaser/Pdistortion" }
+        ToggleButton {
+            id: analogButton
+            extern: phaser.extern + "Phaser/Panalog"
+            whenValue: lambda() { phaser.changeAnalog(analogButton.value) }
+        }
+    }
+}

--- a/src/mruby-zest/example/ZynPortamento.qml
+++ b/src/mruby-zest/example/ZynPortamento.qml
@@ -1,0 +1,19 @@
+Group {
+    id: port
+    label: "portamento"
+    copyable: false
+    ParModuleRow {
+        Col{
+            ToggleButton { extern: port.extern+"portamento.receive"}
+            ToggleButton { extern: port.extern+"portamento.pitchthreshtype"}
+        }
+        NumEntry   { extern: port.extern+"portamento.pitchthresh"}
+        Knob   { extern: port.extern+"portamento.time"}
+        Knob   { extern: port.extern+"portamento.updowntimestretch"}
+    }
+    ParModuleRow {
+        ToggleButton { extern: port.extern+"portamento.proportional"}
+        Knob   { extern: port.extern+"portamento.propRate"}
+        Knob   { extern: port.extern+"portamento.propDepth"}
+    }
+}

--- a/src/mruby-zest/example/ZynResOptions.qml
+++ b/src/mruby-zest/example/ZynResOptions.qml
@@ -1,0 +1,77 @@
+ParModuleRow {
+    id: resopt
+    property Function whenValue: nil
+    function cb()
+    {
+        whenValue.call if whenValue
+    }
+    ToggleButton {
+        extern: resopt.extern + "Penabled"
+        label: "enable"
+    }
+    Knob { extern: resopt.extern + "PmaxdB";      label: "max"}
+    Knob { extern: resopt.extern + "Pcenterfreq";  label: "c.f."}
+    Knob { extern: resopt.extern + "Poctavesfreq"; label: "oct."}
+    //TODO interpolate previously worked with right/left click
+    //This should be broken into two separate buttons
+    //Each button should have a tooltip that actually makes sense
+    TriggerButton {
+        whenValue: lambda {
+            path = resopt.extern + "interpolatepeaks"
+            $remote.action(path, 0)
+            resopt.cb
+        }
+        label: "interp"
+        tooltip: "Interpolate between sparsely added points"
+    }
+    ToggleButton {
+        extern: resopt.extern + "Pprotectthefundamental"
+    }
+    TextBox {}
+    TextBox {}
+    TriggerButton {
+        whenValue: lambda {
+            path = resopt.extern + "zero"
+            $remote.action(path)
+            resopt.cb
+        }
+        label: "zero"
+        tooltip: "reset frequency response"
+    }
+    TriggerButton {
+        whenValue: lambda {
+            path = resopt.extern + "smooth"
+            $remote.action(path)
+            resopt.cb
+        }
+        label: "smooth"
+        tooltip: "smooth out frequency response"
+    }
+    TriggerButton {
+        whenValue: lambda {
+            path = resopt.extern + "randomize"
+            $remote.action(path, 0)
+            resopt.cb
+        }
+        label: "random 1"
+        tooltip: "create slow changing random response"
+    }
+    TriggerButton {
+        whenValue: lambda {
+            path = resopt.extern + "randomize"
+            $remote.action(path, 1)
+            resopt.cb
+        }
+        label: "random 2"
+        tooltip: "create random response"
+    }
+    TriggerButton {
+        whenValue: lambda {
+            path = resopt.extern + "randomize"
+            $remote.action(path, 2)
+            resopt.cb
+        }
+        label: "random 3"
+        tooltip: "create fast changing random response"
+    }
+}

--- a/src/mruby-zest/example/ZynResonance.qml
+++ b/src/mruby-zest/example/ZynResonance.qml
@@ -1,0 +1,39 @@
+Widget {
+    id: reson
+    function refresh()
+    {
+        vis.refresh
+    }
+    VisResonance {
+        id: vis
+        extern: reson.extern + "respoints"
+    }
+    Indent {
+        ZynResOptions {
+            whenValue: lambda {reson.refresh}
+            extern: reson.extern
+        }
+        function draw(vg)
+        {
+            vg.path do |v|
+                v.rect(0,0,w,h)
+                paint = v.linear_gradient(0,0,0,h,
+                Theme::InnerGrad1, Theme::InnerGrad2)
+                v.fill_paint paint
+                v.fill
+                v.stroke_color color(:black)
+                v.stroke_width 1.0
+                v.stroke
+            end
+        }
+    }
+    function layout(l, selfBox)
+    {
+        children[0].fixed(l, selfBox, 0, 0.0, 1, 0.8)
+        children[1].fixed(l, selfBox, 0, 0.8, 1, 0.2)
+        selfBox
+    }
+    function draw(vg)
+    {
+    }
+}

--- a/src/mruby-zest/example/ZynReverb.qml
+++ b/src/mruby-zest/example/ZynReverb.qml
@@ -1,0 +1,34 @@
+Group {
+    id: reverb
+    label: "reverb"
+    topSize: 0.2
+
+    function refresh() {
+        return if rw.content.nil?
+        return if rw.content.children.length < 4
+        rw.content.children[3..-1].each do |c|
+            c.refresh
+        end
+    }
+
+    ParModuleRow {
+        id: rw
+        layoutOpts: []
+        Selector {
+            extern: reverb.extern + "Reverb/preset"
+            whenValue: lambda { reverb.refresh }
+        }
+        Knob { extern: reverb.extern + "Pvolume"}
+        Knob { extern: reverb.extern + "Ppanning"}
+
+        Selector { extern: reverb.extern + "Reverb/Ptype"}
+        Knob { extern: reverb.extern + "Reverb/Proomsize" }
+        Knob { extern: reverb.extern + "Reverb/Ptime" }
+        Knob { extern: reverb.extern + "Reverb/Pidelay"}
+        Knob { extern: reverb.extern + "Reverb/Pidelayfb"}
+        Knob { extern: reverb.extern + "Reverb/Plpf"}
+        Knob { extern: reverb.extern + "Reverb/Phpf"}
+        Knob { extern: reverb.extern + "Reverb/Plohidamp"}
+        Knob { extern: reverb.extern + "Reverb/Pbandwidth" }
+    }
+}

--- a/src/mruby-zest/example/ZynScale.qml
+++ b/src/mruby-zest/example/ZynScale.qml
@@ -1,0 +1,70 @@
+Widget {
+    id: micro
+    function class_name() { "part" }
+    function layout(l, selfBox) {
+        Draw::Layout::vfill(l, selfBox, children, [0.2,0.10,0.70])
+    }
+    Group {
+        topSize: 0.2
+        copyable: false
+        label: "scale settings"
+        ParModuleRow {
+            ToggleButton { extern: micro.extern + "Penabled" }
+            NumBox   {
+                extern: micro.extern + "octavesize"
+                label: "per/oct"
+            }
+            Knob {
+                extern: micro.extern + "PAfreq"
+                type: "f"
+            }
+            Knob { extern: micro.extern + "PAnote" }
+            Knob { extern: micro.extern + "Pinvertupdowncenter" }
+        }
+    }
+    Widget {
+        Widget {
+            Widget {
+                Text {
+                    label: "name:"
+                    height: 0.8
+                }
+                TextLine {
+                    extern: micro.extern + "Pname"
+                }
+                function layout(l, selfBox) {
+                    Draw::Layout::hfill(l, selfBox, children, [0.3, 0.7], 0, 4)
+                }
+            }
+            Widget {
+                Text {
+                    label: "comment:"
+                    height: 0.8
+                }
+                TextLine {
+                    extern: micro.extern + "Pcomment"
+                }
+                function layout(l, selfBox) {
+                    Draw::Layout::hfill(l, selfBox, children, [0.3, 0.7], 0, 4)
+                }
+            }
+            function class_name() { "partsub" }
+            function layout(l, selfBox) {
+                Draw::Layout::vpack(l, selfBox, children, 0, 1, 4)
+            }
+        }
+        ParModuleRow {
+            Knob { extern: micro.extern + "Pscaleshift" }
+        }
+        function draw(vg) {
+            Draw::GradBox(vg, Rect.new(0,0,w,h))
+        }
+        function layout(l, selfBox)
+        {
+            children[0].fixed(l, selfBox, 0.0, 0, 0.9, 1)
+            children[1].fixed(l, selfBox, 0.9, 0, 0.1, 1)
+            selfBox
+        }
+    }
+    ZynTuning {}
+}

--- a/src/mruby-zest/example/ZynSendToGrid.qml
+++ b/src/mruby-zest/example/ZynSendToGrid.qml
@@ -1,0 +1,34 @@
+Widget {
+    Widget {
+        Widget {
+            id: title
+        }
+        function onSetup(old=nil)
+        {
+            return if children.length > 1
+            rows = 4
+            (rows).times do |x|
+                ch = Qml::ZynSendToRow.new(db)
+                ch.row_id = x
+                ch.cols   = 3
+                Qml::add_child(self, ch)
+            end
+        }
+
+        function class_name() { "send_to_grid" }
+
+        function layout(l, selfBox) {
+            Draw::Layout::vpack(l, selfBox, children)
+        }
+    }
+    function draw(vg) {
+        Draw::GradBox(vg, Rect.new(0,0,w,h))
+    }
+
+    function layout(l, selfBox) {
+        pad = 4
+        children[0].fixed_long(l, selfBox, 0, 0, 1, 1,
+        pad, pad, -2*pad, -2*pad)
+        selfBox
+    }
+}

--- a/src/mruby-zest/example/ZynSendToRow.qml
+++ b/src/mruby-zest/example/ZynSendToRow.qml
@@ -1,0 +1,33 @@
+Widget {
+    id: row
+    property Int row_id: 0
+    property Int cols:   4
+    TextSel {
+        id: send_name
+        extern: "/sysefx#{row.row_id}/efftype"
+    }
+
+    function onSetup(old=nil)
+    {
+        return if children.length > 1
+        send_name.label = (row.row_id+1).to_s + " reverb"
+        (cols-row_id).times do |x|
+            ch = Qml::HSlider.new(db)
+            ch.extern = "/sysefxfrom#{row_id}/to#{x+row_id+1}"
+            ch.tooltip = "Route from system effect #{row_id+1} to effect #{x+row_id+2}"
+            Qml::add_child(self, ch)
+        end
+    }
+
+    function layout(l, selfBox)
+    {
+        step = 1.0/(cols+1)
+        children[0].fixed(l, selfBox, 0, 0, step, 1)
+        off = step*(1+row_id)
+        (1...children.length).each do |bx|
+            children[bx].fixed(l, selfBox, off, 0, step, 1)
+            off += step
+        end
+        selfBox
+    }
+}

--- a/src/mruby-zest/example/ZynSettings.qml
+++ b/src/mruby-zest/example/ZynSettings.qml
@@ -1,0 +1,83 @@
+Widget {
+    Forms {
+        label: "Global Settings"
+        TextField {tooltip: "Sample Rate:"; label: "48 kHz"}
+        ToggleButton {tooltip: "Swap Stereo:"}
+        TextField {tooltip: "Oscil Size:";  label: "256 samples"}
+        TextField {tooltip: "Buffer Size:"; label: "128 samples"}
+        NumEntry {tooltip: "XML Compression:"}
+        Selector {tooltip: "Virtual Keyboard layout:"
+            options: ["QWERTY", "AZERTY"]
+        }
+        ToggleButton {tooltip: "Ignore MIDI Program Change:"}
+    }
+    Widget{
+    function draw(vg) {
+        vg.path do |v|
+            v.rect(0,0,w,h)
+            paint = v.linear_gradient(0,0,0,h,
+            Theme::ModuleGrad1, Theme::ModuleGrad2)
+            v.fill_paint paint
+            v.fill
+            v.stroke_color(color("000000"))
+            v.stroke
+        end
+    }
+        Text {
+            label: "bank root"
+        }
+        Widget {
+            Button {
+                label: "prioritize"
+            }
+            Button {
+                label: "+"
+            }
+            Button {
+                label: "-"
+            }
+            function layout(l, selfBox) {
+                Draw::Layout::hfill(l, selfBox, children, [0.7, 0.15, 0.15])
+            }
+        }
+        function layout(l, selfBox) {
+            Draw::Layout::vfill(l, selfBox, children, [0.9, 0.1])
+        }
+    }
+    Widget {
+    function draw(vg) {
+        vg.path do |v|
+            v.rect(0,0,w,h)
+            paint = v.linear_gradient(0,0,0,h,
+            Theme::ModuleGrad1, Theme::ModuleGrad2)
+            v.fill_paint paint
+            v.fill
+            v.stroke_color(color("000000"))
+            v.stroke
+        end
+    }
+        Text {
+            label: "preset roots"
+        }
+        Widget {
+            Button {
+                label: "prioritize"
+            }
+            Button {
+                label: "+"
+            }
+            Button {
+                label: "-"
+            }
+            function layout(l, selfBox) {
+                Draw::Layout::hfill(l, selfBox, children, [0.7, 0.15, 0.15])
+            }
+        }
+        function layout(l, selfBox) {
+            Draw::Layout::vfill(l, selfBox, children, [0.9, 0.1])
+        }
+    }
+    function layout(l, selfBox) {
+        Draw::Layout::hpack(l, selfBox, children, 0, 1, 10)
+    }
+}

--- a/src/mruby-zest/example/ZynSidebar.qml
+++ b/src/mruby-zest/example/ZynSidebar.qml
@@ -1,0 +1,121 @@
+Widget {
+    id: side
+    function class_name() { "ZynSidebar" }
+    SidebarButton {
+        id: partsetting
+        label: "part settings"
+        tooltip: "show part settings panel"
+        whenClick: lambda { side.set_content :part }
+    }
+    Indent {
+        id: part
+        KitButtons { sym: :part}
+    }
+    SidebarButton {
+        id: browser
+        label: "browser"
+        tooltip: "show instruments browser panel"
+        whenClick: lambda { side.set_content :banks }
+    }
+    SidebarButton {
+        id: mixer
+        label: "mixer"
+        tooltip: "show mixer settings panel"
+        whenClick: lambda { side.set_content :mixer }
+    }
+    SidebarButton {
+        id: kitedit
+        label: "kits"
+        tooltip: "show kits panel"
+        whenClick: lambda { side.set_content :kits }
+    }
+    Indent {
+        id: kit
+        KitButtons { sym: :kit}
+    }
+    SidebarButton {
+        id: arp
+        label: "macro learn"
+        tooltip: "show macro learn panel"
+        whenClick: lambda { side.set_content :automate }
+    }
+    SidebarButton {
+        id: eff
+        label: "effects"
+        tooltip: "show the effects panel"
+        whenClick: lambda { side.set_content :effects }
+    }
+    FancyButton {
+        id: add
+        label: "add"
+        value: true;
+        whenClick: lambda { side.set_content :add_synth }
+    }
+    Indent {
+        id: voices
+        KitButtons { sym: :voice; rows: 2}
+    }
+    FancyButton {
+        id: subButton
+        label: "sub"
+        whenClick: lambda { side.set_content :sub_synth }
+    }
+    FancyButton {
+        id: padButton
+        label: "pad"
+        whenClick: lambda { side.set_content :pad_synth }
+    }
+
+    function set_content(type, flag=nil)
+    {
+        tabs = [:part, :banks, :mixer, :kits, :automate, :effects,
+                :add_synth, :sub_synth, :pad_synth]
+        ind = 0
+        self.children.each do |ch|
+            if([Qml::FancyButton, Qml::SidebarButton].include? ch.class)
+                n = (type == tabs[ind])
+                if(n != ch.value)
+                    ch.value = n
+                    root.damage_item ch if root
+                end
+                ind += 1
+            end
+        end
+
+        parent.set_content(type) if flag.nil? && parent.respond_to?(:set_content)
+    }
+
+    function set_view()
+    {
+        prt  = root.get_view_pos(:part)
+        kid  = root.get_view_pos(:kit)
+        typ  = root.get_view_pos(:view)
+        padButton.extern = "/part#{prt}/kit#{kid}/Ppadenabled"
+        subButton.extern = "/part#{prt}/kit#{kid}/Psubenabled"
+        add.extern       = "/part#{prt}/kit#{kid}/Padenabled"
+        set_content(typ, true)
+    }
+
+    function onSetup(old=nil)
+    {
+        set_view
+    }
+
+    function layout(l, selfBox)
+    {
+        partsetting.fixed(l, selfBox, 0.1, 0,     0.8, 0.045)
+        part.fixed(l,        selfBox, 0.1, 0.05,  0.8, 0.19)
+        browser.fixed(l,     selfBox, 0.1, 0.248, 0.8, 0.045)
+        mixer.fixed(l,       selfBox, 0.1, 0.3,   0.8, 0.045)
+        kitedit.fixed(l,     selfBox, 0.1, 0.35,  0.8, 0.045)
+        kit.fixed(l,         selfBox, 0.1, 0.405, 0.8, 0.187)
+        arp.fixed(l,         selfBox, 0.1, 0.6,   0.8, 0.045)
+        eff.fixed(l,         selfBox, 0.1, 0.65,  0.8, 0.045)
+        add.fixed(l,         selfBox, 0.1, 0.7,   0.8, 0.045)
+        voices.fixed(l,      selfBox, 0.1, 0.76,  0.8, 0.10)
+        subButton.fixed(l,   selfBox, 0.1, 0.88,  0.8, 0.045)
+        padButton.fixed(l,   selfBox, 0.1, 0.94,  0.8, 0.045)
+
+        selfBox
+    }
+}

--- a/src/mruby-zest/example/ZynSubAmp.qml
+++ b/src/mruby-zest/example/ZynSubAmp.qml
@@ -1,0 +1,36 @@
+Widget {
+    id: subamp
+    extern: "/part0/kit0/subpars/"
+    //visual
+    ZynEnvEdit {
+        id: edit
+        extern: subamp.extern + "AmpEnvelope/"
+    }
+    Widget {
+        Group {
+            label: "general"
+            ParModuleRow {
+                ToggleButton { extern: subamp.extern + "Pstereo" }
+
+                Knob { extern: subamp.extern + "Volume" 
+                       type: :float
+                }
+                Knob { extern: subamp.extern + "PPanning" }
+                Knob { extern: subamp.extern + "AmpVelocityScaleFunction"
+                       type: :float
+                 }
+            }
+            Widget {}
+        }
+        ZynAmpEnv {
+            extern: subamp.extern+"AmpEnvelope/"
+            whenModified: lambda { edit.refresh }
+        }
+        function layout(l, selfBox) {
+            Draw::Layout::hpack(l, selfBox, children)
+        }
+    }
+    function layout(l, selfBox) {
+        Draw::Layout::vfill(l, selfBox, children, [0.6, 0.4])
+    }
+}

--- a/src/mruby-zest/example/ZynSubAmpbutton.qml
+++ b/src/mruby-zest/example/ZynSubAmpbutton.qml
@@ -1,0 +1,17 @@
+Group {
+            id: subamp
+            label: "general"
+            extern: "/part0/kit0/subpars/"
+            ParModuleRow {
+                ToggleButton { extern: subamp.extern + "Pstereo" }
+
+                Knob { extern: subamp.extern + "Volume" 
+                       type: :float
+                }
+                Knob { extern: subamp.extern + "PPanning" }
+                Knob { extern: subamp.extern + "AmpVelocityScaleFunction"
+                       type: :float
+                 }
+            }
+            Widget {}
+        }

--- a/src/mruby-zest/example/ZynSubAnalogFilter.qml
+++ b/src/mruby-zest/example/ZynSubAnalogFilter.qml
@@ -1,0 +1,7 @@
+  ZynAnalogFilter {
+            subsynth: true
+            toggleable: "/part0/kit0/subpars/PGlobalFilterEnabled"
+            extern: self.extern  + "GlobalFilter/"
+            whenClick: lambda { root.set_view_pos(:vis, :filter); parent.parent.parent.set_view() }
+            whenModified: lambda { elm = parent.parent.parent.row1.children[0]; elm.refresh if elm.respond_to? :refresh}
+        }

--- a/src/mruby-zest/example/ZynSubBandwidth.qml
+++ b/src/mruby-zest/example/ZynSubBandwidth.qml
@@ -1,0 +1,33 @@
+Widget {
+    id: subbw
+    extern: "/part0/kit0/subpars/"
+    //visual
+    ZynEnvEdit {
+        id: edit
+        extern: subbw.extern + "BandWidthEnvelope/"
+    }
+    Widget {
+        Group {
+            label: "general"
+            ParModuleRow {
+                Selector { extern: subbw.extern + "Pstart" }
+                NumEntry { extern: subbw.extern + "Pnumstages" }
+                Knob { extern: subbw.extern + "Pbandwidth" }
+                Knob { extern: subbw.extern + "Pbwscale" }
+            }
+            Widget {
+            }
+        }
+        ZynBandwidthEnv {
+            toggleable: subbw.extern + "PBandWidthEnvelopeEnabled"
+            whenModified: lambda {edit.refresh}
+            extern: subbw.extern + "BandWidthEnvelope/"
+        }
+        function layout(l, selfBox) {
+            Draw::Layout::hpack(l, selfBox, children)
+        }
+    }
+    function layout(l, selfBox) {
+        Draw::Layout::vfill(l, selfBox, children, [0.6, 0.4])
+    }
+}

--- a/src/mruby-zest/example/ZynSubFilter.qml
+++ b/src/mruby-zest/example/ZynSubFilter.qml
@@ -1,0 +1,105 @@
+Widget {
+    id: subfl
+
+    property Object valueRef: nil
+    property Symbol filtertype: nil
+
+    function change_vis(x)
+    {
+        root.set_view_pos(:vis, x)
+        root.change_view
+    }
+
+    //visual
+    Swappable {
+        id: edit
+    }
+
+    Widget {
+        ZynAnalogFilter {
+            id: gen
+            subsynth: true
+            toggleable: subfl.extern + "PGlobalFilterEnabled"
+            extern: subfl.extern + "GlobalFilter/"
+            whenClick: lambda { subfl.change_vis(:filter) }
+        }
+        ZynFilterEnv {
+            id: env
+            extern: subfl.extern+"GlobalFilterEnvelope/"
+            whenClick: lambda { subfl.change_vis(:envlope) }
+        }
+        function layout(l, selfBox) {
+            Draw::Layout::hpack(l, selfBox, children)
+        }
+    }
+
+    function layout(l, selfBox) {
+        Draw::Layout::vfill(l, selfBox, children, [0.6, 0.4])
+    }
+
+    function set_vis_env(ext)
+    {
+        edit.extern  = ext + "GlobalFilterEnvelope/"
+        edit.content = Qml::ZynEnvEdit
+        env.whenModified = lambda {
+            elm = edit.children[0]
+            elm.refresh if elm.respond_to? :refresh
+        }
+    }
+
+    function set_vis_filter(ext)
+    {
+        edit.extern = ext + "GlobalFilter/"
+        if(self.filtertype == :formant)
+            edit.content = Qml::ZynFormant
+        else
+            edit.extern = ext + "GlobalFilter/response"
+            edit.content = Qml::VisFilter
+        end
+        gen.whenModified = lambda {
+            elm = edit.children[0]
+            elm.refresh if elm.respond_to? :refresh
+        }
+    }
+
+    function set_view()
+    {
+        base = self.extern
+        vis  = root.get_view_pos(:vis)
+
+        types = [:envelope, :filter]
+        if(!types.include?(vis))
+            vis = :envelope
+            root.set_view_pos(:vis, vis)
+        end
+
+        if(vis == :envelope)
+            set_vis_env(base)
+        elsif(vis == :filter)
+            set_vis_filter(base)
+        end
+    }
+
+    onExtern: {
+        subfl.add_cat()
+    }
+
+    function add_cat()
+    {
+        return if self.valueRef
+        if(self.valueRef.nil?)
+            path = self.extern + "GlobalFilter/Pcategory"
+            self.valueRef = OSC::RemoteParam.new($remote, path)
+            self.valueRef.mode = :full
+            self.valueRef.callback = lambda {|x|
+                subfl.filtertype = [:analog, :formant, :statevar][x]
+            }
+        end
+    }
+
+    function onSetup(old=nil) {
+
+        gen.move_sense()
+        set_view()
+    }
+}

--- a/src/mruby-zest/example/ZynSubFilterEnv.qml
+++ b/src/mruby-zest/example/ZynSubFilterEnv.qml
@@ -1,0 +1,3 @@
+ZynFilterEnv{
+    whenClick: lambda { root.set_view_pos(:vis, :envelope); parent.parent.parent.set_view() }
+}

--- a/src/mruby-zest/example/ZynSubFreq.qml
+++ b/src/mruby-zest/example/ZynSubFreq.qml
@@ -1,0 +1,38 @@
+Widget {
+    id: subfq
+    extern: "/part0/kit0/subpars/"
+    //visual
+    ZynEnvEdit {
+        id: edit
+        extern: subfq.extern + "FreqEnvelope/"
+    }
+    Widget {
+        Group {
+            label: "general"
+            ParModuleRow {
+                Knob {     extern: subfq.extern + "PDetune" }
+                Selector { extern: subfq.extern + "PDetuneType" }
+                NumEntry { extern: subfq.extern + "octave" }
+                Knob     { extern: subfq.extern + "PBendAdjust"}
+                //eqt
+
+            }
+            ParModuleRow {
+                ToggleButton {   extern: subfq.extern + "Pfixedfreq" }
+                Knob   {   extern: subfq.extern + "PfixedfreqET" }
+                Knob     { extern: subfq.extern + "POffsetHz"}
+            }
+        }
+        ZynFreqEnv {
+            toggleable: subfq.extern + "PFreqEnvelopeEnabled"
+            extern: subfq.extern+"FreqEnvelope/"
+            whenModified: lambda { edit.refresh }
+        }
+        function layout(l, selfBox) {
+            Draw::Layout::hpack(l, selfBox, children)
+        }
+    }
+    function layout(l, selfBox) {
+        Draw::Layout::vfill(l, selfBox, children, [0.6, 0.4])
+    }
+}

--- a/src/mruby-zest/example/ZynSubFreqEnv.qml
+++ b/src/mruby-zest/example/ZynSubFreqEnv.qml
@@ -1,0 +1,4 @@
+ZynFreqEnv {
+    toggleable: "/part0/kit0/subpars/PFreqEnvelopeEnabled"
+    extern: self.extern+"FreqEnvelope/"
+    }

--- a/src/mruby-zest/example/ZynSubFreqbutton.qml
+++ b/src/mruby-zest/example/ZynSubFreqbutton.qml
@@ -1,0 +1,18 @@
+ Group {
+            id: subfqbutton
+            extern: "/part0/kit0/subpars/"
+            label: "general"
+            ParModuleRow {
+                Knob {     extern: subfqbutton.extern + "PDetune" }
+                Selector { extern: subfqbutton.extern + "PDetuneType" }
+                NumEntry { extern: subfqbutton.extern + "octave" }
+                Knob     { extern: subfqbutton.extern + "PBendAdjust"}
+                //eqt
+
+            }
+            ParModuleRow {
+                ToggleButton {   extern: subfqbutton.extern + "Pfixedfreq" }
+                Knob   {   extern: subfqbutton.extern + "PfixedfreqET" }
+                Knob     { extern: subfqbutton.extern + "POffsetHz"}
+            }
+        }

--- a/src/mruby-zest/example/ZynSubGlobal.qml
+++ b/src/mruby-zest/example/ZynSubGlobal.qml
@@ -1,0 +1,174 @@
+Widget {
+    id: subglobal
+
+    property Object valueRef: nil
+    property Symbol filtertype: nil
+
+
+    function layout(l, selfBox) {
+        Draw::Layout::vfill(l, selfBox, children, [0.55, 0.4, 0.05])
+    }
+
+    Swappable {
+        id: row1
+        content: Qml::LfoVis
+
+        function setDataVis(type, tab) {
+            root.set_view_pos(:vis, type)
+            root.change_view
+        }
+    }
+
+  Widget 
+    {
+        id: row2
+        function layout(l, selfBox) {
+            Draw::Layout::hpack(l, selfBox, children)
+        }
+
+
+        Swappable { id: gen }
+        Swappable { id: env }
+    }
+
+    Widget {
+        id: footer
+
+        function layout(l, selfBox) {
+            Draw::Layout::tabpack(l, selfBox, self)
+        }
+
+        function setTab(id)
+        {
+            (0..2).each do |ch_id|
+                children[ch_id].value = (ch_id == id)
+                children[ch_id].damage_self
+            end
+            mapping = {0 => :amplitude,
+                       1 => :frequency,
+                       2 => :filter}
+            root.set_view_pos(:subsubview, mapping[id])
+            root.change_view
+        }
+
+        TabButton { label: "amplitude"; whenClick: lambda {footer.setTab(0)}; highlight_pos: :top}
+        TabButton { label: "frequency"; whenClick: lambda {footer.setTab(1)}; highlight_pos: :top}
+        TabButton { label: "filter";    whenClick: lambda {footer.setTab(2)}; highlight_pos: :top}
+    }
+
+ 
+     function set_view()
+    {
+        subsubview = root.get_view_pos(:subsubview)
+        types = [:amplitude, :frequency, :filter, :envelope]
+        if(!types.include?(subsubview))
+            subsubview = :amplitude
+            root.set_view_pos(:subsubview, subsubview)
+        end
+
+        vis = root.get_view_pos(:vis)
+        types = [:amplitude, :frequency, :filter, :oscilloscope]
+        if(!types.include?(vis))
+            vis = :amplitude
+            root.set_view_pos(:vis, vis)
+        end
+
+        if(subsubview == :amplitude)
+            set_amp(self.extern)
+        elsif(subsubview == :frequency)
+            set_freq(self.extern)
+        elsif(subsubview == :filter)
+            set_filter(self.extern)
+        end
+
+         if(vis == :amplitude)
+            set_vis_amp(self.extern)
+        elsif(vis == :frequency)
+            set_vis_freq(self.extern)
+        elsif(vis == :filter)
+            set_vis_filter(self.extern)
+        elsif(vis == :oscilloscope)
+            set_vis_oscilloscope()
+        elsif(vis == :envelope)
+            set_vis_env(self.extern)
+        end
+        db.update_values
+    }
+
+      function set_amp(base)
+    {
+        footer.children[0].value = true
+        gen.extern = base
+        env.extern  = base + "AmpEnvelope/"
+        gen.content = Qml::ZynSubAmpbutton
+        env.content = Qml::ZynAmpEnv
+    }
+
+    function set_freq(base)
+    {
+        footer.children[1].value = true
+        gen.extern = base
+        env.extern  = base + "FreqEnvelope/"
+        gen.content = Qml::ZynSubFreqbutton
+        env.content = Qml::ZynSubFreqEnv
+    }
+
+    function set_filter(base)
+    {
+        footer.children[2].value = true
+        gen.extern = base + "GlobalFilter/"
+        env.extern  = base + "GlobalFilterEnvelope/"
+        gen.content = Qml::ZynSubAnalogFilter
+        env.content = Qml::ZynSubFilterEnv
+        
+    }
+
+      function set_vis_amp(ext)
+    {
+        row1.extern  = ext + "AmpEnvelope/"
+        row1.content = Qml::ZynEnvEdit
+    }
+
+    function set_vis_filter(ext)
+    {
+        add_cat()
+        #row1.extern  = ext + "FreqEnvelope/"
+
+         if(self.filtertype == :formant)
+            row1.content = Qml::ZynFormant
+        else
+            row1.extern = ext + "GlobalFilter/response"
+            row1.content = Qml::VisFilter
+        end
+    }
+
+    function set_vis_oscilloscope()
+    {
+        row1.content = Qml::ZynSubOscilloscope
+    }
+
+     function set_vis_env(ext)
+    {
+        row1.extern  = ext + "GlobalFilterEnvelope/"
+        row1.content = Qml::ZynEnvEdit
+        row1.whenModified = lambda {
+            elm = row1.children[0]
+            elm.refresh if elm.respond_to? :refresh
+        }
+    }
+
+      function add_cat()
+    {
+        return if self.valueRef
+        if(self.valueRef.nil?)
+            path = self.extern + "GlobalFilter/Pcategory"
+            self.valueRef = OSC::RemoteParam.new($remote, path)
+            self.valueRef.mode = :full
+            self.valueRef.callback = lambda {|x|
+                subglobal.filtertype = [:analog, :formant, :statevar][x]
+            }
+        end
+    }
+
+    
+}

--- a/src/mruby-zest/example/ZynSubHarmonic.qml
+++ b/src/mruby-zest/example/ZynSubHarmonic.qml
@@ -1,0 +1,63 @@
+Widget {
+    id: harm
+
+    VisSubHarmonics {
+        id:     sub_harmonics
+        extern: harm.extern + "response"
+    }
+    Widget {
+        ParModuleRow {
+            lsize: 0.3
+            TriggerButton   {
+                label: "clear"
+                whenValue: lambda {harm.clear}
+            }
+            Selector {
+                extern: harm.extern + "Phmagtype"
+                whenValue: lambda {sub_harmonics.refresh}
+            }
+            NumEntry {
+                label:  "stages"
+                extern: harm.extern + "Pnumstages"
+                whenValue: lambda {sub_harmonics.refresh}
+            }
+            Widget { label: "          " }
+            Selector {
+                //layoutOpts: [:no_constraint]
+                extern: harm.extern+"POvertoneSpread.type"
+                whenValue: lambda {sub_harmonics.refresh}
+            }
+            Knob {
+                extern: harm.extern+"POvertoneSpread.par1"
+                whenValue: lambda {sub_harmonics.refresh}
+            }
+            Knob {
+                extern: harm.extern+"POvertoneSpread.par2"
+                whenValue: lambda {sub_harmonics.refresh}
+            }
+            Knob {
+                extern: harm.extern+"POvertoneSpread.par3"
+                whenValue: lambda {sub_harmonics.refresh}
+            }
+        }
+
+        function draw(vg) {
+            Draw::GradBox(vg, Rect.new(0,0,w,h))
+        }
+    }
+
+    HarmonicEdit {
+        id: edit
+        extern: harm.extern
+        type:   :subsynth
+        whenValue: lambda { sub_harmonics.refresh }
+    }
+    function class_name() { "subsynth" }
+    function layout(l, selfBox) {
+        Draw::Layout::vfill(l, selfBox, children, [0.50, 0.10, 0.40])
+    }
+    function clear() {
+        edit.clear
+        sub_harmonics.refresh
+    }
+}

--- a/src/mruby-zest/example/ZynSubOscilloscope.qml
+++ b/src/mruby-zest/example/ZynSubOscilloscope.qml
@@ -1,0 +1,11 @@
+Group_nocp {
+    ZynOscilloscope{
+        options: ["> filter", "> amp int", "> legato"]
+        opt_vals: ["/part0/kit0/subpars/noteout/filter","/part0/kit0/subpars/noteout/amp_int","/part0/kit0/subpars/noteout/legato"] 
+    }
+
+    ZynOscilloscope{
+        options: ["> filter", "> amp int", "> legato"]
+        opt_vals: ["/part0/kit0/subpars/noteout/filter","/part0/kit0/subpars/noteout/amp_int","/part0/kit0/subpars/noteout/legato"] 
+    }
+}

--- a/src/mruby-zest/example/ZynSubSynth.qml
+++ b/src/mruby-zest/example/ZynSubSynth.qml
@@ -1,0 +1,87 @@
+Widget {
+    id: subsynth
+
+
+    TabGroup {
+        id: subtabs
+        TabButton {label: "harmonic" }
+        TabButton {label: "global" }
+        TabButton {label: "bandwidth" }
+
+        TriggerButton {
+            id: oscillbutton
+            layoutOpts: [:no_constraint];
+            label: "   oscilloscope"
+            whenValue: lambda {
+            root.set_view_pos(:subview, :sub_global)
+            root.set_view_pos(:vis, :oscilloscope)
+            root.change_view
+            subsynth.turn_off_tab()  
+             }
+        }
+
+        CopyButton  { id: cpy; extern: subsynth.extern}
+        PasteButton { extern: subsynth.extern}
+
+        function layout(l, selfBox) {
+            selfBox = Draw::Layout::tabpack(l, selfBox, self, oscillbutton)
+        }
+
+        function set_tab(wid)
+        {
+            selected = get_tab wid
+
+            #Define a mapping from tabs to values
+            mapping = {0 => :harmonic,
+                       1 => :sub_global,
+                       2 => :bandwidth
+                       }
+            return if !mapping.include?(selected)
+            root.set_view_pos(:subview, mapping[selected])
+            root.change_view
+        }
+    }
+    
+    Swappable { id: swap }
+
+    function layout(l, selfBox) {
+        Draw::Layout::vfill(l, selfBox, children, [0.05, 0.95])
+    }
+
+    function set_view()
+    {
+        vw = root.get_view_pos(:subview)
+        mapping = {:harmonic  => Qml::ZynSubHarmonic,
+                   :sub_global => Qml::ZynSubGlobal,
+                   :bandwidth => Qml::ZynSubBandwidth}
+        tabid   = {:harmonic  => 0,
+                   :sub_global => 1,
+                   :bandwidth => 2}
+        if(!mapping.include?(vw))
+            root.set_view_pos(:subview, :harmonic)
+            vw = :harmonic
+        end
+
+        swap.extern  = subsynth.extern
+        swap.content = mapping[vw]
+        subtabs.children[tabid[vw]].value = true
+    }
+
+    function onSetup(old=nil)
+    {
+        set_view
+    }
+
+    function turn_off_tab()
+    {
+        n = 5
+        (0..n).each do |ch_id|
+            child = subtabs.children[ch_id]
+           
+                if(child.value)
+                    child.value = false
+                    child.damage_self
+                end
+            end
+    }
+}

--- a/src/mruby-zest/example/ZynTuning.qml
+++ b/src/mruby-zest/example/ZynTuning.qml
@@ -1,0 +1,100 @@
+Widget {
+    id: scale
+    function load_scale(type)
+    {
+        @opt = type
+        win = window()
+        wid = Qml::FileSelector.new(db)
+        wid.whenValue = lambda { |x| scale.load_scale_file(x)}
+        wid.x = 0
+        wid.y = 0
+        wid.w = win.w
+        wid.h = win.h
+        wid.pat = type
+        Qml::add_child(win, wid)
+        self.db.update_values
+        setup_widget wid
+        self.db.update_values
+
+        if(root)
+            root.smash_layout
+            root.damage_item(win, :all)
+        end
+    }
+    
+    function setup_widget(w)
+    {
+        w.onSetup()
+        w.children.each do |c|
+            setup_widget(c)
+        end
+    }
+
+    function load_scale_file(val)
+    {
+        $remote.action("/load_kbm", val) if @opt == ".kbm"
+        $remote.action("/load_scl", val) if @opt == ".scl"
+        $remote.action("/microtonal/mapping")
+        $remote.action("/microtonal/tunings")
+    }
+
+    Widget {
+        Group {
+            id: tune
+            label: "tunings"
+            extern: scale.extern + "tunings"
+            copyable: false
+            TextEdit {
+                height: 0.05
+                extern: "/microtonal/tunings"
+            }
+            //ColorBox { pad: 0.03; bg: color("222222") }
+        }
+        Group {
+            id: mapp
+            label: "key mapping"
+            extern: scale.extern + "mapping"
+            copyable: false
+            TextEdit {
+                height: 0.05
+                extern: "/microtonal/mapping"
+            }
+            //ColorBox { pad: 0.03; bg: color("222222") }
+        }
+        function class_name() { "partsub" }
+        function layout(l, selfBox) {
+            Draw::Layout::hfill(l, selfBox, children, [0.5, 0.5])
+        }
+    }
+    ColorBox {
+        bg: Theme::GeneralBackground
+        ParModuleRow {
+            TriggerButton {
+                label: "import .scl"
+                tooltip: "load microtonal scale"
+                whenValue: lambda {scale.load_scale(".scl")}
+            }
+            TriggerButton {
+                label: "import .kbm"
+                tooltip: "load keyboard mapping"
+                whenValue: lambda {scale.load_scale(".kbm")}
+            }
+            TriggerButton {
+                label: "retune"
+                whenValue: lambda { scale.apply }
+                active: false
+            }
+        }
+    }
+
+    function class_name() { "part" }
+    function layout(l, selfBox) {
+        Draw::Layout::vfill(l, selfBox, children, [0.9, 0.1])
+    }
+
+    function apply() {
+        return false
+        tune.apply
+        mapp.apply
+    }
+}

--- a/src/mruby-zest/example/ZynWip.qml
+++ b/src/mruby-zest/example/ZynWip.qml
@@ -1,0 +1,46 @@
+Widget {
+    ZynWipTwo {}
+
+    function layout(l, selfBox)
+    {
+        children[0].fixed(l,        selfBox, 0.05, 0.05, 0.95, 0.85)
+    }
+
+    function draw(vg)
+    {
+        draw2(vg)
+    }
+
+    function draw2(vg)
+    {
+        vg.text_align NVG::ALIGN_MIDDLE | NVG::ALIGN_CENTER
+        vg.font_size 30.0
+        vg.fill_color color("ffffff")
+        vg.text(550, 10, "Format Vowel (Live?) View [radius=1.0/q]")
+        vg.text(20, 470, "-10 dB")
+        vg.text(20, 300, "-5 dB")
+        vg.text(20, 100, "0 dB")
+        vg.text(20, 10, "10 dB")
+        
+        vg.text(150, 500, "10 Hz")
+        vg.text(550, 500, "100 Hz")
+        vg.text(950, 500, "1 kHz")
+
+    }
+    function draw1(vg)
+    {
+        vg.text_align NVG::ALIGN_MIDDLE | NVG::ALIGN_CENTER
+        vg.font_size 30.0
+        vg.fill_color color("ffffff")
+        vg.text(550, 10, "Format Sequence View")
+        vg.text(20, 470, "0 Hz")
+        vg.text(20, 300, "100 Hz")
+        vg.text(20, 100, "1k Hz")
+        vg.text(20, 10, "10k Hz")
+        
+        vg.text(150, 500, "Seq Pos 1")
+        vg.text(550, 500, "Seq Pos 2")
+        vg.text(950, 500, "Seq Pos 3")
+
+    }
+}

--- a/src/mruby-zest/example/ZynWipTwo.qml
+++ b/src/mruby-zest/example/ZynWipTwo.qml
@@ -1,0 +1,256 @@
+Widget {
+    function circ(vg, cx, cy, r, col)
+    {
+        vg.path do
+            #vg.arc(cx, cy, r, 0, 3.14, 1)
+            vg.circle(cx, cy, r)
+            vg.fill_color col
+            vg.fill
+        end
+    }
+
+    function circ_mag(vg, cx, cy, h, col)
+    {
+        vg.path do
+            vg.rect(cx-5, cy-h, 10, 2*h)
+            vg.fill_color col
+            vg.fill
+        end
+    }
+
+    function circ_link(vg, x1, y1, m1, x2, y2, m2, col)
+    {
+        vg.path do
+            vg.move_to(x1+5, y1-m1)
+            vg.line_to(x2-5, y2-m2)
+            vg.line_to(x2-5, y2+m2)
+            vg.line_to(x1+5, y1+m1)
+            vg.close_path
+            vg.fill
+        end
+        angle = Math.atan2(y2-y1, x2-x1)
+        xdiff = Math.cos(angle)*20
+        ydiff = Math.sin(angle)*20
+        vg.path do
+            vg.move_to(x1+xdiff, y1+ydiff)
+            vg.line_to(x2-xdiff, y2-ydiff)
+            vg.stroke_color col
+            vg.stroke
+        end
+    }
+
+    function circ_text(vg, bx, by, label)
+    {
+        vg.text_align NVG::ALIGN_MIDDLE | NVG::ALIGN_CENTER
+        vg.font_size 30.0
+        vg.fill_color color("ffffff")
+        vg.text(bx, by, label)
+    }
+
+    function draw(vg)
+    {
+        draw2(vg)
+    }
+    function draw1(vg)
+    {
+        fixedpad = 5
+        pad  = 0
+        pad2 = (1-2*pad)
+        box = Rect.new(w*pad  + fixedpad,   h*pad  + fixedpad,
+                       w*pad2 - 2*fixedpad, h*pad2 - 2*fixedpad)
+        vg.path do
+            vg.rect(box.x, box.y, box.w, box.h)
+            vg.fill_color Theme::VisualBackground
+            vg.fill
+        end
+        Draw::Grid::linear_x(vg, 1, 10, box)
+        vg.stroke_width 1.5
+        Draw::Grid::log_y(vg, 1, 10000, box)
+
+        radius = 20
+
+        bx1 = box.x + 0.1*box.w
+        by1 = box.y + 0.2*box.h
+        m1  = 40
+
+        bx2 = box.x+0.5*box.w
+        by2 = box.y+0.4*box.h
+        m2  = 60
+        
+        bx3 = box.x+0.9*box.w
+        by3 = box.y+0.3*box.h
+        m3  = 20
+
+        green = color("00ff00", 100)
+        lab   = "1"
+
+        circ(vg, bx1, by1, radius, green)
+        circ(vg, bx2, by2, radius, green)
+        circ(vg, bx3, by3, radius, green)
+
+        circ_mag(vg, bx1, by1, m1, green)
+        circ_mag(vg, bx2, by2, m2, green)
+        circ_mag(vg, bx3, by3, m3, green)
+
+        circ_link(vg, bx1, by1, m1, bx2, by2, m2, green)
+        circ_link(vg, bx2, by2, m2, bx3, by3, m3, green)
+        circ_text(vg, bx1, by1, lab)
+        circ_text(vg, bx2, by2, lab)
+        circ_text(vg, bx3, by3, lab)
+        
+        green = color("00ffff", 100)
+        lab   = "2"
+        #bx1 = box.x + 0.2*box.w
+        by1 = box.y + 0.9*box.h
+        m1  = 10
+
+        #bx2 = box.x+0.4*box.w
+        by2 = box.y+0.8*box.h
+        m2  = 100
+        
+        #bx3 = box.x+0.6*box.w
+        by3 = box.y+0.8*box.h
+        m3  = 90
+        
+        circ(vg, bx1, by1, radius, green)
+        circ(vg, bx2, by2, radius, green)
+        circ(vg, bx3, by3, radius, green)
+
+        circ_mag(vg, bx1, by1, m1, green)
+        circ_mag(vg, bx2, by2, m2, green)
+        circ_mag(vg, bx3, by3, m3, green)
+
+        circ_link(vg, bx1, by1, m1, bx2, by2, m2, green)
+        circ_link(vg, bx2, by2, m2, bx3, by3, m3, green)
+        circ_text(vg, bx1, by1, lab)
+        circ_text(vg, bx2, by2, lab)
+        circ_text(vg, bx3, by3, lab)
+        
+        
+        green = color("ffff00", 100)
+        lab   = "3"
+        #bx1 = box.x + 0.2*box.w
+        by1 = box.y + 0.4*box.h
+        m1  = 10
+
+        #bx2 = box.x+0.4*box.w
+        by2 = box.y+0.5*box.h
+        m2  = 2
+        
+        #bx3 = box.x+0.6*box.w
+        by3 = box.y+0.6*box.h
+        m3  = 25
+        
+        circ(vg, bx1, by1, radius, green)
+        circ(vg, bx2, by2, radius, green)
+        circ(vg, bx3, by3, radius, green)
+
+        circ_mag(vg, bx1, by1, m1, green)
+        circ_mag(vg, bx2, by2, m2, green)
+        circ_mag(vg, bx3, by3, m3, green)
+
+        circ_link(vg, bx1, by1, m1, bx2, by2, m2, green)
+        circ_link(vg, bx2, by2, m2, bx3, by3, m3, green)
+        circ_text(vg, bx1, by1, lab)
+        circ_text(vg, bx2, by2, lab)
+        circ_text(vg, bx3, by3, lab)
+        
+        lab   = "4"
+        green = color("ff0000", 100)
+        #bx1 = box.x + 0.2*box.w
+        by1 = box.y + 0.1*box.h
+        m1  = 10
+
+        #bx2 = box.x+0.4*box.w
+        by2 = box.y+0.15*box.h
+        m2  = 35
+        
+        #bx3 = box.x+0.6*box.w
+        by3 = box.y+0.6*box.h
+        m3  = 25
+        
+        circ(vg, bx1, by1, radius, green)
+        circ(vg, bx2, by2, radius, green)
+        #circ(vg, bx3, by3, radius, green)
+
+        circ_mag(vg, bx1, by1, m1, green)
+        circ_mag(vg, bx2, by2, m2, green)
+        #circ_mag(vg, bx3, by3, m3, green)
+
+        circ_link(vg, bx1, by1, m1, bx2, by2, m2, green)
+        #circ_link(vg, bx2, by2, m2, bx3, by3, m3, green)
+        circ_text(vg, bx1, by1, lab)
+        circ_text(vg, bx2, by2, lab)
+        #circ_text(vg, bx3, by3, lab)
+
+    }
+
+    function circ_filter(vg, bx, by, br, lab, col, box)
+    {
+        circ(vg, bx, by, br, col)
+
+        delta = (box.h-by)/2.0
+        bot_left = [bx-delta-br, box.h]
+        bot_right = [bx+delta+br, box.h]
+
+        #vg.path do
+        #    vg.move_to(bx-br, by)
+        #    vg.line_to(bot_left[0], bot_left[1])
+        #    vg.line_to(bot_right[0], bot_right[1])
+        #    vg.line_to(bx+br, by)
+        #    vg.fill_color(col)
+        #    vg.fill
+        #end
+        
+        circ_text(vg, bx, by, lab)
+    }
+
+    function draw2(vg)
+    {
+        fixedpad = 5
+        pad  = 0
+        pad2 = (1-2*pad)
+        box = Rect.new(w*pad  + fixedpad,   h*pad  + fixedpad,
+                       w*pad2 - 2*fixedpad, h*pad2 - 2*fixedpad)
+        vg.path do
+            vg.rect(box.x, box.y, box.w, box.h)
+            vg.fill_color Theme::VisualBackground
+            vg.fill
+        end
+        Draw::Grid::log_x(vg, 1, 10000, box)
+        vg.stroke_width 1.5
+        Draw::Grid::linear_y(vg, 1, 50, box)
+
+        radius = 10
+        green = color("00ff00", 100)
+        lab   = "1"
+        bx1 = box.x + 0.1*box.w
+        by1 = box.y + 0.8*box.h
+
+        circ_filter(vg, bx1, by1, radius, lab, green, box)
+
+        radius = 30
+        green = color("00ffff", 100)
+        lab   = "2"
+        bx1 = box.x + 0.2*box.w
+        by1 = box.y + 0.75*box.h
+        
+        circ_filter(vg, bx1, by1, radius, lab, green, box)
+
+        radius = 20
+        green = color("ffff00", 100)
+        lab   = "3"
+        bx1 = box.x + 0.6*box.w
+        by1 = box.y + 0.2*box.h
+
+        circ_filter(vg, bx1, by1, radius, lab, green, box)
+
+        radius = 90
+        green = color("ff0000", 100)
+        lab   = "4"
+        bx1 = box.x + 0.8*box.w
+        by1 = box.y + 0.4*box.h
+
+        circ_filter(vg, bx1, by1, radius, lab, green, box)
+    }
+}

--- a/src/mruby-zest/mrbgem.rake
+++ b/src/mruby-zest/mrbgem.rake
@@ -1,0 +1,14 @@
+MRuby::Gem::Specification.new('mruby-zest') do |spec|
+  spec.license = 'MIT'
+  spec.author  = 'Mark McCurry'
+
+  # Default build files
+  # spec.rbfiles = Dir.glob("#{dir}/mrblib/*.rb")
+  # spec.objs = Dir.glob("#{dir}/src/*.{c,cpp,m,asm,S}").map { |f| objfile(f.relative_path_from(dir).pathmap("#{build_dir}/%X")) }
+  # spec.test_rbfiles = Dir.glob("#{dir}/test/*.rb")
+  # spec.test_objs = Dir.glob("#{dir}/test/*.{c,cpp,m,asm,S}").map { |f| objfile(f.relative_path_from(dir).pathmap("#{build_dir}/%X")) }
+  # spec.test_preload = 'test/assert.rb'
+
+  # Values accessible as TEST_ARGS inside test scripts
+  # spec.test_args = {'tmp_dir' => Dir::tmpdir}
+end

--- a/src/mruby-zest/mrblib/build.rb
+++ b/src/mruby-zest/mrblib/build.rb
@@ -1,0 +1,385 @@
+#load '../../mruby-qml-parse/mrblib/main.rb'
+#load "database.rb"
+TotalObjs = 0
+class ProgBuildVM
+    #SC = "/start_context"
+    #CC = "/create_class"
+    #EI = "/extend_instance"
+    #AA = "/add_attr"
+    #CA = "/connect_attr"
+    #SA = "/set_attr"
+    #SP = "/set_parent"
+    #AM = "/add_method"
+    #CI = "/commit_instance"
+    #EC = "/end_context"
+    attr_accessor :instance
+    def ensure_properties(value)
+        if(!value.respond_to?(:properties))
+            value.instance_eval{@properties = Hash.new}
+            value.instance_eval{def properties;@properties;end}
+        end
+    end
+
+    def ensure_database(value, database)
+        #puts "Ensuring database = '#{database}'"
+        if(!value)
+            raise "Cannot ensure_database on nil"
+        end
+        if(!value.respond_to?(:db))
+            value.instance_eval{def db;@db;end}
+            value.instance_eval{def db=(db);@db=db;end}
+            value.db = database
+        else
+            #puts "value.methods = #{value.methods.sort}"
+            #puts "value.db = '#{value.db}'"
+        end
+        if(!value.respond_to?(:ui_path))
+            value.instance_eval{def ui_path;@ui_path;end}
+            value.instance_eval{def ui_path=(ui_path);@ui_path=ui_path;end}
+            value.ui_path = "/ui/"
+        end
+    end
+
+    def add_func(value, name, args, code, file, line)
+        #puts "Adding Function '#{name}'..."
+        eval("value.instance_eval{def #{name}(#{args});#{code};end}", nil, file, line)
+    end
+
+    def add_attr(value, name, type, file, line)
+        #Add Fastpath for layout terms
+        if(["x","y","w","h"].include?(name) && false)
+            value.instance_eval("def #{name};@#{name};end", file, line)
+            value.instance_eval("def #{name}=(val);@#{name}=val;end", file, line)
+        else
+            #puts "adding #{name}"
+            ensure_properties(value)
+            prop = Property.new(name)
+            #puts "value.properties = '#{value.properties.class}'<#{value.properties.nil?}>"
+            value.properties[name] = prop
+            value.db.add_property prop
+            value.instance_eval("def #{name};
+                                prop = @properties[\"#{name}\"]
+                                @db.load_property(prop); end", file, line)
+            value.instance_eval("def #{name}=(val);
+                                prop = @properties[\"#{name}\"]
+                                @db.write_property(prop,val);
+                                prop.onWrite.each do |cb|
+                                    cb.call
+                                    end; end", file, line)
+        end
+    end
+
+    def update_ui_path(value, npath)
+        #puts "update_ui_path(#{value}, #{npath})"
+        value.ui_path = npath
+        value.properties.each do |key,p|
+            p.ppath = npath
+        end
+        idx = 1
+        value.children.each do |c|
+            update_ui_path(c, "#{npath}#{idx}/")
+        end
+    end
+
+    def update_path_recursive(base, npath)
+        children = base.children
+        if(!children.empty?)
+            #TODO this only works one level deep...
+            children.each_with_index do |x,i|
+                update_ui_path(children[i], "#{npath}#{i}/")
+                update_path_recursive(children[i], "#{npath}#{i}/")
+            end
+        end
+    end
+
+    def consume_instruction(inst)
+        #puts "consuming #{inst}"
+        case inst[0]
+        when SC
+            #puts "Ignoring..."
+            inst
+        when CC
+            #pp inst
+            TotalObjs += 1
+            t1 = Time.new
+            id = inst[2]
+            @alloc_id << id
+            obj = nil
+            if(@global_ir.include? inst[1])
+                #puts "Building Subobject '#{inst[1]}'"
+                obj = ProgBuildVM.new(@global_ir[inst[1]], @global_ir, @db, @depth+1).instance
+                ensure_database(obj, @db)
+            else
+                obj = Kernel.const_get(inst[1]).new
+                ensure_database(obj, @db)
+            end
+            if(inst.length == 4 && inst[3] != "anonymous")
+                @context[inst[3]] = obj
+            end
+            if(@objs.length+1 < id)
+                raise "invalid id recorded"
+            elsif(@objs.length < id)
+                @objs << obj
+            else
+                if(@objs[id])
+                    puts "Overwriting Object Slot, Be Prepared For Weirdness"
+                    puts "id=#{id}"
+                    puts @alloc_id
+                    puts @objs[id]
+                end
+                @objs[id] = obj
+            end
+            puts " "*@depth+"Creating #{inst[1]} (#{TotalObjs}) <#{1000*(Time.new-t1)}ms>"
+        when AA
+            (id,name,type) = inst[1..3]
+            #puts "Adding attribute..."
+            add_attr(@objs[id], name, type, inst.file, inst.line)
+        when AM
+            #puts "Adding Function..."
+            (obj,name, args, value) = inst[1..4]
+            add_func(@objs[obj], name, args, value, inst.file, inst.line)
+        when SP
+            (child, parent) = inst[1..2]
+            #puts "Setting parent..."
+            #puts "child=#{child},parent=#{parent}"
+            #puts "parent = #{@objs[parent]}"
+            #puts "child  = #{@objs[child]}"
+            #puts "parent-path = #{@objs[parent].ui_path}"
+            children = @objs[parent].children
+            children << @objs[child]
+            @objs[parent].children = children
+            npath = "#{@objs[parent].ui_path}#{children.length}/"
+            update_ui_path(@objs[child],npath)
+            #puts "think of the children #{@objs[child].children}"
+            update_path_recursive(@objs[child], npath)
+        when CA
+            #puts "Connecting field..."
+            (obj, field, value) = inst[1..3]
+            if(!field.match(/^on/))
+                if((["x","y","w","h"].include?(field)) && false)
+                    @objs[obj].send(field+"=",eval(value))
+                else
+                    if(!@objs[obj].properties.include?(field))
+                        puts "cannot connect field #{field}..."
+                    else
+                        @db.connect_property(@objs[obj].properties[field], value, @context)
+                    end
+                end
+                #instance[obj].send(field+"=",value)
+            else
+                field    = field[2..-1]
+                field[0] = field[0].downcase
+                @db.connect_watcher(@objs[obj].properties[field], value, @context)
+            end
+        when CI
+            obj = inst[1]
+            #puts "Ignoring..."
+        when EC
+            #puts "Ignoring..."
+        else
+            puts "Unknown Opcode..."
+            puts inst
+        end
+    end
+
+    def obj_ids(ir)
+        ids = []
+        ir.each do |inst|
+            op = inst[0]
+            ids << inst[2] if(op == CC)
+        end
+        ids
+    end
+
+    def correct_ir(chunk, old_valid, total)
+        rewrite = []
+        seen    = []
+        (0...@used_id.max).each do |i|
+            if(!old_valid.include? i)
+                seen << i
+                rewrite[i] = i
+            end
+        end
+
+        next_ctr = @used_id.max + 1
+        
+        chunk.map do |inst|
+            case inst[0]
+            when SC
+                #puts "Ignoring..."
+            when CC
+                #pp inst
+                #puts "Creating #{inst[1]}"
+                id = inst[2]
+                if(seen.include? id)
+                    seen << next_ctr
+                    rewrite[id] = next_ctr
+                    next_ctr += 1
+                else
+                    seen << id
+                    rewrite[id] = id
+                end
+                [CC, inst[1],rewrite[id], inst[3]]
+            when AA
+                (id,name,type) = inst[1..3]
+                [AA,rewrite[id], name, type]
+            when AM
+                #puts "Adding Function..."
+                (obj, name, args, value) = inst[1..4]
+                [AM, rewrite[obj], name, args, value]
+            when SP
+                #puts "Setting parent..."
+                (child, parent) = inst[1..2]
+                [SP, rewrite[child], rewrite[parent]]
+            when CA
+                #puts "Connecting field..."
+                (obj, field, value) = inst[1..3]
+                [CA, rewrite[obj], field, value]
+            when CI
+                obj = inst[1]
+                [CI, rewrite[obj]]
+                #puts "Ignoring..."
+            when EC
+                #puts "Ignoring..."
+                inst
+            else
+                puts "Unknown Opcode Rewrite..."
+                puts inst
+                inst
+            end
+        end
+    end
+
+
+    def total_objs(ir)
+        total = 0
+        ir.each do |inst|
+            op = inst[0]
+            total += 1 if(op == CC)
+        end
+        total
+    end
+
+    def initialize(ir, total_ir, db, depth=0)
+        if(!ir)
+            throw :invalid_ir
+        end
+        @ir        = ir
+        @global_ir = total_ir
+        @db        = db
+        @depth     = depth
+        @instance  = nil
+        @context   = Hash.new
+        @alloc_id  = [-1]
+        @used_id   = obj_ids(ir)
+        @objs = []
+        objs = total_objs(ir)
+        objs.times do
+            @objs << nil
+        end
+
+        #ir.each do |i|
+        #    puts i
+        #end
+
+        ir.each do |inst|
+            #puts inst
+            consume_instruction inst
+        end
+
+        #TODO elevate context to function eval...
+        @context.each do |cls, ref|
+            @objs.each do |inst|
+                if(inst)
+                    inst.instance_eval("def #{cls};@#{cls}_ref;end")
+                    inst.instance_eval("def #{cls}=(val);@#{cls}_ref=val;end")
+                    inst.send(cls+"=", ref)
+                end
+            end
+        end
+        @instance = @objs[0]
+        #puts instance
+        #puts "done..."
+    end
+end
+
+GlobalIRCache = Hash.new
+QmlIRCache    = nil
+
+def runBuildTest
+    l = Parser.new
+    qml_data = [Dir.glob("../mruby-zest/mrblib/*.qml"), Dir.glob("../mruby-zest/qml/*.qml"), Dir.glob("../mruby-zest/test/*.qml"), Dir.glob("../mruby-zest/example/*.qml")].flatten
+    qml_ir   = Hash.new
+    different_file = false
+    qml_data.each do |q|
+        cname = q.gsub(".qml","").gsub(/.*\//, "")
+        hash = File::Stat.new(q).ctime.to_s
+        #hash  = `md5sum #{q}`
+        q_ir = nil
+        if(GlobalIRCache.include?(cname+hash))
+            q_ir = GlobalIRCache[cname+hash];
+        else
+            puts "Process '#{q}'..."
+            #puts "Process '#{q.gsub(".qml","")}'"
+            prog = l.load_qml_from_file(q)
+            #puts prog
+            root_node = nil
+            prog.each do |x|
+                if(x.is_a? TInst)
+                    root_node = x
+                end
+            end
+            q_ir = ProgIR.new(root_node).IR
+            GlobalIRCache[cname+hash] = q_ir
+            different_file = true
+        end
+        qml_ir[cname] = q_ir
+    end
+
+    if(!different_file)
+        return nil
+    end
+    QmlIRCache = qml_ir
+
+    pdb = PropertyDatabase.new
+
+    start = Time.now
+    #ir = qml_ir["slider-01-empty"]
+    #ir = qml_ir["window-02-basic"]
+    #ir = qml_ir["Knob"]
+    #ir = qml_ir["module-01-layout"]
+    #ir = qml_ir["module-02-pair"]
+    ir = qml_ir["MainWindow"]
+    #ir = qml_ir["MainMenu"]
+    #ir = qml_ir["macro-02-grid"]
+    #ir  = qml_ir["ZynLFO"]
+    #ir  = qml_ir["Module"]
+    #puts "IR FORM: "
+    #ir.each do |x|
+    #    puts x
+    #end
+    pbvm = ProgBuildVM.new(ir, qml_ir, pdb)
+
+
+    finish = Time.now
+    #puts "working on the db..."
+    #puts pbvm.instance
+    #pdb.update_values
+    #puts "Database (Old?)..."
+    #puts pdb
+    #puts "Database..."
+    pdb.force_update
+    #puts pdb
+    #puts "Instance..."
+    #puts pbvm.instance.to_s
+    #pp pbvm.instance.children
+    #pp pbvm.instance.properties["children"].callback.call
+    puts "Builder Execution took #{finish-start} second(s)"
+    #pc  = ProgVM.new(pir.IR)
+    #puts "Resulting Instance"
+    #puts "------------------"
+    #pp pc.instance
+    pbvm.instance
+end
+
+#runTest

--- a/src/mruby-zest/mrblib/colorwheel.rb
+++ b/src/mruby-zest/mrblib/colorwheel.rb
@@ -1,0 +1,116 @@
+def min(a,b)
+    if(a<b)
+        a
+    else
+        b
+    end
+end
+#hue -1..1
+def draw_color_wheel(vg, x, y, w, h, hue, sx, sy)
+    vg.save()
+
+    cx = x + w/2
+    cy = y + h/2
+
+    r1 = min(w,h)/2 - 5
+    r0 = r1 - 20
+
+    aeps = 0.5 / r1;	# half a pixel arc length in radians (2pi cancels out).
+
+    (0...6).each do |i|
+        a0 = i / 6 * Math::PI * 2 - aeps;
+        a1 = (i+1) / 6 * Math::PI * 2 + aeps;
+        vg.path do
+            vg.arc(cx,cy, r0, a0, a1, NVG::CW);
+            vg.arc(cx,cy, r1, a1, a0, NVG::CCW);
+        end
+        ax = cx + Math::cos(a0) * (r0+r1)*0.5
+        ay = cy + Math::sin(a0) * (r0+r1)*0.5
+        bx = cx + Math::cos(a1) * (r0+r1)*0.5
+        by = cy + Math::sin(a1) * (r0+r1)*0.5
+        paint = vg.linear_gradient(ax,ay, bx,by, 
+                                   NVG::Color::hsla(a0/(Math::PI*2),1.0,0.55,255),
+                                   NVG::Color::hsla(a1/(Math::PI*2),1.0,0.55,255));
+        vg.fill_paint(paint)
+        vg.fill
+    end
+
+    vg.path do
+        vg.circle(cx, cy, r0 - 0.5)
+        vg.circle(cx, cy, r0 + 0.5)
+        vg.stroke_color color("000000",64)
+        vg.stroke_width 1.0
+        vg.stroke
+    end
+
+    # Selector
+    vg.save
+    vg.translate(cx, cy)
+    vg.rotate(hue*Math::PI*2)
+
+    # Marker on
+    vg.path do
+        vg.rect(r0-1,-3,r1-r0+2,6)
+        vg.stroke_color color("ffffff", 192)
+        vg.stroke_width 2.0
+        vg.stroke
+    end
+
+    paint = vg.box_gradient(r0-3,-5,r1-r0+6,10, 2,4,
+                            color("000000", 128),
+                            color("000000", 0))
+    vg.path do
+        vg.rect(r0-2-10,-4-10,r1-r0+4+20,8+20);
+        vg.rect(r0-2,-4,r1-r0+4,8);
+        vg.path_winding NVG::HOLE
+        vg.fill_paint paint
+        vg.fill
+    end
+
+    # Center triangle
+    r = r0 - 6;
+    ax = Math::cos( 120.0/180.0*Math::PI) * r;
+    ay = Math::sin( 120.0/180.0*Math::PI) * r;
+    bx = Math::cos(-120.0/180.0*Math::PI) * r;
+    by = Math::sin(-120.0/180.0*Math::PI) * r;
+    vg.path do
+        vg.move_to(r,  0)
+        vg.line_to(ax, ay)
+        vg.line_to(bx, by)
+        vg.close_path
+
+        paint = vg.linear_gradient(r,0, ax,ay, NVG::Color::hsla(hue,1.0,0.5,255),
+                                               NVG::Color::hsla(255,255,255,255));
+        vg.fill_paint paint
+        vg.fill
+        paint = vg.linear_gradient((r+ax)/2,(0+ay)/2, bx,by,
+                                   color("000000",0),
+                                   color("000000",255))
+        vg.fill_paint paint
+        vg.fill
+        vg.stroke_color color("000000", 64)
+        vg.stroke
+    end
+
+    # Select circle on triangle
+    ax = r*sx
+    ay = r*Math::sin(120.0/180.0*Math::PI)*sy
+    vg.path do
+        vg.circle(ax, ay, 5)
+        vg.stroke_color(color("ffffff", 192))
+        vg.stroke_width 2.0
+        vg.stroke
+    end
+
+    paint = vg.radial_gradient(ax,ay, 7,9, color("000000", 64), color("000000", 0))
+    vg.path do
+        vg.rect(ax-20, ay-20, 40, 40)
+        vg.circle(ax, ay, 7)
+        vg.path_winding NVG::HOLE
+        vg.fill_paint paint
+        vg.fill
+    end
+
+    vg.restore
+    vg.restore
+end

--- a/src/mruby-zest/mrblib/draw-common.rb
+++ b/src/mruby-zest/mrblib/draw-common.rb
@@ -1,0 +1,1201 @@
+
+module Draw
+    module WaveForm
+        def self.sin(vg, bb, pts=128)
+            xpts = Draw::DSP::linspace(0,1,pts)
+            vg.path do |v|
+                vg.move_to(bb.x, bb.y+bb.h/2)
+                (1...pts).each do |pt|
+                    vg.line_to(bb.x+bb.w*xpts[pt],
+                               bb.y+bb.h/2+bb.h/2*Math.sin(2*3.14*xpts[pt]))
+                end
+                v.stroke_color Theme::VisualLine
+                v.stroke_width 2.0
+                v.stroke
+            end
+        end
+
+        def self.plot(vg, ypts, bb, do_norm=true, phase=0, under_highlight=false)
+            Draw::opt_plot(vg, ypts, bb, do_norm, phase, under_highlight)
+            return
+            ypts = DSP::normalize(ypts) if do_norm
+            #xpts = Draw::DSP::linspace(0,1,ypts.length)
+            off = (phase * (ypts.length-1)).to_i
+            vg.path do |v|
+                ypos = bb.y+bb.h/2-bb.h/2*ypts[off]
+                ypos = [bb.y, [ypos, bb.y+bb.h].min].max
+                vg.move_to(bb.x, ypos)
+
+                x_m = bb.w
+                x_b = bb.x
+
+                y_m = -bb.h/2
+                y_b = bb.y+bb.h/2
+                mx = bb.y+bb.h
+                mn = bb.y
+
+                n = ypts.length
+                (1...n).each do |pt|
+                    ii = (off+pt)%n
+                    ypos = y_m*ypts[ii] + y_b
+                    ypos = mx if ypos > mx
+                    ypos = mn if ypos < mn
+                    vg.line_to(x_m*pt/n + x_b, ypos)
+                end
+                v.stroke_color Theme::VisualLine
+                v.stroke_width 2.0
+                v.stroke
+            end
+        end
+
+        def self.bar(vg, data, bb, bar_color, xx=nil)
+            Draw::opt_bar(vg, data, bb, bar_color, xx)
+            return
+            n    = data.length
+            xpts = Draw::DSP::linspace(0,1,n)
+            bx   = bb.x
+            bw   = bb.w
+            by   = bb.y
+            bh   = bb.h
+
+            y  = by+bh
+
+            vg.stroke_color bar_color
+            vg.stroke_width 1.0
+            (0...n).each do |i|
+                x  = bx + xpts[i]*bw      if !xx
+                x  = bx + xx[i]  *bw/64.0 if  xx
+                vg.path do
+                    vg.move_to(x, y)
+                    vg.line_to(x, y-bh*data[i])
+                    vg.stroke
+                end
+            end
+        end
+
+        def self.under_highlight(vg, bb, dat, fill)
+            n = dat.length
+            vg.scissor(bb.x, bb.y+bb.h/2, bb.w, bb.h/2)
+            max_y = bb.y+bb.h/2
+            vg.path do
+                vg.move_to(0.0, 0.0);
+                i = 0
+                while(i<n)
+                    dest_x = bb.x + bb.w*dat[i].x;
+                    dest_y = bb.y + bb.h/2*(1-dat[i].y);
+                    vg.line_to(dest_x, dest_y);
+                    i += 1;
+                    if (dest_y > max_y)
+                        max_y = dest_y;
+                    end
+                end
+                vg.line_to(bb.x+bb.w, 0.0)
+                vg.close_path
+                paint = vg.linear_gradient(bb.x, bb.y+bb.h/2,bb.x, max_y, Theme::HighlightGrad1, Theme::HighlightGrad2)
+                vg.fill_paint paint
+                vg.fill
+            end
+            vg.reset_scissor
+        end
+
+        def self.over_highlight(vg, bb, dat, fill)
+            n = dat.length
+            vg.scissor(bb.x, bb.y, bb.w, bb.h/2);
+            min_y = bb.y+bb.h/2
+            vg.path do
+                vg.move_to(0.0,bb.y+bb.h)
+                (0...n).each do |i|
+                    dest_x = bb.x + bb.w*dat[i].x;
+                    dest_y = bb.y + bb.h/2*(1-dat[i].y);
+                    vg.line_to(dest_x, dest_y);
+                    if (dest_y < min_y)
+                        min_y = dest_y;
+                    end
+                end
+                vg.line_to(bb.x+bb.w,bb.y+bb.h)
+                vg.close_path
+                paint = vg.linear_gradient(bb.x, bb.y+bb.h/2,bb.x, min_y, NVG.rgba(16, 59, 79, 0), NVG.rgba(16, 59, 79, 255))
+                vg.fill_paint paint
+                vg.fill
+            end
+            vg.reset_scissor
+        end
+
+        def self.zero_line(vg, bb, co)
+            vg.translate(0.5, 0.5)
+
+            vg.path do
+                y = (bb.y+bb.h/2).round()
+                vg.move_to(bb.x, y)
+                vg.line_to(bb.x+bb.w, y)
+                vg.stroke_color co
+                vg.stroke
+            end
+
+            vg.translate(-0.5, -0.5)
+        end
+
+        def self.flat_line(vg, bb, co, yy)
+            vg.path do
+                vg.move_to(bb.x,      bb.y+bb.h/2-yy*bb.h/2)
+                vg.line_to(bb.x+bb.w, bb.y+bb.h/2-yy*bb.h/2)
+                vg.stroke_color co
+                vg.stroke
+            end
+        end
+
+        def self.env_sel_line(vg, bb, m, dat, co)
+            n = dat.length
+            #Draw Sel Line
+            if(m >= 0 && m < n)
+                vg.translate(0.5, 0.5)
+
+                x = (bb.x + bb.w*dat[m].x).round()
+
+                vg.path do
+                    vg.move_to(x, bb.y)
+                    vg.line_to(x, bb.y + bb.h)
+                end
+
+                vg.stroke_color co
+                vg.stroke
+
+                vg.translate(-0.5, -0.5)
+            end
+        end
+
+        def self.lfo_plot(vg, bb, dat, stroke)
+            n = dat.length
+            vg.path do
+                vg.move_to(bb.x + bb.w*dat[0].x,
+                           bb.y + bb.h/2*(1-dat[0].y))
+                (0...n).each do |i|
+                    vg.line_to(bb.x + bb.w*dat[i].x,
+                               bb.y + bb.h/2*(1-dat[i].y))
+                end
+                vg.stroke_width 2.0
+                vg.stroke_color stroke
+                vg.stroke
+            end
+            vg.stroke_width 1.0
+        end
+
+        def self.env_plot(vg, bb, dat, stroke, selected)
+            n = dat.length
+            vg.path do
+                vg.move_to(bb.x + bb.w*dat[0].x,
+                           bb.y + bb.h/2*(1-dat[0].y))
+                (0...n).each do |i|
+                    vg.line_to(bb.x + bb.w*dat[i].x,
+                               bb.y + bb.h/2*(1-dat[i].y))
+                end
+                vg.line_join NVG::ROUND
+                vg.stroke_width 2.0
+                vg.stroke_color stroke
+                vg.stroke
+            end
+            vg.stroke_width 1.0
+
+            sel_color    = Theme::VisualSelect
+            bright       = Theme::VisualBright
+            (0...n).each do |i|
+                xx = bb.x + bb.w*dat[i].x;
+                yy = bb.y + bb.h/2*(1-dat[i].y);
+                scale = 3
+                vg.stroke_color sel_color if(selected == i)
+                vg.stroke_color bright    if(selected != i)
+                vg.fill_color   Theme::EnvelopePoint
+                Draw::WaveForm::env_marker(vg, xx, yy, scale)
+            end
+        end
+
+        def self.env_marker(vg, x, y, scale)
+            vg.path do
+                vg.translate(0.5, 0.5)
+                vg.rect((x-scale).round(),(y-scale).round(),(scale*2).round(),(scale*2).round());
+                vg.stroke_width 1.0
+                vg.fill
+                vg.stroke
+                vg.translate(-0.5, -0.5)
+            end
+        end
+
+        def self.overlay(vg, bb, pts)
+            n = pts.length/2
+            sel_color    = Theme::VisualSelect
+            dim_color    = Theme::VisualDimTrans
+            (0...n).each do |i|
+                xx = bb.x + bb.w*(pts[2*i])
+                yy = bb.y + bb.h*(1-pts[2*i+1])
+
+                vg.stroke_color sel_color
+                vg.fill_color   color(:black)
+                env_marker(vg, xx, yy, 3)
+
+                vg.path do |v|
+                    v.move_to(xx, bb.y)
+                    v.line_to(xx, bb.y + bb.h)
+                    v.stroke_color dim_color
+                    v.stroke
+                end
+            end
+        end
+
+        def self.overlay_lfo(vg, bb, pts)
+            n = pts.length/2
+            sel_color    = Theme::VisualSelect
+            dim_color    = Theme::VisualDimTrans
+            (0...n).each do |i|
+                xx = bb.x + 0.2*bb.w + 0.8*bb.w*pts[2*i]
+                yy = bb.y + bb.h/2*(1-pts[2*i+1]/127.0)
+
+                vg.stroke_color sel_color
+                vg.fill_color   color(:black)
+                env_marker(vg, xx, yy, 3)
+
+                vg.path do |v|
+                    v.move_to(xx, bb.y)
+                    v.line_to(xx, bb.y + bb.h)
+                    v.stroke_color dim_color
+                    v.stroke
+                end
+            end
+        end
+    end
+    module Grid
+        def self.log_y(vg, min, max, bb)
+            med_fill     = Theme::GridLine
+            log10 = Math.log(10)
+            min_  = Math.log(min)/log10
+            max_  = Math.log(max)/log10
+            #1,2,3,4,5,6,7,8,9,10,20
+            xx = min_.to_i
+            vg.translate(0.5,0.5)
+
+            loop {
+                break if xx>max_
+                base = (xx-min_)/(max_-min_)
+
+                (0...10).each do |shift|
+                    delta = Math.log((shift+1)*1.0)/(log10*(max_-min_))
+                    dy = bb.h*(base+delta);
+                    
+                    next if(dy < 0 || dy > bb.h)
+                    vg.path do |v|
+                        v.move_to(bb.x,      bb.y+dy);
+                        v.line_to(bb.x+bb.w, bb.y+dy);
+                        v.stroke_color med_fill
+                        v.stroke_width 1.0
+                        v.stroke
+                    end
+                end
+                xx += 1
+            }
+
+            vg.translate(-0.5,-0.5)
+        end
+        def self.log_x(vg, min, max, bb)
+            med_fill     = Theme::GridLine
+            log10 = Math.log(10)
+            min_  = Math.log(min)/log10
+            max_  = Math.log(max)/log10
+            #1,2,3,4,5,6,7,8,9,10,20
+            xx = min_.to_i
+
+            x = (bb.x).floor
+            y = (bb.y).floor
+            h = (bb.h).floor
+
+            vg.translate(0.5,0.5)
+
+            loop {
+                break if xx>max_
+                base = (xx-min_)/(max_-min_)
+
+                (0...10).each do |shift|
+                    delta = Math.log((shift+1)*1.0)/(log10*(max_-min_))
+                    dx = (bb.w*(base+delta)).floor;
+
+                    next if(dx < 0 || dx > bb.w)
+                    vg.path do |v|
+                        v.move_to(x+dx, y);
+                        v.line_to(x+dx, y+h);
+                        v.stroke_color med_fill
+                        v.stroke_width 1.0
+                        v.stroke
+                    end
+                end
+                xx += 1
+            }
+
+            vg.translate(-0.5,-0.5)
+        end
+        def self.linear_x(vg, min, max, bb, thick=1.0)
+            med_fill     = Theme::GridLine
+            light_fill   = Theme::GridLine
+            c = max
+
+            x = (bb.x).floor
+            y = (bb.y).floor
+            h = (bb.h).floor
+
+            vg.translate(0.5,0.5)
+
+            (0..c).each do |ln|
+                vg.path do |v|
+                    off = ((ln/c)*(bb.w)).floor
+                    vg.move_to(x+off, y)
+                    vg.line_to(x+off, y+h)
+                    if((ln%10) == 0)
+                        v.stroke_color med_fill
+                        v.stroke_width 1.0*thick
+                    else
+                        v.stroke_color light_fill
+                        v.stroke_width 1.0*thick
+                    end
+                    v.stroke
+                end
+            end
+            vg.translate(-0.5,-0.5)
+        end
+        def self.linear_y(vg, min, max, bb, thick=1.0, c=40)
+            med_fill     = Theme::GridLine
+            light_fill   = Theme::GridLine
+            c = max
+            
+            x = (bb.x).floor
+            y = (bb.y).floor
+            w = (bb.w).floor
+            h = (bb.h).floor
+
+            vg.translate(0.5,0.5)
+
+            (0..c).each do |ln|
+                vg.path do |v|
+                    off = ((ln/c)*(bb.h)).floor
+                    vg.move_to(x,   y+off)
+                    vg.line_to(x+w, y+off)
+                    if((ln%10) == 0)
+                        v.stroke_color med_fill
+                        v.stroke_width 1.0*thick
+                    else
+                        v.stroke_color light_fill
+                        v.stroke_width 1.0*thick
+                    end
+                    v.stroke
+                end
+            end
+            vg.translate(-0.5,-0.5)
+        end
+    end
+
+    module DSP
+        PI = 3.14
+
+        #try to get a -1..1 signal
+        def self.normalize(seq)
+            min = 1
+            max = -1
+            seq.each do |x|
+                min = x if x < min
+                max = x if x > max
+            end
+            mag = [max,-min].max
+            mag = 1.0 if mag == 0.0
+            (0...seq.length).each do |i|
+                seq[i] /= mag
+            end
+            seq
+        end
+
+        def self.norm_harmonics(seq)
+            return Draw::opt_norm_harmonics(seq)
+            (0...seq.length).each do |i|
+                seq[i] = -seq[i] if seq[i] < 0
+            end
+            max = -1
+            seq.each do |x|
+                max = x if x > max
+            end
+            (0...seq.length).each do |i|
+                seq[i] = (seq[i]/max)**0.1
+            end
+            seq
+        end
+
+        def self.magnitude(num, dem, freq, order=1)
+            angle = PI*freq
+            n = Complex(0,0)
+            d = Complex(1,0)
+            (0...num.length).each do |i|
+                n += Complex.polar(num[i], i*angle)
+                d -= Complex.polar(dem[i], i*angle)
+            end
+            (n/d).abs**order
+        end
+
+        def self.logspace(a,b,n)
+            la = Math.log10(a)
+            lb = Math.log10(b)
+            out = []
+            (0...n).each do |i|
+                out << 10.0**(la + i*1.0/n*(lb-la))
+            end
+            out
+        end
+
+        def self.linspace(a,b,n)
+            out = []
+            (0...n).each do |i|
+                out << a + i*1.0/n*(b-a)
+            end
+            out
+        end
+
+        def self.cumsum(x)
+            partial = 0
+            n       = x.length
+            (0...n).each do |i|
+                partial += x[i]
+                x[i]     = partial
+            end
+            x
+        end
+
+        def self.ary_max(x)
+            max = -1e20
+            x.each do |xx|
+                max = xx if xx>max
+            end
+            max
+        end
+
+        def self.norm_0_1(x)
+            max = ary_max(x)
+
+            #avoid division by zero
+            max = [1, max].max
+
+            n   = x.length
+            (0...n).each do |i|
+                x[i] /= 1.0*max
+            end
+            x
+        end
+
+        def self.ary_sum(x)
+            sum = 0
+            x.each do |xx|
+                sum += xx
+            end
+            sum
+        end
+
+        def self.norm_sum(x)
+            sum = ary_sum(x)
+            n   = x.length
+            (0...n).each do |i|
+                x[i] /= 1.0*sum
+            end
+            x
+        end
+
+        def self.pad_norm(x,y)
+            prev = -99.0
+            xx = []
+            x.each do |pt|
+                p = pt
+                p = prev + y if p - prev < y
+                xx << p
+                prev = p
+            end
+            xx
+        end
+    end
+    module Layout
+        def self.vpack(l, selfBox, b, x=0, w=1,fixed_pad=0, y=0, h=1)
+          off = 0.0+y
+            delta = h*1.0/b.length
+            b.each_with_index do |bb,i|
+                l.fixed_long(bb, selfBox, x, off, w, delta,
+                        0, fixed_pad, 0, -2*fixed_pad)
+                off += delta
+            end
+            selfBox
+        end
+
+        def self.hpack(l, selfBox, children, y=0, h=1, fixed_pad=0)
+          off = 0.0
+            delta = 1.0/children.length
+            children.each_with_index do |ch,i|
+                l.fixed_long(ch, selfBox, off, y, delta, h,
+                             fixed_pad, 0, -2*fixed_pad, 0)
+                off += delta
+            end
+            selfBox
+        end
+
+        def self.hfill(l, selfBox, b, w, pad=0, fixed_pad=0)
+            off = pad/2.0
+            b.each_with_index do |bb,i|
+                l.fixed_long(bb, selfBox, off, 0, w[i], 1,
+                            fixed_pad, 0, -2*fixed_pad, 0)
+                off += w[i] + pad
+            end
+            selfBox
+        end
+
+        def self.vfill(l, selfBox, b, h, pad=0, fixed_pad=0)
+            #puts "vfill"
+            #puts "selfBox = #{selfBox}"
+            off = 0.0
+            b.each_with_index do |bb,i|
+                l.fixed_long(bb, selfBox, 0, off, 1,  h[i],
+                            0, fixed_pad, 0, -2*fixed_pad)
+                off += h[i] + pad
+            end
+            selfBox
+        end
+
+        def self.grid(l, selfBox, children, rows, cols, padw=0, padh=0)
+            width  = 1.0/cols
+            height = 1.0/rows
+
+            children.each_with_index do |bb,i|
+                r = (i/cols).to_i
+                c = i%cols
+                l.fixed_long(bb, selfBox, c*width, r*height, width, height,
+                            padw, padh, -2*padw, -2*padh)
+            end
+            selfBox
+        end
+        #Transposed grid
+        def self.gridt(l, selfBox, children, rows, cols, padw=0, padh=0)
+            width  = 1.0/cols
+            height = 1.0/rows
+
+            children.each_with_index do |bb,i|
+                r = (i%rows).to_i
+                c = (i/rows).to_i
+                l.fixed_long(bb, selfBox, c*width, r*height, width, height,
+                            padw, padh, -2*padw, -2*padh)
+            end
+            selfBox
+        end
+
+        def self.tabpack(l, selfBox, base, weak=nil)
+            prev = nil
+
+            total   = 0
+            weights = []
+            base.children.each do |ch|
+                scale = 100
+                $vg.font_size scale
+                lab      = ch.label.upcase
+                lab      = "- VCE9999 +" if lab.length < 5
+                weight   = $vg.text_bounds(0, 0, lab.upcase)
+                weights << weight
+                total   += weight
+            end
+
+            n = base.children.length
+            pos = 0
+            boxes = []
+            weak_box_id = base.children.length
+            base.children.each_with_index do |ch, idx|
+                boxes << ch.fixed(l, selfBox, pos, 0, weights[idx]/total, 1)
+                pos += weights[idx]/total
+                weak_box_id = idx if ch == weak
+            end
+            px = 0
+            boxes[0...weak_box_id].each do |b|
+                b.x  = px
+                px  += b.w
+            end
+
+            px = selfBox.w
+            boxes[weak_box_id..boxes.length].reverse.each do |b|
+                b.x  = px-b.w
+                px  -= b.w
+            end
+            #puts boxes.map{|b|b.x}
+            #puts boxes.map{|b|b.y}
+            #puts boxes.map{|b|b.w}
+            #puts boxes.map{|b|b.h}
+            #puts boxes.map{|b|b.info.class}
+            selfBox
+        end
+        def self.vstack(l, selfBox, children, vpad=10, hpad=5)
+            prev = nil
+
+
+            minheight = 99999
+            n = children.length
+
+            boxes = []
+            children.each_with_index do |ch, ind|
+                box = ch.fixed_long(l, selfBox, 0, ind*1.0/n, 1, 1.0/n,
+                                   hpad, 0, -2*hpad, 0)
+                minheight = box.h if box.h < minheight
+                boxes << box
+                #l.sh([box.y], [-1], -vpad/2)
+                #l.contains(selfBox,box)
+                #l.topOf(prev, box) if(prev)
+                #l.sheq([prev.y, prev.h, box.y], [1,1,-1],-vpad) if(prev)
+                #l.aspect(box, 1, 5) if(ch.class != Qml::Selector)
+                prev = box
+            end
+
+            #Apply minimum height
+            boxes.each_with_index do |box, ind|
+                box.h = minheight
+                if(!box.info.children.empty?)
+                    box.info.layout(l, box)
+                end
+            end
+
+            yy = vpad
+            #Repack
+            boxes.each do |box|
+                box.y  = yy
+                yy    += box.h + vpad
+            end
+            selfBox
+        end
+    end
+
+    def self.indent(rect, padw, padh)
+        Rect.new(padw+rect.x, padh+rect.y, rect.w-2*padw, rect.h-2*padh)
+    end
+
+    def self.fade(c)
+        cc = c.clone
+        cc.a = 0.8
+        cc
+    end
+
+    def self.GradBox(vg, bb)
+        vg.path do |v|
+            v.rect(bb.x,bb.y,bb.w,bb.h)
+            paint = v.linear_gradient(0,0,0,bb.h,
+                  Theme::InnerGrad1, Theme::InnerGrad2)
+            v.fill_paint paint
+            v.fill
+            v.stroke_color color(:black)
+            v.stroke_width 1.0
+            v.stroke
+        end
+    end
+
+    def self.zipToPos(x,y)
+        o = []
+        n = [x.length, y.length].min
+        (0...n).each do |i|
+            o << Pos.new(x[i], y[i])
+        end
+        o
+    end
+
+    def self.toPos(p)
+        o = []
+        n = p.length/2
+        (0...n).each do |i|
+            o << Pos.new(p[2*i+1], p[2*i+0])
+        end
+        o
+    end
+
+end
+
+def color(c,alpha=255)
+    if(c.class == Symbol)
+        if(c == :red)
+            return color("ff0000")
+        elsif(c == :blue)
+            return color("0000ff")
+        elsif(c == :green)
+            return color("00ff00")
+        elsif(c == :coral)
+            return color("FF7F50")
+        elsif(c == :dark_orange)
+            return color("FF8C00")
+        elsif(c == :gold)
+            return color("FFD700")
+        elsif(c == :black)
+            return color("000000")
+        else
+            raise Exception.new("Invalid Color", c)
+        end
+    end
+    r = c[0..1].to_i 16
+    g = c[2..3].to_i 16
+    b = c[4..5].to_i 16
+    NVG.rgba(r,g,b,alpha)
+end
+def color_rgb(r,g,b,alpha=255)
+    NVG.rgba(r*255,g*255,b*255,alpha)
+end
+
+module Theme
+    GeneralBackground   = color("2C2C2D")
+
+    #Confirmed with designer
+    SliderActive        = color("0A596F")
+    SliderBackground    = color("1F2E3A")
+    SliderStroke        = color("097d89")
+    SliderVisActive     = color("15AEA3")
+
+    KnobGrad1           = color("4E5050")
+    KnobGrad2           = color("3D3E3E")
+
+    HarmonicColor       = color("026392")
+
+    TextColor           = color("CECECE")
+    BackgroundTextColor = color("818181")
+    TextActiveColor     = color("52FAFE")
+    TextModColor        = color("5BDBBA")
+
+    ScrollInactive      = color("212121")
+    ScrollActive        = color("606060")
+    ButtonInactive      = color("424B56")
+    ButtonActive        = color("00818E")
+
+    ButtonGrad1         = color("4A4B4B")
+    ButtonGrad2         = color("3E3F3F")
+
+    ModuleGrad1         = color("4E4E4E")
+    ModuleGrad2         = color("393939")
+
+    WindowGrad1         = color("3A3A3B")
+    WindowGrad2         = color("2A2A2B")
+
+    InnerGrad1          = color("4E4E4F")
+    InnerGrad2          = color("39393B")
+
+    SustainPoint        = color("005f8a")
+    EnvelopePoint       = color("232c36")
+
+    #Keyboard Widget
+    KeyWhiteGrad1       = color("B0B7C0")
+    KeyWhiteGrad2       = color("91989E")
+    KeyWhiteAccent      = color("AEB7BF")
+    KeyBlack            = color("2F3C45")
+    KeyBlackAccent      = color("3C4F56")
+    KeyEnable           = color("52FAFE")
+    KeyBackground       = color("212121")
+
+    TitleBar            = ButtonGrad1
+    #Visualizations
+    VisualBackground    = color("212121")
+    VisualStroke        = color("014767")
+    VisualLightFill     = color("014767",55)
+    VisualBright        = color("3ac5ec")
+    VisualDim           = color("143644")
+    VisualDimTrans      = color("143644", 155)
+    VisualSelect        = color("00ff00")
+    VisualLine          = color("00Cff7")
+
+    HighlightGrad1      = NVG.rgba(16, 59, 79, 0)
+    HighlightGrad2      = NVG.rgba(16, 59, 79, 255)
+
+    FilterHighlight1    = color("0ac5ff", 85)
+    FilterHighlight2    = color("0ac5ff", 165)
+
+    GridLine            = color("253743")
+
+    #Bank Elements
+    BankOdd             = color("3B3B3D")
+    BankEven            = color("434344")
+end
+
+Pokemon = [
+        "Bulbasaur",
+        "Ivysaur",
+        "Venusaur",
+        "Charmander",
+        "Charmeleon",
+        "Charizard",
+        "Squirtle",
+        "Wartortle",
+        "Blastoise",
+        "Caterpie",
+        "Metapod",
+        "Butterfree",
+        "Weedle",
+        "Kakuna",
+        "Beedrill",
+        "Pidgey",
+        "Pidgeotto",
+        "Pidgeot",
+        "Rattata",
+        "Raticate",
+        "Spearow",
+        "Fearow",
+        "Ekans",
+        "Arbok",
+        "Pikachu",
+        "Raichu",
+        "Sandshrew",
+        "Sandslash",
+        "Nidoran",
+        "Nidorina",
+        "Nidoqueen",
+        "Nidoran",
+        "Nidorino",
+        "Nidoking",
+        "Clefairy",
+        "Clefable",
+        "Vulpix",
+        "Ninetales",
+        "Jigglypuff",
+        "Wigglytuff",
+        "Zubat",
+        "Golbat",
+        "Oddish",
+        "Gloom",
+        "Vileplume",
+        "Paras",
+        "Parasect",
+        "Venonat",
+        "Venomoth",
+        "Diglett",
+        "Dugtrio",
+        "Meowth",
+        "Persian",
+        "Psyduck",
+        "Golduck",
+        "Mankey",
+        "Primeape",
+        "Growlithe",
+        "Arcanine",
+        "Poliwag",
+        "Poliwhirl",
+        "Poliwrath",
+        "Abra",
+        "Kadabra",
+        "Alakazam",
+        "Machop",
+        "Machoke",
+        "Machamp",
+        "Bellsprout",
+        "Weepinbell",
+        "Victreebel",
+        "Tentacool",
+        "Tentacruel",
+        "Geodude",
+        "Graveler",
+        "Golem",
+        "Ponyta",
+        "Rapidash",
+        "Slowpoke",
+        "Slowbro",
+        "Magnemite",
+        "Magneton",
+        "Farfetch'd",
+        "Doduo",
+        "Dodrio",
+        "Seel",
+        "Dewgong",
+        "Grimer",
+        "Muk",
+        "Shellder",
+        "Cloyster",
+        "Gastly",
+        "Haunter",
+        "Gengar",
+        "Onix",
+        "Drowzee",
+        "Hypno",
+        "Krabby",
+        "Kingler",
+        "Voltorb",
+        "Electrode",
+        "Exeggcute",
+        "Exeggutor",
+        "Cubone",
+        "Marowak",
+        "Hitmonlee",
+        "Hitmonchan",
+        "Lickitung",
+        "Koffing",
+        "Weezing",
+        "Rhyhorn",
+        "Rhydon",
+        "Chansey",
+        "Tangela",
+        "Kangaskhan",
+        "Horsea",
+        "Seadra",
+        "Goldeen",
+        "Seaking",
+        "Staryu",
+        "Starmie",
+        "Mr. Mime",
+        "Scyther",
+        "Jynx",
+        "Electabuzz",
+        "Magmar",
+        "Pinsir",
+        "Tauros",
+        "Magikarp",
+        "Gyarados",
+        "Lapras",
+        "Ditto",
+        "Eevee",
+        "Vaporeon",
+        "Jolteon",
+        "Flareon",
+        "Porygon",
+        "Omanyte",
+        "Omastar",
+        "Kabuto",
+        "Kabutops",
+        "Aerodactyl",
+        "Snorlax",
+        "Articuno",
+        "Zapdos",
+        "Moltres",
+        "Dratini",
+        "Dragonair",
+        "Dragonite",
+        "Mewtwo",
+        "Mew"]
+
+#Draw a linear x/y grid
+def draw_grid(vg, r, c, x, y, w, h)
+    light_fill   = NVG.rgba(0x11,0x45,0x75,200)
+    med_fill   = NVG.rgba(0x11,0x45,0x75,240)
+
+    (1..r).each do |ln|
+        vg.path do |v|
+            off = (ln/r)*(h/2)
+            vg.move_to(x,   y + h/2+off);
+            vg.line_to(x+w, y + h/2+off)
+            vg.move_to(x,   y + h/2-off);
+            vg.line_to(x+w, y + h/2-off)
+            if((ln%10) == 0)
+                v.stroke_color med_fill
+                v.stroke_width 2.0
+            else
+                v.stroke_color light_fill
+                v.stroke_width 1.0
+            end
+            v.stroke
+        end
+    end
+
+    (1..c).each do |ln|
+        vg.path do |v|
+            off = (ln/c)*(w)
+            vg.move_to(x+off, y)
+            vg.line_to(x+off, y + h)
+            if((ln%10) == 0)
+                v.stroke_color med_fill
+                v.stroke_width 2.0
+            else
+                v.stroke_color light_fill
+                v.stroke_width 1.0
+            end
+            v.stroke
+        end
+    end
+end
+
+def abs_sum(ary)
+    sum = 0
+    ary.each do |a|
+        if(a>0)
+            sum += a
+        else
+            sum -= a
+        end
+    end
+    sum
+end
+
+def eq_response(xpts, pars)
+    ypts  = []
+    xnorm = []
+    fs   = 48000.0
+    xpts.each do |x|
+        ypts << 1
+        xnorm << x / fs*2
+    end
+
+    n = pars.length/2
+    b = pars[0...n]
+    a = pars[n..-1]
+
+    filters = n/3
+
+    (0...filters).each do |f|
+        bb = b[3*f..3*f+2]
+        aa = a[3*f..3*f+2]
+        next if abs_sum(bb) < 1e-6
+        aa[0]  = 0.0
+        aa[1] *= -1
+        aa[2] *= -1
+        oo = Draw::opt_magnitude(bb, aa, xnorm, 1)
+        xpts.each_with_index do |x, i|
+            ypts[i] *= oo[i]
+        end
+    end
+
+    ypts
+end
+
+def make_bandpass(freq, fs, bw, gain, stages, log2)
+    omega = 2 * 3.14159 * freq / fs
+    sn    = Math.sin omega
+    cs    = Math.cos omega
+    alpha = sn * Math.sinh(log2 / 2 * bw * omega / sn);
+
+    alpha = 1  if alpha > 1
+    alpha = bw if alpha > bw
+
+    b = [0.0, 0.0, 0.0]
+    a = [0.0, 0.0, 0.0]
+    b[0] =  alpha / (1 + alpha) * gain / stages;
+    b[2] = -alpha / (1 + alpha) * gain / stages;
+    a[1] = 2 * cs / (1 + alpha);
+    a[2] = -(1 - alpha) / (1 + alpha);
+
+    return b, a
+end
+
+def make_formant(freq, fs, q, gain, stages)
+    omega = 2 * 3.14159 * freq / fs
+    sn    = Math.sin omega
+    cs    = Math.cos omega
+    alpha = sn / (2 * q);
+    gain *= Math.sqrt(q + 1)
+
+    b = [0.0, 0.0, 0.0]
+    a = [0.0, 0.0, 0.0]
+
+    b[0] = alpha / (1 + alpha)  * gain
+    b[2] = -alpha / (1 + alpha) * gain
+    a[1] = 2 * cs / (1 + alpha)
+    a[2] = -(1 - alpha) / (1 + alpha)
+
+    return b, a
+end
+
+
+def sub_synth_response(xpts, pars)
+    ypts  = []
+    xnorm = []
+    fs   = 48000.0
+    xpts.each do |x|
+        ypts << 0
+        xnorm << x / fs*2
+    end
+
+    stages = pars[0]
+
+    filters = (pars.length-1)/3
+    log2 = Math.log(2)
+
+    (0...filters).each do |f|
+        freq = pars[f*3+1]
+        bw   = pars[f*3+2]
+        gain = pars[f*3+3]
+
+        (b, a) = make_bandpass(freq, fs, bw, gain, stages, log2)
+
+        oo = Draw::opt_magnitude(b, a, xnorm, stages)
+        xpts.each_with_index do |x, i|
+            ypts[i] += oo[i]
+        end
+    end
+
+    ypts
+end
+
+def formant_filter_response(xpts, formants, q_value,
+                            stages, gain)
+    ypts  = []
+    xnorm = []
+    fs   = 48000.0
+    xpts.each do |x|
+        ypts << 0
+        xnorm << x / fs*2
+    end
+
+    b = [0.0, 0.0, 0.0]
+    a = [0.0, 0.0, 0.0]
+
+    #for each formant...
+    (0...formants.length).each do |nformant|
+        #compute formant parameters(frequency,amplitude,etc.)
+        filter_freq = formants[nformant].freq;
+        filter_q    = formants[nformant].q * q_value;
+
+        filter_q    = filter_q ** (1 / stages) if(stages > 1 && filter_q > 1)
+
+        filter_amp = formants[nformant].amp
+
+        #printf("NFORMANT %d\n", nformant);
+        #printf("CHARACTERISTICS: FREQ %f Q %f AMP %f\n", filter_freq, filter_q, filter_amp);
+        sample_rate = 48000
+
+        next if(filter_freq > (sample_rate / 2 - 100))
+
+        (b, a) = make_formant(filter_freq, sample_rate,
+                               filter_q, filter_amp, stages)
+
+        oo = Draw::opt_magnitude(b, a, xnorm, stages)
+        xpts.each_with_index do |x, i|
+            ypts[i] += oo[i]
+        end
+    end
+
+    ypts.map {|x| [-40, to_dB(x) + gain].max }
+end
+
+def path_simp(x)
+    dat = x.split("/").reverse
+    todel = 0
+    o = []
+    dat.each do |d|
+        if(d == "..")
+            todel += 1
+        elsif(todel != 0)
+            todel -= 1
+        elsif(d != "")
+            o << d
+        end
+    end
+    return "/" if o.empty?
+    o << ""
+    o.reverse.join("/")
+end
+
+#i = ["/foo/bar/blam", "/foo/../blam", "/foo/bar/../..", "/a/b/c/d/../../e/f/../g"]
+#o = ["/foo/bar/blam", "/blam",        "/",              "/a/b/e/g"]
+#
+#n = i.length
+#(0...n).each do |j|
+#    puts "Input    = #{i[j].inspect}"
+#    puts "Output   = #{simp(i[j]).inspect}"
+#    puts "Expected = #{o[j].inspect}"
+#end
+
+
+def to_dB(x)
+    20*Math.log(x)/Math.log(10)
+end
+
+class Formant
+    def initialize(freq, amp, q)
+        @freq = freq
+        @amp  = amp
+        @q    = q
+    end
+
+    attr_reader :freq, :amp, :q
+end
+
+def fixedpad(box, pad)
+    [box[0]+pad, box[1]+pad, box[2]-2*pad, box[3]-2*pad]
+end

--- a/src/mruby-zest/mrblib/file-browser.rb
+++ b/src/mruby-zest/mrblib/file-browser.rb
@@ -1,0 +1,499 @@
+#File Browser Model
+#
+# Operations:
+#  - setting the home directory
+#  - single character addition
+#  - single character deletion
+#  - apply cursor motion [later version]
+#  - setting the current file
+#  - setting the current relative directory
+#  - setting the current absolute directory
+#  - setting the file mask
+#  - clear flags
+#
+# Properties:
+#  - File/Directory list needs to be refreshed
+#  - Path display needs refresh or not
+#  - What the current path display should show
+
+class PathElm
+    #Types:
+    # - window_start
+    # - unix_start
+    # - full_dir
+    # - partial
+    attr_accessor :type
+    def initialize(type, string, sep)
+        @type = type
+        @str  = string
+        @sep  = sep
+    end
+
+    def to_s
+        return "/"       if @type == :unix_start
+        return @str+@sep if @type == :full_dir
+        return @str
+    end
+
+end
+
+class Path
+    attr_accessor :path_elements
+    def initialize(path_str)
+        @unix      = !self.windows_path?(path_str)
+        @separator = "/"  if  @unix
+        @separator = "\\" if !@unix
+        parse_unix_path(path_str)    if  @unix
+        parse_windows_path(path_str) if !@unix
+    end
+
+    def parse_windows_path(path_str)
+        #[A-Za-z]:\\?path\folder\etc\partial
+        @path_elements = []
+        partial = ""
+        len = 0
+        path_str.each_char do |chr|
+            len = @path_elements.length
+            if(chr == "\\" && len == 0 && partial.length >= 3)
+                partial += chr
+                @path_elements << PathElm.new(:windows_start, partial, @separator)
+                partial = ""
+            elsif(chr != "\\" && len == 0 && partial.length == 3)
+                @path_elements << PathElm.new(:windows_start, partial, @separator)
+                partial = chr
+            elsif(chr != "\\" && len > 0)
+                partial += chr
+            elsif(chr == "\\" && len > 0)
+                @path_elements << PathElm.new(:full_dir, partial, @separator)
+                partial = ""
+            else
+                partial += chr
+            end
+        end
+        if(len == 0 && partial.length == 3)
+            @path_elements << PathElm.new(:windows_start, partial, @separator)
+        end
+        @path_elements << PathElm.new(:partial, partial, @separator) if len != 0 && partial != ""
+    end
+
+    def parse_unix_path(path_str)
+        raise "no-windows-support" if !@unix
+        @path_elements = []
+        partial = ""
+        len = 0
+        path_str.each_char do |chr|
+            len = @path_elements.length
+            if(chr == "/" && len == 0)
+                @path_elements << PathElm.new(:unix_start, "/", "/")
+                partial = ""
+            elsif(chr != "/" && len > 0)
+                partial += chr
+            elsif(chr == "/" && len > 0)
+                @path_elements << PathElm.new(:full_dir, partial, "/")
+                partial = ""
+            end
+        end
+        @path_elements << PathElm.new(:partial, partial, "/") if len != 0 && partial != ""
+    end
+
+    def windows_path?(path)
+        x = path
+        return false if x.length < 3
+        return false if x[0].ord < "A".ord || x[0].ord > "Z".ord
+        return false if x[1].ord != 58
+        return false if x[2].ord != 92
+        return true
+    end
+
+    def add_dir(dir)
+        len = @path_elements.length
+        if(len > 1 && @path_elements[-1].type == :partial)
+            @path_elements = @path_elements[0..-2]
+        end
+        @path_elements << PathElm.new(:full_dir, dir, @separator)
+    end
+
+    def updir
+        len = @path_elements.length
+        if(len == 2)
+            @path_elements = [@path_elements[0]]
+        elsif(len > 2 && @path_elements[-1].type == :partial)
+            @path_elements = @path_elements[0..-3]
+        elsif(len > 2)
+            @path_elements = @path_elements[0..-2]
+        end
+        nil
+    end
+
+    def set_partial(part)
+        len = @path_elements.length
+        return if len < 1
+        del_partial
+        @path_elements << PathElm.new(:partial, part, @separator)
+    end
+
+    def del_partial
+        len = @path_elements.length
+        if(len > 1 && @path_elements[-1].type == :partial)
+            @path_elements = @path_elements[0..-2]
+        end
+    end
+
+    def convert_partial_to_dir
+        len = @path_elements.length
+        if(len > 1 && @path_elements[-1].type == :partial)
+            @path_elements[-1].type = :full_dir
+        end
+    end
+
+
+    def to_s
+        @path_elements.map{|x|x.to_s}.join
+    end
+end
+
+
+class FileBrowser
+    attr_reader :needs_refresh, :path, :state
+
+    def initialize()
+        @state         = :invalid
+        @current_dir   = nil
+        @current_file  = nil
+        @needs_refresh = true
+
+        @path      = "/"
+    end
+
+    def set_home_dir(dir_name)
+        @state = :on_dir
+        path   = Path.new(dir_name)
+        path.convert_partial_to_dir
+        @path  = path.to_s
+        $current_dir = @path
+        @needs_refresh = true
+    end
+
+    def add_char(chr)
+        @path += chr
+        @needs_refresh = true
+    end
+
+    def del_char()
+        @path = @path[0...-1] if !@path.empty?
+        @needs_refresh = true
+    end
+
+    def change_file(file_name)
+        raise "no home directory found..." if @state == :invalid
+        path = Path.new(@path)
+        path.del_partial            if file_name == ""
+        path.set_partial(file_name) if file_name != ""
+        npath = path.to_s
+        @needs_refresh = true if npath != @path
+        @path = npath
+    end
+
+    def change_dir_rel(dir_name)
+        raise "no home directory found..." if @state == :invalid
+        path = Path.new(@path)
+        path.updir             if dir_name == ".."
+        path.add_dir(dir_name) if dir_name != ".."
+        npath = path.to_s
+        @needs_refresh = true if npath != @path
+        @path = npath
+        $current_dir = @path
+    end
+
+    def change_dir_abs(dir_name)
+        path = Path.new(dir_name)
+        npath = path.to_s
+        @needs_refresh = true if npath != @path
+        @path = npath
+        $current_dir = @path
+    end
+
+    def clear_flags()
+        @needs_refresh = false
+    end
+
+    def search_path
+        path = Path.new(@path)
+        path.del_partial
+        path.to_s
+    end
+
+    def set_dirs(dirs)
+        @dirs = dirs
+    end
+
+    def set_files(files)
+        @files = files
+    end
+
+end
+
+if(false)
+    require "test/unit"
+
+    class FileBrowserTest < Test::Unit::TestCase
+        def setup
+            @file = FileBrowser.new
+        end
+
+        def teardown
+            @file = nil
+        end
+
+        def test_no_home
+            assert_raise(RuntimeError) {
+                @file.change_dir_rel("..")
+            }
+
+            assert_raise(RuntimeError) {
+                @file.change_file("anything")
+            }
+
+            @file.set_home_dir "/foo/bar/blam/"
+
+            assert_nothing_raised {
+                @file.change_dir_rel("..")
+            }
+
+            assert_nothing_raised {
+                @file.change_file("anything")
+            }
+        end
+
+        def test_paths
+            tmp = Path.new("/foo/bar/")
+            assert_equal("/foo/bar/", tmp.to_s)
+            tmp = Path.new("/foo/bar")
+            assert_equal("/foo/bar", tmp.to_s)
+        end
+
+        def test_unix_cd
+            @file.set_home_dir "/foo/bar/blam/"
+            assert_equal("/foo/bar/blam/", @file.path)
+            assert_equal(true, @file.needs_refresh)
+
+            @file.clear_flags
+            assert_equal(false, @file.needs_refresh)
+
+            @file.change_dir_rel "box"
+            assert_equal("/foo/bar/blam/box/", @file.path)
+            assert_equal(true, @file.needs_refresh)
+
+            @file.change_dir_rel ".."
+            assert_equal("/foo/bar/blam/", @file.path)
+
+            @file.change_dir_rel ".."
+            assert_equal("/foo/bar/", @file.path)
+
+            @file.change_dir_rel ".."
+            assert_equal("/foo/", @file.path)
+
+            @file.change_dir_rel ".."
+            assert_equal("/", @file.path)
+
+            assert_equal(true, @file.needs_refresh)
+            @file.clear_flags
+            assert_equal(false, @file.needs_refresh)
+
+            @file.change_dir_rel ".."
+            assert_equal("/", @file.path)
+
+            @file.change_dir_rel ".."
+            assert_equal("/", @file.path)
+        end
+
+        def test_unix_file
+            @file.set_home_dir "/foo/bar/blam/"
+            assert_equal("/foo/bar/blam/", @file.path)
+            assert_equal(true, @file.needs_refresh)
+
+            assert_equal(true, @file.needs_refresh)
+            @file.clear_flags
+            assert_equal(false, @file.needs_refresh)
+
+            @file.change_file "testa"
+            assert_equal("/foo/bar/blam/testa", @file.path)
+            assert_equal("/foo/bar/blam/", @file.search_path)
+
+            assert_equal(true, @file.needs_refresh)
+            @file.clear_flags
+            assert_equal(false, @file.needs_refresh)
+
+            @file.change_file "xxx"
+            assert_equal("/foo/bar/blam/xxx", @file.path)
+            assert_equal("/foo/bar/blam/", @file.search_path)
+
+            assert_equal(true, @file.needs_refresh)
+            @file.clear_flags
+            assert_equal(false, @file.needs_refresh)
+
+            @file.change_file ""
+            assert_equal("/foo/bar/blam/", @file.path)
+            assert_equal("/foo/bar/blam/", @file.search_path)
+
+            assert_equal(true, @file.needs_refresh)
+            @file.clear_flags
+            assert_equal(false, @file.needs_refresh)
+        end
+
+        def test_unix_set_home
+            @file.set_home_dir "/foo/bar/blam/"
+            assert_equal("/foo/bar/blam/", @file.path)
+            @file.set_home_dir "/foo/bar/blam"
+            assert_equal("/foo/bar/blam/", @file.path)
+        end
+
+        def test_unix_add_char
+            @file.set_home_dir "/foo/bar/blam"
+            assert_equal("/foo/bar/blam/", @file.path)
+            @file.add_char "a"
+            assert_equal("/foo/bar/blam/a", @file.path)
+            @file.add_char "b"
+            @file.clear_flags
+            assert_equal(false, @file.needs_refresh)
+            @file.add_char "c"
+            assert_equal(true, @file.needs_refresh)
+            @file.add_char "d"
+            assert_equal("/foo/bar/blam/abcd", @file.path)
+            @file.del_char
+            assert_equal("/foo/bar/blam/abc", @file.path)
+            4.times { @file.del_char }
+            assert_equal("/foo/bar/blam", @file.path)
+            assert_equal("/foo/bar/",     @file.search_path)
+            40.times { @file.del_char }
+            assert_equal("", @file.path)
+            assert_equal("", @file.search_path)
+        end
+
+        def test_windows_set_home
+            @file.set_home_dir "C:\\\\windows\\paths\\are\\dumb"
+            assert_equal("C:\\\\windows\\paths\\are\\dumb\\", @file.path)
+            @file.set_home_dir "C:\\\\windows\\paths\\are\\dumb\\"
+            assert_equal("C:\\\\windows\\paths\\are\\dumb\\", @file.path)
+        end
+
+        def test_window_cd
+            @file.set_home_dir "C:\\\\foo\\bar\\blam"
+            assert_equal("C:\\\\foo\\bar\\blam\\", @file.path)
+            assert_equal(true, @file.needs_refresh)
+
+            @file.clear_flags
+            assert_equal(false, @file.needs_refresh)
+
+            @file.change_dir_rel "box"
+            assert_equal("C:\\\\foo\\bar\\blam\\box\\", @file.path)
+            assert_equal(true, @file.needs_refresh)
+
+            @file.change_dir_rel ".."
+            assert_equal("C:\\\\foo\\bar\\blam\\", @file.path)
+
+            @file.change_dir_rel ".."
+            assert_equal("C:\\\\foo\\bar\\", @file.path)
+
+            @file.change_dir_rel ".."
+            assert_equal("C:\\\\foo\\", @file.path)
+
+            @file.change_dir_rel ".."
+            assert_equal("C:\\\\", @file.path)
+
+            assert_equal(true, @file.needs_refresh)
+            @file.clear_flags
+            assert_equal(false, @file.needs_refresh)
+
+            @file.change_dir_rel ".."
+            assert_equal("C:\\\\", @file.path)
+
+            @file.change_dir_rel ".."
+            assert_equal("C:\\\\", @file.path)
+        end
+
+        def test_window_cd_alt
+            @file.set_home_dir "C:\\foo\\bar\\blam"
+            assert_equal("C:\\foo\\bar\\blam\\", @file.path)
+            assert_equal(true, @file.needs_refresh)
+
+            @file.clear_flags
+            assert_equal(false, @file.needs_refresh)
+
+            @file.change_dir_rel "box"
+            assert_equal("C:\\foo\\bar\\blam\\box\\", @file.path)
+            assert_equal(true, @file.needs_refresh)
+
+            @file.change_dir_rel ".."
+            assert_equal("C:\\foo\\bar\\blam\\", @file.path)
+
+            @file.change_dir_rel ".."
+            assert_equal("C:\\foo\\bar\\", @file.path)
+
+            @file.change_dir_rel ".."
+            assert_equal("C:\\foo\\", @file.path)
+
+            @file.change_dir_rel ".."
+            assert_equal("C:\\", @file.path)
+
+            assert_equal(true, @file.needs_refresh)
+            @file.clear_flags
+            assert_equal(false, @file.needs_refresh)
+
+            @file.change_dir_rel ".."
+            assert_equal("C:\\", @file.path)
+
+            @file.change_dir_rel ".."
+            assert_equal("C:\\", @file.path)
+        end
+
+        def test_windows_file
+            @file.set_home_dir "C:\\\\foo\\bar\\blam\\"
+            assert_equal(      "C:\\\\foo\\bar\\blam\\", @file.path)
+            assert_equal(true, @file.needs_refresh)
+
+            assert_equal(true, @file.needs_refresh)
+            @file.clear_flags
+            assert_equal(false, @file.needs_refresh)
+
+            @file.change_file "testa"
+            assert_equal("C:\\\\foo\\bar\\blam\\testa", @file.path)
+            assert_equal("C:\\\\foo\\bar\\blam\\", @file.search_path)
+
+            assert_equal(true, @file.needs_refresh)
+            @file.clear_flags
+            assert_equal(false, @file.needs_refresh)
+
+            @file.change_file "xxx"
+            assert_equal("C:\\\\foo\\bar\\blam\\xxx", @file.path)
+            assert_equal("C:\\\\foo\\bar\\blam\\", @file.search_path)
+
+            assert_equal(true, @file.needs_refresh)
+            @file.clear_flags
+            assert_equal(false, @file.needs_refresh)
+
+            @file.change_file ""
+            assert_equal("C:\\\\foo\\bar\\blam\\", @file.path)
+            assert_equal("C:\\\\foo\\bar\\blam\\", @file.search_path)
+
+            assert_equal(true, @file.needs_refresh)
+            @file.clear_flags
+            assert_equal(false, @file.needs_refresh)
+        end
+
+        def test_windows_change_drive
+            @file.set_home_dir "C:\\\\foo"
+            assert_equal("C:\\\\foo\\", @file.path)
+            10.times {@file.del_char}
+            assert_equal("", @file.path)
+            @file.add_char "Z"
+            @file.add_char ":"
+            @file.add_char "\\"
+            @file.add_char "\\"
+            assert_equal("Z:\\\\", @file.path)
+            @file.change_file("blam")
+            assert_equal("Z:\\\\blam", @file.path)
+        end
+
+    end
+end

--- a/src/mruby-zest/mrblib/macro-state.rb
+++ b/src/mruby-zest/mrblib/macro-state.rb
@@ -1,0 +1,8 @@
+class MacroState
+    attr_reader :qid, :id, :data
+    def initialize(id,qid)
+        @qid  = id
+        @id   = qid
+        @data = []
+    end
+end

--- a/src/mruby-zest/mrblib/osc.rb
+++ b/src/mruby-zest/mrblib/osc.rb
@@ -1,0 +1,24 @@
+class Osc
+    attr_accessor :value, :metadata, :url
+    attr_accessor :internalDb
+    attr_accessor :externalDb
+    def initialize(url)
+        @value_prop
+        @meta_prop
+        @url = url
+        @value = 0
+        @internalDb = nil
+        @externalDb = nil
+    end
+
+    def setValue(v)
+        @value = v
+        if(@internalDb)
+            @internalDb.damage(@url)
+        end
+        if(@externalDb)
+            @externalDb.damage(@url, value)
+        end
+    end
+end
+

--- a/src/mruby-zest/mrblib/util.rb
+++ b/src/mruby-zest/mrblib/util.rb
@@ -1,0 +1,240 @@
+def border(scale, pos)
+    pos[0] += scale;
+    pos[1] += scale;
+    pos[2] -= 2*scale;
+    pos[3] -= 2*scale;
+end
+
+def pad(scale, bb)
+    cx = bb[0] + bb[2]/2.0;
+    cy = bb[1] + bb[3]/2.0;
+    w  = bb[2]*scale;
+    h  = bb[3]*scale;
+    bb[0] = cx - w/2.0;
+    bb[1] = cy - h/2.0;
+    bb[2] = w;
+    bb[3] = h;
+end
+
+class EditRegion
+    def initialize(vg, string, width, height)
+        @vg     = vg
+        @string = string
+        @width  = width
+        @row_h  = height
+
+        #Info on input
+        @widths = []
+        @chrcls = []
+
+        #Intermediates
+        @word_buffer = ""
+        @word_buf_w  = []
+        @active_line = 0
+        @lastw       = 0
+        @activew     = 0
+
+        #Output
+        @lines       = [""]
+        @line_widths = []
+
+
+        #cursor
+        @cursor_row = 0
+        @cursor_col = 0
+
+        string_to_stats
+        string_to_lines
+
+        #cursor
+        @cursor_row = @lines.length-1
+        @cursor_col = @lines[-1].length
+        calc_cursor_x
+    end
+
+    def lines
+        @lines
+    end
+    def line_widths
+        @line_widths
+    end
+
+    def flush_word_buffer
+        if(@activew < @width)
+            @lines[@active_line] += @word_buffer
+            @lastw = @activew
+        else
+            @line_widths[@active_line] = @lastw
+            @active_line += 1
+            @lines[@active_line] = ""
+            @activew = 0
+            @lastw   = 0
+            n = @word_buffer.length
+            (0...n).each do |i|
+                push_char(@word_buffer[i], @word_buf_w[i])
+            end
+        end
+        @word_buffer = ""
+        @word_buf_w  = []
+    end
+
+    def push_char(chr, width)
+        if(@lastw + width < @width)
+            @lines[@active_line] += chr
+            @lastw   += width
+            @activew += width
+        else
+            @line_widths[@active_line] = @lastw
+            @active_line += 1
+            @lines[@active_line] = chr
+            @lastw = @activew = width
+        end
+    end
+
+    def string_to_stats
+        @vg.font_face("bold")
+        @vg.font_size @row_h
+        @string.each_char do |c|
+            @widths << @vg.text_bounds(0, 0, c)
+            if(c == " " || c == "\t")
+                @chrcls << :space
+            elsif(c == "\n" || c == "\r")
+                @chrcls << :line
+            else
+                @chrcls << :chr
+            end
+        end
+    end
+
+    def string_to_lines
+        n = @widths.length
+        (0...n).each do |i|
+            if(@chrcls[i] == :chr)
+                @word_buffer += @string[i]
+                @word_buf_w  << @widths[i]
+                @activew      += @widths[i]
+            elsif(@chrcls[i] == :space)
+                flush_word_buffer()
+
+                push_char(@string[i], @widths[i])
+            elsif(@chrcls[i] == :line)
+                flush_word_buffer()
+
+                @line_widths[@active_line] = @lastw
+                @lastw = @activew = 0
+                @active_line += 1
+                @lines[@active_line] = ""
+            end
+        end
+
+        flush_word_buffer
+
+        @line_widths[@active_line] = @lastw
+    end
+
+    def left()
+        @cursor_col -= 1 if @cursor_col > 0
+        calc_cursor_x
+    end
+
+    def right()
+        n = @lines[@cursor_row].length
+        @cursor_col += 1 if @cursor_col < n
+        calc_cursor_x
+    end
+
+    def up()
+        @cursor_row -= 1 if @cursor_row > 0
+        n = @lines[@cursor_row].length
+        @cursor_col = n if @cursor_col > n
+
+        old_x = @cursor_x
+        best = 0
+        best_diff = 1.0/0.0
+        (0...n).each do |i|
+            @cursor_col = i
+            calc_cursor_x
+            new_diff = abs(old_x-@cursor_x)
+            if(best_diff > new_diff)
+                best_diff = new_diff
+                best = i
+            end
+        end
+
+        @cursor_col = best
+        calc_cursor_x
+    end
+
+    def down()
+        @cursor_row += 1 if @cursor_row < @lines.length-1
+        n = @lines[@cursor_row].length
+        @cursor_col = n if @cursor_col > n
+
+        old_x = @cursor_x
+        best = 0
+        best_diff = 1.0/0.0
+        (0...n).each do |i|
+            @cursor_col = i
+            calc_cursor_x
+            new_diff = abs(old_x-@cursor_x)
+            if(best_diff > new_diff)
+                best_diff = new_diff
+                best = i
+            end
+        end
+
+        @cursor_col = best
+        calc_cursor_x
+    end
+
+    def abs(x)
+        if(x > 0)
+            x
+        else
+            -x
+        end
+    end
+
+    def calc_cursor_x
+        @vg.font_face("bold")
+        @vg.font_size @row_h
+        str = @lines[@cursor_row][0,@cursor_col]
+        #puts "row = #{@cursor_row}"
+        #puts "col = #{@cursor_col}"
+        @cursor_x = @vg.text_bounds(0, 0, str)
+    end
+
+    def each_string(&block)
+        x  = 0
+        y  = @row_h/2
+        @lines.each do |str|
+            cursor = false
+            block.call(x,y,str,cursor)
+            y += @row_h
+        end
+        block.call(@cursor_x, @row_h/2 + @cursor_row*@row_h, "|", true)
+    end
+
+    def pos()
+        pos = @cursor_col
+        (0...@cursor_row).each do |i|
+            pos += @lines[i].length
+        end
+        pos
+    end
+
+    def pos=(x)
+        x = 0 if(x < 0)
+        p = x
+        (0...@lines.length).each do |i|
+            if(@lines[i].length > p)
+                @cursor_col = p
+                @cursor_row = i
+                calc_cursor_x
+                return
+            else
+                p -= @lines[i].length
+            end
+        end
+    end
+end

--- a/src/mruby-zest/qml/Button.qml
+++ b/src/mruby-zest/qml/Button.qml
@@ -1,0 +1,149 @@
+Widget {
+    id: button
+    property signal   action: nil;
+    property Bool     value:    false;
+    property String   renderer: nil;
+    property Float    textScale: 0.75;
+    property Function whenValue: nil;
+    property Float    pad: 1.0/64
+    property Bool     active: true
+
+    function onMousePress(ev) {
+        return if !self.active
+        button.value = !button.value
+        damage_self
+        whenValue.call if whenValue
+    }
+
+    function onMerge(val)
+    {
+        button.value = val.value if(val.respond_to? :value)
+    }
+
+    function class_name()
+    {
+        "Button"
+    }
+
+    function aspect2(box, ww, hh)
+    {
+        provided    = box.w/box.h
+        recommended = ww/hh
+        if(recommended > provided)
+            #Decrease height
+            new_height = box.h*provided/recommended
+            box.y += (box.h-new_height)/2
+            box.h = new_height
+        else
+            new_width = box.w*recommended/provided
+            box.x += (box.w-new_width)/2
+            box.w  = new_width
+        end
+    }
+
+
+    function layout(l, selfBox)
+    {
+        if(!self.layoutOpts.include?(:no_constraint))
+            if(label.length == 1)
+                l.aspect(selfBox, 1, 1)
+            else
+                scale = 100
+                $vg.font_size scale
+                bb = $vg.text_bounds(0, 0, label.upcase)
+                if(bb != 0)
+                    #Width cannot be so small that letters overflow
+                    self.aspect2(selfBox, bb, scale)
+                end
+            end
+        end
+        selfBox
+    }
+
+    function draw_text(vg)
+    {
+        text_color1   = Theme::TextActiveColor
+        text_color2   = Theme::TextColor
+        vg.font_face("bold")
+        vg.font_size h*self.textScale
+        if(value == true)
+            vg.fill_color(text_color1)
+        else
+            vg.fill_color(text_color2)
+        end
+        if(layoutOpts.include? :left_text)
+            vg.text_align NVG::ALIGN_LEFT | NVG::ALIGN_MIDDLE
+            vg.text(8,h/2,button.label.upcase)
+        else
+            vg.text_align NVG::ALIGN_CENTER | NVG::ALIGN_MIDDLE
+            vg.text(w/2,h/2,button.label.upcase)
+        end
+    }
+
+    function draw_inactive(vg)
+    {
+        strike_color = Theme::TextColor
+        vg.path do
+            vg.move_to(w*pad, h*pad)
+            vg.line_to(w*(1-2*pad), h*(1-2*pad))
+            vg.stroke_width 1.0
+            vg.stroke_color strike_color
+            vg.stroke
+        end
+    }
+
+    function draw_button(vg)
+    {
+        off_color     = Theme::ButtonInactive
+        on_color      = Theme::ButtonActive
+        cs = 0
+        vg.path do |v|
+            v.rounded_rect(w*pad, h*pad, w*(1-2*pad), h*(1-2*pad), 2)
+            if(button.value == true)
+                cs = 1
+                v.fill_color on_color
+            elsif(button.value.class == Float && button.value != 0)
+                cs = 2
+                t = button.value
+                on = on_color
+                of = Theme::ButtonGrad1
+                v.fill_color(color_rgb(on.r*t + of.r*(1-t),
+                                       on.g*t + of.g*(1-t),
+                                       on.b*t + of.b*(1-t)))
+            else
+                paint = v.linear_gradient(0,0,0,h,
+                Theme::ButtonGrad1, Theme::ButtonGrad2)
+                v.fill_paint paint
+            end
+            v.fill
+            v.stroke_width 1
+            v.stroke
+
+        end
+
+        vg.path do |v|
+            hh = h/20
+            v.move_to(w*pad+1,       h*pad+hh)
+            v.line_to(w*(1-2*pad)+1, h*pad+hh)
+            if(cs == 0)
+                v.stroke_color color("5c5c5c")
+            elsif(cs == 1)
+                v.stroke_color color("16a39c")
+            end
+            if([0,1].include?(cs))
+                v.stroke_width hh
+                v.stroke
+            end
+        end
+    }
+
+
+    function draw(vg)
+    {
+        draw_button(vg)
+
+        draw_text(vg)
+
+        draw_inactive(vg) if !self.active
+    }
+}

--- a/src/mruby-zest/qml/Col.qml
+++ b/src/mruby-zest/qml/Col.qml
@@ -1,0 +1,48 @@
+Widget {
+    id: col
+    property Float spacer: 5
+
+    function layout(l, selfBox) {
+        #Create A list of boxes
+        bbs = []
+        begin
+            n = children.length
+            children.each_with_index do |ch, i|
+                sh = selfBox.h-spacer*n
+                box = l.genConstBox(0, selfBox.h*i/n,
+                selfBox.w, sh/n, ch)
+                bb = ch.layout(l, box)
+                bbs << bb
+            end
+        end
+
+        minheight = 99999
+        widths = Hash.new
+        bbs.each do |b|
+            tp = b.info.class == Qml::Knob ? :knob : :other
+            minheight     = b.h if b.h < minheight
+            widths[tp]  ||= b.w
+            widths[tp]    = b.w if b.w < widths[tp]
+        end
+
+        bbs.each do |b|
+            tp = b.info.class == Qml::Knob ? :knob : :other
+            b.y  += (b.h-minheight)/2
+            b.h   = minheight
+            b.x   = 0
+            b.w   = selfBox.w
+        end
+
+        #make longer lists compact
+        if(bbs.length > 3)
+            py = spacer
+            bbs.each do |b|
+                b.y  = py
+                py  += b.h + spacer
+            end
+        end
+
+        selfBox
+    }
+
+}

--- a/src/mruby-zest/qml/DropDown.qml
+++ b/src/mruby-zest/qml/DropDown.qml
@@ -1,0 +1,78 @@
+Widget {
+    property Array    options:  []
+    property Function callback: nil
+    property Int      hl:       nil
+    function prime(root) {
+        @ctime = Time.new
+        root.set_modal(self)
+    }
+    function draw(vg)
+    {
+        self.options = [self.options] if self.options.class == String
+        n  = options.length
+        dy = h/n
+
+        if self.hl.nil?
+            self.hl = 0   if self.y == 0
+            self.hl = n-1 if self.y != 0
+        end
+
+        (0...n).each do |row|
+            vg.path do |v|
+                v.rect(1, row*dy, w-1, dy+1)
+                v.fill_color Theme::BankEven     if row%2 == 0
+                v.fill_color Theme::BankOdd      if row%2 == 1
+                v.fill_color Theme::ButtonActive if hl == row
+                v.stroke_color color(:black)
+                v.stroke_width  2.0
+                v.stroke
+                v.fill
+            end
+        end
+
+
+        text_color = Theme::TextColor
+        vg.font_face("bold")
+        vg.font_size h*0.8/n
+        vg.text_align NVG::ALIGN_LEFT | NVG::ALIGN_MIDDLE
+        vg.fill_color text_color
+
+        pad  = 1.0/64
+        options.each_with_index do |opt, i|
+            vg.text(3+w*pad*2,dy*(i+0.5),opt.upcase)
+        end
+        vg.path do |v|
+            v.rect(1, 1, w-1, h-1)
+            v.stroke_color color(:black)
+            v.stroke_width  2.0
+            v.stroke
+        end
+    }
+
+    function onMousePress(ev) {
+        #Allow Tap within 200ms
+        return if @ctime && Time.new-@ctime < 0.200
+        n   = options.length
+        opt = (n*(ev.pos.y-global_y)/h).to_i
+        xsp = (ev.pos.x-global_x)/w
+        inx = (0 <= xsp && xsp <= 1) && (0 <= opt && opt < n)
+
+
+        callback.call opt if callback &&  inx
+        callback.call nil if callback && !inx
+        rt = self.root
+        return if rt.nil?
+        rt.set_modal(nil)
+        rt.ego_death self
+    }
+
+    function onMouseRelease(ev) { onMousePress(ev) }
+    function onMouseHover(ev)   { onMouseMove(ev)  }
+    function onMouseMove(ev)
+    {
+        n   = options.length
+        opt = ((n*(ev.pos.y-global_y))/h).to_i
+        self.hl = opt
+        damage_self
+    }
+}

--- a/src/mruby-zest/qml/Envelope.qml
+++ b/src/mruby-zest/qml/Envelope.qml
@@ -1,0 +1,372 @@
+Widget {
+    id: env
+
+    property Object prev: nil;
+    property Int    selected: nil;
+    property Array  xpoints: [0.0, 0.2, 0.7, 0.8, 1.0]
+    property Array  ypoints: [0.0, 0.5, 0.3, -0.9, 0.0]
+
+    property Int    points: 5
+    property Int    sustain_point: 3
+    property Object valueRef: nil
+    property Bool   mouse_enable: true
+    property Function whenTime: nil
+    property Int      emode: nil
+
+    function setup_valuerefs()
+    {
+        ext = env.extern
+        xpts = OSC::RemoteParam.new($remote, ext + "envdt")
+        ypts = OSC::RemoteParam.new($remote, ext + "envval")
+        pts = OSC::RemoteParam.new($remote, ext + "Penvpoints")
+        pts.mode = :selector
+        sus = OSC::RemoteParam.new($remote, ext + "Penvsustain")
+        sus.mode = :full
+        free = OSC::RemoteParam.new($remote, ext + "Pfreemode")
+        mode = OSC::RemoteParam.new($remote, ext + "Envmode")
+        mode.mode = :selector
+        xpts.callback = lambda { |x|
+            env.xpoints = x
+            env.damage_self
+            whenTime.call if whenTime
+        }
+        ypts.callback = lambda { |x|
+            env.ypoints = x.map {|xx| 2*xx-1}
+            env.damage_self
+        }
+        pts.callback = lambda { |x|
+            env.points = x
+            env.damage_self
+            whenTime.call if whenTime
+        }
+        sus.callback = lambda { |x|
+            env.sustain_point = x
+            env.damage_self
+        }
+        free.callback = lambda { |x|
+            env.mouse_enable = x
+        }
+        mode.callback = lambda { |x|
+            env.emode = x
+        }
+        env.valueRef = [xpts, ypts, pts, sus, free, mode]
+
+        run_view.extern = env.extern+"out"
+    }
+
+    onExtern: {
+        env.setup_valuerefs
+    }
+
+    function refresh() {
+        return if self.valueRef.nil?
+        self.valueRef.each do |v|
+            v.refresh
+        end
+    }
+
+    function get_x_points() {
+        cumsum = Draw::DSP::cumsum(xpoints[0...points])
+        tmp = Draw::DSP::norm_0_1(cumsum)
+
+        #we need to make sure that the envelopes starts at 0 and finishes at 1
+        #(otherwise, the graph won't be displayed correctly)
+        tmp[0] = 0
+        tmp[-1] = 1
+
+        Draw::DSP::pad_norm(tmp, 0.0001)
+    }
+
+    function warp(x)
+    {
+        wp = get_x_points()
+        y  = []
+        x.each_with_index do |xx, i|
+            if((i%2) == 1)
+                y << xx
+            else
+                ps = xx.to_i
+                # this shouldn't be needed. TODO: figure out why ps ends up being out of range
+                ps = limit(ps, 0, wp.length)
+                fr = xx-ps
+                ps -= 1
+                y << xx if(ps >= wp.length)
+                next    if(ps >= wp.length)
+                aa = wp[ps]
+                bb = wp[ps]
+                bb = wp[ps+1] if(ps+1 < wp.length)
+                y << aa+fr*(bb-aa)
+            end
+        end
+        y
+    }
+
+    function onMousePress(ev) {
+        #return if !self.mouse_enable
+        #//Try to identify the location  of the nearest grabbable point
+        #valuator.prev = ev.pos
+        xdat = get_x_points()
+        ydat = env.ypoints
+        n = [xdat.length, ydat.length].min
+        next_sel = 0
+        best_dist = 1e10
+
+        mx = ev.pos.x-global_x
+        my = ev.pos.y-global_y
+        (0...n).each do |i|
+            xx = w*xdat[i];
+            yy = h/2-h/2*ydat[i];
+
+            dst = (mx-xx)**2 + (my-yy)**2
+            if(dst < best_dist)
+                best_dist = dst
+                next_sel  = i
+            end
+        end
+        if(env.selected != next_sel)
+            env.selected = next_sel
+            env.root.damage_item env
+        end
+        env.prev = ev.pos
+    }
+
+    function bound_points(array, low, high)
+    {
+        n = array.length
+        (0...n).each do |i|
+            if(array[i] < low)
+                array[i] = low
+            elsif(array[i] > high)
+                array[i] = high
+            end
+        end
+    }
+
+    function onMouseMove(ev) {
+        #return if !self.mouse_enable
+
+        if(env.selected)
+            scalex = 4*(env.xpoints[env.selected]+10)
+            dy = 2*(ev.pos.y - env.prev.y)/env.h
+            dx = scalex*(ev.pos.x - env.prev.x)/env.w
+            n  = [env.xpoints.length, env.ypoints.length].min
+            if(env.selected == 0 || env.selected == n-1)
+                env.ypoints[env.selected] -= dy
+            else
+                env.xpoints[env.selected] += dx
+                env.ypoints[env.selected] -= dy
+            end
+
+            bound_points(env.xpoints,  0.0, 40950.0)
+            bound_points(env.ypoints, -1.0, 1.0)
+
+            send_points() if mouse_enable
+            update_nonfree_x(env.xpoints) if !mouse_enable
+            update_nonfree_y(env.ypoints) if !mouse_enable
+
+            env.prev = ev.pos
+            env.root.damage_item env
+        end
+    }
+
+    function cvt_x(x)
+    {
+        fval = Math::log2(x/10.0 + 1.0) * 127.0/12.0
+        [0, [127, fval.round].min].max.to_i
+    }
+
+    function update_nonfree_x(pts)
+    {
+        if(emode == 1)
+            $remote.seti(extern + "PA_dt", cvt_x(pts[1]))
+            $remote.seti(extern + "PD_dt", cvt_x(pts[2]))
+            $remote.seti(extern + "PR_dt", cvt_x(pts[3]))
+        elsif(emode == 2)
+            $remote.seti(extern + "PA_dt", cvt_x(pts[1]))
+            $remote.seti(extern + "PD_dt", cvt_x(pts[2]))
+            $remote.seti(extern + "PR_dt", cvt_x(pts[3]))
+        elsif(emode == 3)
+            $remote.seti(extern + "PA_dt", cvt_x(pts[1]))
+            $remote.seti(extern + "PR_dt", cvt_x(pts[2]))
+        elsif(emode == 4)
+            $remote.seti(extern + "PA_dt", cvt_x(pts[1]))
+            $remote.seti(extern + "PD_dt", cvt_x(pts[2]))
+            $remote.seti(extern + "PR_dt", cvt_x(pts[3]))
+        elsif(emode == 5)
+            $remote.seti(extern + "PA_dt", cvt_x(pts[1]))
+            $remote.seti(extern + "PR_dt", cvt_x(pts[2]))
+        end
+        whenTime.call if whenTime
+    }
+
+    function cvt_y(x)
+    {
+        [0, [127, 127*(x+1)/2].min].max.to_i
+    }
+
+    function update_nonfree_y(pts)
+    {
+        if(emode == 1)
+            pts[0]      = -1.0
+            pts[1]      = +1.0
+            $remote.seti(extern + "PS_val", cvt_y(pts[2]))
+            pts[3]      = -1.0
+        elsif(emode == 2)
+            pts[0]      = -1.0
+            pts[1]      = +1.0
+            $remote.seti(extern + "PS_val", cvt_y(pts[2]))
+            pts[3]      = -1.0
+        elsif(emode == 3)
+            $remote.seti(extern + "PA_val", cvt_y(pts[0]))
+            pts[1]      = 0.0
+            $remote.seti(extern + "PR_val", cvt_y(pts[2]))
+        elsif(emode == 4)
+            $remote.seti(extern + "PA_val", cvt_y(pts[0]))
+            $remote.seti(extern + "PD_val", cvt_y(pts[1]))
+            pts[2]      = 0.0
+            $remote.seti(extern + "PR_val", cvt_y(pts[3]))
+        elsif(emode == 5)
+            $remote.seti(extern + "PA_val", cvt_y(pts[0]))
+            pts[1]      = 0.0
+            $remote.seti(extern + "PR_val", cvt_y(pts[2]))
+        end
+    }
+
+
+    function send_points()
+    {
+        return if self.extern.nil?
+        ry = ypoints.map {|xx| (xx+1)/2}
+        valueRef[0].value = env.xpoints
+        valueRef[1].value = ry
+    }
+
+    function class_name()
+    {
+        "Envelope"
+    }
+
+    function draw(vg)
+    {
+        xdat = get_x_points()
+        ydat = env.ypoints
+
+        fill_color    = Theme::VisualBackground
+        stroke_color  = Theme::VisualStroke
+        light_fill    = Theme::VisualLightFill
+        bright        = Theme::VisualBright
+        dim           = Theme::VisualDim
+        sel_color     = Theme::VisualSelect
+        sustain_color = Theme::SustainPoint
+
+        padfactor = 12
+        bb = Draw::indent(Rect.new(0,0,w,h), padfactor, padfactor)
+
+        pts = Draw::zipToPos(xdat, ydat)
+
+        background(fill_color)
+
+        #Draw borders of the envelope display
+        vg.translate(0.5, 0.5)
+        vg.path do |v|
+            v.stroke_width = 1
+            v.stroke_color = Theme::GridLine
+            v.rounded_rect(bb.x.round(), bb.y.round(), bb.w.round(), bb.h.round(), 2)
+            v.stroke()
+        end
+        vg.translate(-0.5, -0.5)
+
+        #Draw Highlights
+        Draw::WaveForm::under_highlight(vg, bb, pts, light_fill)
+        Draw::WaveForm::over_highlight(vg,  bb, pts, light_fill)
+
+        #Draw Zero Line
+        Draw::WaveForm::zero_line(vg, bb, dim)
+
+        #Indicate Sustain Point
+        Draw::WaveForm::env_sel_line(vg, bb, self.sustain_point, pts, sustain_color)
+
+        #Draw Actual Line
+        Draw::WaveForm::env_plot(vg, bb, pts, bright, selected)
+
+    }
+    Widget {
+        id: run_view
+        //animation layer
+        layer: 1
+
+        //extern is cloned
+        extern: run_view.parent.extern
+
+        function class_name()
+        {
+            "EnvVisAnimation"
+        }
+
+        //Workaround due to buggy nested properties
+        function valueRef=(value_ref)
+        {
+            @value_ref = value_ref
+        }
+
+        function valueRef()
+        {
+            @value_ref
+        }
+        
+        function runtime_points()
+        {
+            return @runtime_points
+        }
+
+        function runtime_points=(pts)
+        {
+            @runtime_points = pts
+        }
+
+        onExtern: {
+            return if run_view.extern.nil?
+            run_view.valueRef = OSC::RemoteParam.new($remote, run_view.extern)
+            run_view.valueRef.set_watch
+            run_view.valueRef.callback = Proc.new {|x|
+                y = run_view.runtime_points
+                if(y.nil? || y.length != 0 || x.length != 0)
+                    run_view.update_points(env.warp(x))
+                    run_view.runtime_points = env.warp(x);
+                    run_view.root.damage_item run_view
+                end
+            }
+        }
+
+        function update_points(xx)
+        {
+            self.runtime_points = xx
+            damage_self
+
+            @last = Time.new
+        }
+
+        function animate()
+        {
+            run_view.valueRef.watch run_view.extern
+            now     = Time.new
+            @last ||= now
+            update_points([]) if((now-@last)>0.1)
+        }
+
+        function draw(vg)
+        {
+            sel_color    = Theme::VisualSelect
+            dim_color    = Theme::VisualDimTrans
+            #Draw the data
+            pts   = @runtime_points
+            pts ||= []
+            return if pts.class != Array
+
+            padfactor = 12
+            bb = Draw::indent(Rect.new(0,0,w,h), padfactor, padfactor)
+
+            Draw::WaveForm::overlay(vg, bb, pts)
+        }
+    }
+}

--- a/src/mruby-zest/qml/FlowLayout.qml
+++ b/src/mruby-zest/qml/FlowLayout.qml
@@ -1,0 +1,22 @@
+Object {
+    id: this
+
+    function bound_child(l, c)
+    {
+        p  = this
+        ch = c
+        l.let(:pw, p.w, :ph, p.h,
+              :x, c.x, :y, c.y, :w, c.w, :h, c.h) do
+            l.c(:x, :w, :<, :pw)
+            l.c(:y, :h, :<, :ph)
+        end
+    }
+
+
+    function layout(l)
+    {
+        if(l.parent)
+            bound_parent(l)
+        end
+    }
+}

--- a/src/mruby-zest/qml/Group.qml
+++ b/src/mruby-zest/qml/Group.qml
@@ -1,0 +1,198 @@
+Widget {
+    id: mod
+    property Bool copyable: true;
+    property Bool toggleable: false;
+    property Bool editable: false;
+    property Function whenClick: nil
+    property Float topSize: 0.1
+    property Float pxpad: 8.0
+
+    layoutOpts: [:horizontal]
+
+    function class_name() { "Group" }
+
+    function onMousePress(ev) {
+        whenClick.call if whenClick
+    }
+
+    onToggleable: {
+        return if(mod.copyable && titleW.children.length < 2)
+        if(mod.toggleable && titleW.children[1].class != Qml::PowButton)
+            pb = Qml::PowButton.new(mod.db)
+            pb.extern = mod.toggleable
+            pb.parent = titleW
+            ch = titleW.children
+            ch.insert(1, pb)
+            titleW.children = ch
+        end
+    }
+
+    function onSetup(old=nil) {
+        mch = mod.children
+        cch = content.children
+        if(mch.length > 2)
+            cch = cch+mch[2..-1]
+            mch = mch[0..1]
+            content.children = cch
+            mod.children     = mch
+        else
+        end
+        content.children.each do |ch|
+            ch.parent = content
+        end
+    }
+
+    //1. This widget forms a bounding box
+    //2. The children of this widget exist
+    //   within the bounding box
+    //3. The children are packed horizontally
+    function layout(l, selfBox)
+    {
+        titleW.fixed(l,   selfBox, 0, 0,       1, topSize)
+        content.fixed_long(l, selfBox, 0, topSize, 1, 1-topSize, pxpad, pxpad, -2*pxpad, -2*pxpad)
+
+        selfBox
+    }
+
+    function draw(vg)
+    {
+        vg.path do |v|
+            v.rect(0, 0, mod.w, mod.h)
+            v.fill_color(color("000000"))
+            v.fill
+        end
+        #//paint the top half
+        pos = [0, 0, mod.w, topSize*mod.h]
+        vg.path do |v|
+            border(pos[3]*0.01, pos);
+            vg.rect(*pos);
+            v.fill_color Theme::ModuleGrad2
+            vg.fill
+        end
+
+        #upperspace = [pos[0]+pos[2]*2.0f/3.0f, pos[1], pos[2]/3.0f, pos[3]];
+        #//upper.draw(upperspace);
+
+        pos2 = [*pos]
+        pos2[2] /= 3;
+        pad((1-topSize), pos2);
+        #drawLeftLabel(vg, str, SPLAT(pos2));
+
+
+
+        innerspace = [0, mod.h*topSize, mod.w, mod.h*(1-topSize)];
+        border(w*0.003, innerspace);
+        #//paint the inner panel
+        vg.path do |v|
+            v.rect(*innerspace)
+            paint = v.linear_gradient(0,innerspace[1],0,innerspace[3],
+            Theme::ModuleGrad1, Theme::ModuleGrad2)
+            v.fill_paint paint
+            v.fill
+        end
+
+    }
+
+    Widget {
+        id: titleW
+
+        function onMousePress(ev) {
+            mod.whenClick.call if mod.whenClick
+        }
+
+        function class_name() { "TitleBox" }
+
+        function pack_misc(l, selfBox, ch)
+        {
+            #Create A list of boxes
+            bbs = []
+            n = children.length
+            children.each_with_index do |ch, i|
+                box = l.genConstBox(selfBox.w*i/n, 0,
+                selfBox.w/n, selfBox.h, ch)
+                bb = ch.layout(l, box)
+                bbs << bb
+            end
+
+            bbs[0].x = 15 if bbs[0].x > 15
+
+            #put stuff on backwards
+            bx = selfBox.w
+            bbs[1..-1].reverse.each do |b|
+                b.x  = bx-b.w
+                bx  -= b.w
+            end
+
+            return selfBox
+
+            minheight = 99999
+            widths = Hash.new
+            bbs.each do |b|
+                tp = b.info.class == Qml::Knob ? :knob : :other
+                minheight     = b.h if b.h < minheight
+                widths[tp]  ||= b.w
+                widths[tp]    = b.w if b.w < widths[tp]
+            end
+            bbs.each do |b|
+                tp = b.info.class == Qml::Knob ? :knob : :other
+                #b.y += (b.h-widths[tp])/2
+                b.y  += (b.h-minheight)/2
+                b.h   = minheight
+                b.x   = 0
+                b.w   = selfBox.w
+            end
+            selfBox
+            return
+            prev = ch[0]
+            ch[1..-1].each_with_index do |c,i|
+                l.contains(selfBox, c)
+                l.rightOf(prev,c)
+                l.aspect(c, 1, 1) if children[i+1].class == Qml::PowButton
+                prev = c
+            end
+            l.weak(ch[1].x) if ch.length > 1
+            selfBox
+        }
+
+        function layout(l, selfBox)
+        {
+            #return selfBox if children.length == 1
+            pack_misc(l, selfBox, children)
+        }
+
+        Text {
+            id: title
+            label: mod.label
+            align: :left
+            textColor: Theme::TextModColor
+            height: 0.8
+        }
+
+        function onSetup(old=nil)
+        {
+            return if children.length != 1
+            if(mod.toggleable)
+                pb = Qml::PowButton.new(db)
+                pb.extern = mod.toggleable
+                Qml::add_child(self, pb)
+            end
+            if(mod.copyable)
+                cb = Qml::CopyButton.new(db)
+                pb = Qml::PasteButton.new(db)
+                cb.extern = mod.extern
+                pb.extern = mod.extern
+                Qml::add_child(self, cb)
+                Qml::add_child(self, pb)
+            end
+        }
+    }
+    Widget {
+        id: content
+
+        function layout(l, selfBox) {
+            Draw::Layout::vpack(l, selfBox, children)
+        }
+
+        function class_name() { "ContentBox" }
+    }
+}

--- a/src/mruby-zest/qml/Group_nocp.qml
+++ b/src/mruby-zest/qml/Group_nocp.qml
@@ -1,0 +1,180 @@
+Widget {
+    id: mod
+    property Bool copyable: true;
+    property Bool toggleable: false;
+    property Bool editable: false;
+    property Function whenClick: nil
+    property Float topSize: 0
+    property Float pxpad: 8.0
+
+    layoutOpts: [:horizontal]
+
+    function class_name() { "Group" }
+
+    function onMousePress(ev) {
+        whenClick.call if whenClick
+    }
+
+    onToggleable: {
+        return if(mod.copyable && titleW.children.length < 2)
+        if(mod.toggleable && titleW.children[1].class != Qml::PowButton)
+            pb = Qml::PowButton.new(mod.db)
+            pb.extern = mod.toggleable
+            pb.parent = titleW
+            ch = titleW.children
+            ch.insert(1, pb)
+            titleW.children = ch
+        end
+    }
+
+    function onSetup(old=nil) {
+        mch = mod.children
+        cch = content.children
+        if(mch.length > 2)
+            cch = cch+mch[2..-1]
+            mch = mch[0..1]
+            content.children = cch
+            mod.children     = mch
+        else
+        end
+        content.children.each do |ch|
+            ch.parent = content
+        end
+    }
+
+    //1. This widget forms a bounding box
+    //2. The children of this widget exist
+    //   within the bounding box
+    //3. The children are packed horizontally
+    function layout(l, selfBox)
+    {
+        titleW.fixed(l,   selfBox, 0, 0,       1, topSize)
+        content.fixed_long(l, selfBox, 0, topSize, 1, 1-topSize, pxpad, pxpad, -2*pxpad, -2*pxpad)
+
+        selfBox
+    }
+
+    function draw(vg)
+    {
+        vg.path do |v|
+            v.rect(0, 0, mod.w, mod.h)
+            v.fill_color(color("000000"))
+            v.fill
+        end
+        #//paint the top half
+        pos = [0, 0, mod.w, topSize*mod.h]
+        vg.path do |v|
+            border(pos[3]*0.01, pos);
+            vg.rect(*pos);
+            v.fill_color Theme::ModuleGrad2
+            vg.fill
+        end
+
+        #upperspace = [pos[0]+pos[2]*2.0f/3.0f, pos[1], pos[2]/3.0f, pos[3]];
+        #//upper.draw(upperspace);
+
+        pos2 = [*pos]
+        pos2[2] /= 3;
+        pad((1-topSize), pos2);
+        #drawLeftLabel(vg, str, SPLAT(pos2));
+
+
+
+        innerspace = [0, mod.h*topSize, mod.w, mod.h*(1-topSize)];
+        border(w*0.003, innerspace);
+        #//paint the inner panel
+        vg.path do |v|
+            v.rect(*innerspace)
+            paint = v.linear_gradient(0,innerspace[1],0,innerspace[3],
+            Theme::ModuleGrad1, Theme::ModuleGrad2)
+            v.fill_paint paint
+            v.fill
+        end
+
+    }
+
+    Widget {
+        id: titleW
+
+        function onMousePress(ev) {
+            mod.whenClick.call if mod.whenClick
+        }
+
+        function class_name() { "TitleBox" }
+
+        function pack_misc(l, selfBox, ch)
+        {
+            #Create A list of boxes
+            bbs = []
+            n = children.length
+            children.each_with_index do |ch, i|
+                box = l.genConstBox(selfBox.w*i/n, 0,
+                selfBox.w/n, selfBox.h, ch)
+                bb = ch.layout(l, box)
+                bbs << bb
+            end
+
+            bbs[0].x = 15 if bbs[0].x > 15
+
+            #put stuff on backwards
+            bx = selfBox.w
+            bbs[1..-1].reverse.each do |b|
+                b.x  = bx-b.w
+                bx  -= b.w
+            end
+
+            return selfBox
+
+            minheight = 99999
+            widths = Hash.new
+            bbs.each do |b|
+                tp = b.info.class == Qml::Knob ? :knob : :other
+                minheight     = b.h if b.h < minheight
+                widths[tp]  ||= b.w
+                widths[tp]    = b.w if b.w < widths[tp]
+            end
+            bbs.each do |b|
+                tp = b.info.class == Qml::Knob ? :knob : :other
+                #b.y += (b.h-widths[tp])/2
+                b.y  += (b.h-minheight)/2
+                b.h   = minheight
+                b.x   = 0
+                b.w   = selfBox.w
+            end
+            selfBox
+            return
+            prev = ch[0]
+            ch[1..-1].each_with_index do |c,i|
+                l.contains(selfBox, c)
+                l.rightOf(prev,c)
+                l.aspect(c, 1, 1) if children[i+1].class == Qml::PowButton
+                prev = c
+            end
+            l.weak(ch[1].x) if ch.length > 1
+            selfBox
+        }
+
+        function layout(l, selfBox)
+        {
+            #return selfBox if children.length == 1
+            pack_misc(l, selfBox, children)
+        }
+
+        Text {
+            id: title
+            label: mod.label
+            align: :left
+            textColor: Theme::TextModColor
+            height: 0.8
+        }
+    }
+    Widget {
+        id: content
+
+        function layout(l, selfBox) {
+            Draw::Layout::vpack(l, selfBox, children)
+        }
+
+        function class_name() { "ContentBox" }
+    }
+}

--- a/src/mruby-zest/qml/Keyboard.qml
+++ b/src/mruby-zest/qml/Keyboard.qml
@@ -1,0 +1,328 @@
+Widget {
+    id: keyboard
+    property Array  data: nil
+    property Array  prev_channels: Array.new(128)
+    property Array  partchannelRefs: Array.new(16)
+    property Array  partchannels: (0..15).to_a
+    property Object valueRef: nil
+    property Int    whiteKeys: 8*7-5
+    property Float  fixpad: 1.5
+    property Int    select_id: nil
+    property Int    prev_note: nil
+
+    property Float  velocity: 100
+    property Float  velrnd: 0
+    property Int    octave: 0
+
+    //Widget hierarchy priority
+    property Int    priority: 10
+
+    function set_data(data_)
+    {
+        if(self.data != data_)
+            self.data = data_
+            self.damage_self
+        end
+    }
+
+    function onSetup(old=nil)
+    {
+        self.valueRef = OSC::RemoteParam.new($remote, "/active_keys")
+        self.valueRef.callback = lambda { |x| keyboard.set_data x }
+        (0..15).each do |i|
+            self.partchannelRefs[i] = OSC::RemoteParam.new($remote, "/part#{i}/Prcvchn")
+            self.partchannelRefs[i].mode = :normal_int
+            self.partchannelRefs[i].callback = lambda { |x| self.partchannels[i] = x.to_i }
+        end
+    }
+
+    function animate()
+    {
+        self.valueRef.refresh
+    }
+
+    function class_name() {"Keyboard"}
+
+    function white_key_id(ind)
+    {
+        @@key_lookup ||= Hash.new
+        return @@key_lookup[ind] if @@key_lookup.include?(ind)
+
+        base = 9
+        black_pattern = [1,0,1,1,0,1,1];
+
+        off = 0
+
+        black_pos = 0
+        ind.times do
+            black_pos = black_pos % black_pattern.length
+            off += 1
+            off += black_pattern[black_pos]
+            black_pos += 1
+        end
+
+        @@key_lookup[ind] = base + off
+        base + off
+    }
+
+    function get_note(pos)
+    {
+        rel = Pos.new(pos.x-global_x, pos.y-global_y)
+        (0..whiteKeys).each do |i|
+            bid = black_key_id(i)
+            wid = white_key_id(i)
+            bb  = black_bb(i, whiteKeys, false)
+            wb  = white_bb(i, whiteKeys, false)
+            if((i != whiteKeys) && (Rect.new(*bb).include? rel))
+                return bid
+            elsif(Rect.new(*wb).include? rel)
+                return wid
+            end
+        end
+        return nil
+    }
+
+    function get_note_name(note)
+    {
+        return "" if note.nil?
+        note_names = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"]
+        octave_num = note / 12 -1
+        index = note % 12
+        note_names[index] + octave_num.floor.to_s + " " + note.to_s
+    }
+
+    function onMousePress(ev)
+    {
+        note = get_note(ev.pos)
+        self.prev_note = note
+        self.root.log(:tooltip, get_note_name(note))
+        noteOn(note)
+    }
+
+    function channel()
+    {
+        if(self.root)
+            part = self.root.get_view_pos(:part)
+            self.partchannels[part]
+        else
+            0
+        end
+    }
+
+    function noteOn(note)
+    {
+        vel = velocity+(rand-0.5)*velrnd;
+        vel = [0, [127, vel].min].max.to_i
+
+        if(note && data && data[note])
+            return
+        end
+
+        if(note && $remote)
+            chan = channel()
+            if(self.prev_channels[note])
+                noteOff(note)
+            end
+            self.prev_channels[note] = chan
+            $remote.action("/noteOn", chan, note, vel)
+        end
+    }
+
+    function noteOff(note)
+    {
+        if(note && $remote)
+            chan = self.prev_channels[note]
+            chan = channel() if chan.nil?
+            self.prev_channels[note] = nil
+            $remote.action("/noteOff", chan, note)
+        end
+    }
+
+    function onMouseMove(ev)
+    {
+        note = get_note(ev.pos)
+        name = get_note_name(note)
+        self.root.log(:tooltip, name)
+        if(note != self.prev_note)
+            noteOff(self.prev_note)
+            noteOn(note)
+            self.prev_note = note
+        end
+    }
+
+    function onMouseHover(ev)
+    {
+        note = get_note(ev.pos)
+        name = get_note_name(note)
+        self.root.log(:tooltip, name)
+    }
+
+    function onMouseRelease(ev)
+    {
+        note = get_note(ev.pos)
+        noteOff(note)
+    }
+        //qwertz_high = ['q','2','w','3','e','r','5','t','6','z','7','u','i','9','o','0','p',252,"'",'+','\\']
+        //qwertz_low  = ['y','s','x','d','c','v','g','b','h','n','j','m',',','l','.',246,'-']
+
+        //azerty_high = ['a',233,'z','"','e','r','(','t','-','y',232,'u','i',231,'o',224,'p',65106,'=','$']#)
+        //azerty_low  = ['w','s','x','d','c','v','g','b','h','n','j',',',';','l',':','m','!']
+        //dvorak_high = "'2,3.p5y6f7gc9r0l/]=\\".to_a
+        //dvorak_low  = ";oqejkixdbhmwnvsz".to_a
+        
+
+    function onKey(k, act)
+    {
+        qwerty_high = "q2w3er5t6y7ui9o0p[=]\\"
+        qwerty_low  = "zsxdcvgbhnjm,l.;/"
+
+        note = nil
+        off = 0
+        qwerty_low.each_char do |i|
+            if(k==i)
+                note = 60 - 12 + off + self.octave*12
+                break
+            end
+            off += 1
+        end
+
+        off = 0
+        qwerty_high.each_char do |i|
+            if(k==i)
+                note = 60 + off
+                break
+            end
+            off += 1
+        end
+
+        return if note.nil?
+
+        if(act == "press")
+            noteOn(note)
+            self.root.log(:tooltip, get_note_name(note))
+        else
+            noteOff(note)
+        end
+
+    }
+
+    function black_key_id(ind)
+    {
+        white_key_id(ind) + 1
+    }
+
+    function no_black(i)
+    {
+        black_pattern = [1,0,1,1,0,1,1];
+        black_pattern[i%7] == 0
+    }
+
+    function white_bb(i, white_keys, pad=true)
+    {
+        padh = fixpad/2
+        box  = [i*w*1.0/(white_keys+1), padh, w*1.0/(white_keys+1), h-padh];
+        if(pad)
+            fixedpad(box, fixpad)
+        else
+            box
+        end
+    }
+
+    function black_bb(i, white_keys, pad=true)
+    {
+        width = 0.65
+        box = [(i+1.0-width/2)*w*1.0/(white_keys+1), 0,
+               w*width/(white_keys+1), h*0.7];
+        if(pad)
+            fixedpad(box, fixpad)
+        else
+            box
+        end
+    }
+
+    function draw_white(vg, i, white_keys)
+    {
+        white1       = Theme::KeyWhiteGrad1
+        white2       = Theme::KeyWhiteGrad2
+        white_accent = Theme::KeyWhiteAccent
+        enable_color = Theme::KeyEnable
+
+        box = white_bb(i, white_keys)
+        wid = white_key_id i
+        vg.path do |vg|
+            vg.rect(*box)
+            paint = vg.linear_gradient(0,0,0,h,white1, white2)
+            vg.fill_paint paint
+            vg.fill_color enable_color if data && data[wid]
+            vg.fill_color enable_color if wid == select_id
+            vg.stroke_color white_accent
+
+            vg.fill
+            vg.stroke_width fixpad
+            vg.stroke
+        end
+    }
+
+    function draw_black(vg, i, white_keys)
+    {
+        black_color  = Theme::KeyBlack
+        black_accent = Theme::KeyBlackAccent
+        enable_color = Theme::KeyEnable
+        bg_color     = Theme::KeyBackground
+
+        id = black_key_id i
+        return if no_black i
+        box = black_bb(i, white_keys)
+        vg.path do |vg|
+            vg.rect(*box)
+            vg.fill_color black_color
+            vg.fill_color enable_color if data && data[id]
+            vg.fill_color enable_color if id == select_id
+            vg.stroke_color bg_color
+            vg.fill
+            vg.stroke
+        end
+        id = black_key_id i
+        return if no_black i
+
+        box = black_bb(i, white_keys)
+        vg.path do |vg|
+            p = fixpad/2
+            vg.move_to(box[0]       -p,p+box[1]+box[3])
+            vg.line_to(box[0]+box[2]+p,p+box[1]+box[3])
+            vg.stroke_color bg_color
+            vg.stroke_width fixpad*2
+            vg.stroke
+        end
+        vg.path do |vg|
+            p = fixpad/2
+            o = fixpad/4
+            vg.move_to(box[0]       +p,box[1]+box[3]-o)
+            vg.line_to(box[0]+box[2]-p,box[1]+box[3]-o)
+            vg.stroke_color black_accent
+            vg.stroke_width fixpad
+            vg.stroke
+        end
+    }
+
+    function draw(vg)
+    {
+        white_keys = 8*7-3;
+        white_keys = self.whiteKeys;
+        black_pattern = [1,0,1,1,0,1,1];
+
+        bg_color     = Theme::KeyBackground
+        background bg_color
+
+        #draw the white keys 7 octaves + 2
+        (0..white_keys).each do |i|
+            draw_white(vg, i, white_keys)
+        end
+
+        #draw the black keys at the joints
+        (0..white_keys-2).each do |i|
+            draw_black(vg, i, white_keys)
+        end
+    }
+
+}

--- a/src/mruby-zest/qml/Knob.qml
+++ b/src/mruby-zest/qml/Knob.qml
@@ -1,0 +1,115 @@
+Valuator {
+    id: knob
+
+    function draw_classic(vg)
+    {
+        pi = 3.14159
+        start = pi/4;
+        end_   = pi*3.0/4.0;
+        inner  = 0.2*[h,w].min
+        outer = 0.4*[h,w].min
+        cy = h/2;
+        cx = w/2;
+        kr = h/4;
+        vg.path do |v|
+            v.arc(cx, cy, outer, start, end_, 1);
+            v.arc(cx, cy, inner, end_, start, 2);
+            v.close_path
+            v.fill_color color("114575")
+            v.fill
+        end
+
+        len = (3.0/2.0*pi)*knob.value;
+        startt = end_ + len;
+
+        vg.path do |v|
+            v.arc(cx, cy, inner, end_, startt, 2);
+            v.arc(cx, cy, outer, startt, end_, 1);
+            v.close_path
+            v.fill_color color("3AC5EC")
+            v.fill
+        end
+    }
+    
+    function strike_through(vg)
+    {
+        strike_color = Theme::TextColor
+        vg.path do
+            vg.move_to(w*0, h*0)
+            vg.line_to(w*(1-2*0), h*(1-2*0))
+            vg.stroke_width 1.0
+            vg.stroke_color strike_color
+            vg.stroke
+        end
+    }
+
+    function draw(vg)
+    {
+        #background color("123456")
+        pi = 3.14159
+        start = pi/4;
+        end_   = pi*3.0/4.0;
+        radius  = 0.25*[h*1.0,w].min
+        inner  = 0.35*[h*1.0,w].min
+        outer = 0.48*[h*1.0,w].min
+
+        #lowest point is 0.707 cy-outer*0.707
+        #shift by 0.293/2 to compinsate
+        cy = h/2 + h*0.293/4;
+        cx = w/2;
+        kr = h/4;
+        vg.path do |v|
+            v.arc(cx, cy, outer, start, end_, 1);
+            v.arc(cx, cy, inner, end_, start, 2);
+            v.close_path
+            v.fill_color color("114575")
+            v.fill
+        end
+
+        len = (3.0/2.0*pi)*knob.value;
+        startt = end_ + len;
+
+        vg.path do |v|
+            v.arc(cx, cy, inner, end_, startt, 2);
+            v.arc(cx, cy, outer, startt, end_, 1);
+            v.close_path
+            v.fill_color color("3AC5EC")
+            v.fill
+            v.stroke
+        end
+
+        knob_dash = color("E7E5E2")
+
+        vg.path do |v|
+            v.circle(cx, cy, radius)
+            paint = v.linear_gradient(0,0,0,h,
+            Theme::KnobGrad1, Theme::KnobGrad2)
+            v.fill_paint paint
+            v.fill
+            v.stroke
+        end
+
+        vg.path do |v|
+            angle = 3*pi/4+3*pi/2*knob.value
+            v.move_to(cx, cy)
+            v.line_to(cx+radius*Math.cos(angle), cy+radius*Math.sin(angle))
+            v.stroke_color knob_dash
+            v.stroke_width 0.2*radius
+            v.stroke
+        end
+        
+        strike_through(vg) if !self.active
+        
+    }
+
+    function class_name()
+    {
+        "Knob"
+    }
+
+    function layout(l, selfBox)
+    {
+        l.aspect(selfBox, 0.9, 1)
+        selfBox
+    }
+}

--- a/src/mruby-zest/qml/LogWidget.qml
+++ b/src/mruby-zest/qml/LogWidget.qml
@@ -1,0 +1,36 @@
+Widget {
+    property Int lines: 2
+
+    function display_log(type, message, src)
+    {
+        if(self.label != message)
+            self.label = message
+            damage_self
+        end
+    }
+
+    function onSetup(old)
+    {
+        self.root.log_widget = self
+    }
+
+    function draw(vg)
+    {
+        textColor  = color("3ac5ec")
+        splitColor = color("133A4C")
+
+        vg.path do |vg|
+            vg.move_to(0,0.5*h)
+            vg.line_to(w,0.5*h)
+            vg.stroke_width 2.0
+            vg.stroke_color splitColor
+            vg.stroke
+        end
+
+        vg.font_face("bold")
+        vg.font_size h/self.lines*0.8
+        vg.text_align NVG::ALIGN_LEFT | NVG::ALIGN_MIDDLE
+        vg.fill_color(textColor)
+        vg.text_box(0,h/4,w,self.label.upcase)
+    }
+}

--- a/src/mruby-zest/qml/ModWheel.qml
+++ b/src/mruby-zest/qml/ModWheel.qml
@@ -1,0 +1,28 @@
+Valuator {
+    function draw(vg)
+    {
+        c1 = color("0b0b0b")
+        c2 = color("525252")
+        bright_green = color("00AE9C")
+        grad1 = vg.linear_gradient(0,0,0,h/2,c1,c2)
+        grad2 = vg.linear_gradient(0,h/2,0,h,c2,c1)
+        vg.path do |v|
+            v.rect(0, 0, w, h/2)
+            vg.fill_paint(grad1)
+            v.fill
+        end
+        vg.path do |v|
+            v.rect(0, h/2, w, h/2)
+            vg.fill_paint(grad2)
+            v.fill
+        end
+        vg.path do |v|
+            v.rect(0, h*7/8*(1-value), w, h/8)
+            scale = 2*(0.5-[0.5-value, value-0.5].max)
+            scale = scale+0.4
+            bright_green = NVG.rgba(0x00*scale,0xAe*scale,0x9c*scale, 255)
+            v.fill_color(bright_green)
+            v.fill
+        end
+    }
+}

--- a/src/mruby-zest/qml/NumEntry.qml
+++ b/src/mruby-zest/qml/NumEntry.qml
@@ -1,0 +1,125 @@
+Widget {
+    id: numentry
+    property Function whenValue: nil
+    property Int      value: 0
+    property Object   valueRef: nil
+    property String   format:   ""
+
+    property Int      offset: 0
+    property Int      minimum: 0
+    property Int      maximum: 10
+    
+    property Bool     active: true
+
+    onExtern: {
+        meta = OSC::RemoteMetadata.new($remote, numentry.extern)
+        numentry.label   = meta.short_name
+        numentry.tooltip = meta.tooltip
+        numentry.minimum = meta.min.to_i if numentry.minimum == 0
+        numentry.maximum = meta.max.to_i if numentry.maximum == 10
+
+        numentry.valueRef = OSC::RemoteParam.new($remote, numentry.extern)
+        numentry.valueRef.mode     = :full
+        numentry.valueRef.callback = Proc.new {|x| numentry.setValue(x)}
+
+    }
+
+    function class_name() {"num_entry"}
+    function layout(l, selfBox)
+    {
+        return selfBox if layoutOpts.include?(:free)
+
+        #Assume all digit bounding boxes are roughly the same
+        scale = 100
+        $vg.font_size scale
+        bb = $vg.text_bounds(0, 0, "- 9999 +"+format)
+        l.aspect(selfBox, bb, scale)
+
+        selfBox
+    }
+
+    function refresh() {
+        self.valueRef.refresh if self.valueRef
+    }
+
+    function draw(vg)
+    {
+        textHeight = 0.8
+        vg.path do
+            vg.rect(0, 0, w, h)
+            paint = vg.linear_gradient(0,0,0,h,
+                Theme::ButtonGrad1, Theme::ButtonGrad2)
+            vg.fill_paint paint
+            vg.fill
+            vg.stroke_width 1
+            vg.stroke
+        end
+
+        vg.path do
+            vg.move_to(0.2*w, 0*h)
+            vg.line_to(0.2*w, 1*h)
+            vg.move_to(0.8*w, 0*h)
+            vg.line_to(0.8*w, 1*h)
+            vg.stroke
+        end
+
+        vg.font_face("bold")
+        vg.font_size h*textHeight
+        vg.fill_color Theme::TextColor
+        vg.text_align NVG::ALIGN_CENTER | NVG::ALIGN_MIDDLE
+        vg.text(0.1*w,h/2,"-")
+        vg.text(0.9*w,h/2,"+")
+        vg.text(0.5*w,h/2,self.format+self.value.to_s)
+
+        if(!self.active)
+            pad = 1
+            vg.path do
+                vg.move_to(pad, pad)
+                vg.line_to(w-2*pad, h-2*pad)
+                vg.stroke_color Theme::TextColor
+                vg.stroke
+            end
+        end
+    }
+
+    function setValue(val)
+    {
+        self.value = val + offset
+        damage_self
+    }
+
+    function updatePos(delta)
+    {
+        return if !self.active
+        if self.value + delta > maximum
+            self.value = maximum
+            return
+        end
+        if self.value + delta < minimum
+            self.value = minimum
+            return
+        end
+        self.value += delta
+        if(self.valueRef)
+            self.valueRef.value = self.value - offset
+        end
+        whenValue.call if whenValue
+        damage_self
+    }
+
+    function onScroll(ev)
+    {
+        updatePos(+1) if ev.dy > 0
+        updatePos(-1) if ev.dy < 0
+    }
+
+    function onMousePress(ev)
+    {
+        return if !ev.buttons.include? :leftButton
+        if(ev.pos.x-global_x > 0.5*w)
+            updatePos(+1)
+        else
+            updatePos(-1)
+        end
+    }
+}

--- a/src/mruby-zest/qml/PanicButton.qml
+++ b/src/mruby-zest/qml/PanicButton.qml
@@ -1,0 +1,43 @@
+TriggerButton {
+    whenValue: lambda { $remote.action("/Panic") }
+    function layout(l, selfBox) {
+        selfBox
+    }
+
+    function draw(vg)
+    {
+        text_color1   = color("505050")
+        text_color2   = color("B9CADE")
+        pad = 1.0/64
+        vg.path do |v|
+            v.rect(w*pad, h*pad, w*(1-2*pad), h*(1-2*pad))
+            paint = v.linear_gradient(0,0,0,h,
+            Theme::ButtonGrad1, Theme::ButtonGrad2)
+            v.fill_paint paint
+            v.fill
+            v.stroke_width 1
+            v.stroke
+        end
+        vg.path do |v|
+            angle = 30*3.14/180
+            delta = 0.4*[w,h].min
+            dy = delta*Math.sin(angle)
+            dx = delta*Math.cos(angle)
+            cy = 0.6*h
+            v.move_to(0.5*w,    cy-delta)
+            v.line_to(0.5*w+dx, cy+dy)
+            v.line_to(0.5*w-dx, cy+dy)
+            v.close_path
+            v.fill_color(text_color2)
+            v.fill
+        end
+
+        vg.font_face("bold")
+        vg.font_size h*0.75
+        vg.text_align NVG::ALIGN_CENTER | NVG::ALIGN_MIDDLE
+        vg.fill_color(text_color1)
+        vg.text(w/2,h/2,"!")
+
+    }
+
+}

--- a/src/mruby-zest/qml/ParModule.qml
+++ b/src/mruby-zest/qml/ParModule.qml
@@ -1,0 +1,247 @@
+Widget {
+    id: mod
+    property Bool copyable: false;
+    property Bool editable: false;
+    property String extern: "";
+
+    layoutOpts: [:horizontal]
+
+    function class_name() { "ParModule" }
+
+    onChildren: {
+        mch = mod.children
+        cch = content.children
+        if(mch.length > 3)
+            cch = cch+mch[3..-1]
+            mch = mch[0..2]
+            content.children = cch
+            mod.children     = mch
+        else
+        end
+    }
+
+    function onSetup(old=nil) {
+        n = content.children.length
+        (0...n).each do |i|
+            label = createInstance("Text", labels, mod.db)
+            if(content.children[i].class_name != "Button")
+                label.label = content.children[i].label
+            end
+        end
+    }
+
+    //1. This widget forms a bounding box
+    //2. The children of this widget exist
+    //   within the bounding box
+    //3. The children are packed horizontally
+    function layout(l)
+    {
+        selfBox = l.genBox :parmodule, mod
+        contentBox = content.layout(l)
+        labelsBox  = labels.layout(l)
+        titleBox   = titleW.layout(l)
+
+        #Constrain Content Box
+        l.contains(selfBox,titleBox)
+        l.contains(selfBox,contentBox)
+        l.contains(selfBox,labelsBox)
+        l.topOf(titleBox,contentBox)
+        l.topOf(contentBox,labelsBox)
+        l.sheq([contentBox.h, selfBox.h], [1, -0.5], 0)
+        l.sheq([contentBox.w, selfBox.w], [1, -1], 0)
+        l.sheq([labelsBox.h, selfBox.h],  [1, -0.3], 0)
+        l.sheq([labelsBox.w, selfBox.w],  [1, -1], 0)
+
+        l.contains(selfBox, titleBox)
+        l.sheq([titleBox.x],[1],0)
+        l.sheq([titleBox.h, selfBox.h], [1, -0.2], 0)
+
+
+        prev = nil
+        blist = []
+        mod.content.children.each do |ch|
+            bb = ch.layout(l)
+            if(bb)
+                blist << bb
+                l.contains(contentBox, bb)
+                #l.le([bb.y, selfBox.h], [-1, 0.2])
+                if(prev)
+                    l.rightOf(prev,bb, true)
+                end
+                prev = bb
+            end
+        end
+
+        #Punish Different Sizes
+        blist.each do |x|
+            l.punish2([selfBox.w], [1.0/blist.length], x.w)
+        end
+        
+        #Punish floating in the y dir
+        blist.each do |x|
+            l.weak(x.y)
+        end
+
+        #Center Stuff Horizontally
+        if(!blist.empty?)
+            l.sheq([blist[0].x, selfBox.w, blist[-1].x, blist[-1].w],
+            [1,       -1,       1,     1], 0)
+        end
+        breal = blist
+
+        content_items = blist
+
+        prev = nil
+        blist = []
+        lh    = l.gensym :modlabelHeight
+        mod.labels.children.each do |ch|
+            bb = ch.layout(l)
+            if(bb)
+                blist << bb
+                l.contains(labelsBox, bb)
+                l.sheq([lh, bb.h], [1, -1], 0)
+                if(prev)
+                    l.rightOf(prev,bb, true)
+                end
+                prev = bb
+            end
+        end
+
+        #Punish Different Sizes
+        blist.each do |x|
+            l.punish2([selfBox.w], [1.0/blist.length], x.w)
+        end
+
+        #Center Stuff Horizontally
+        if(!blist.empty?)
+            l.sheq([blist[0].x, selfBox.w, blist[-1].x, blist[-1].w],
+            [1,       -1,       1,     1], 0)
+        end
+
+        #Stitch labels
+        n = blist.length
+        (1...n).each do |i|
+            l.rightOf(breal[i-1],blist[i])
+        end
+
+        label_items = blist
+
+        #Center labels
+        if(label_items.length == content_items.length && true)
+            (1...n).each do |i|
+                li = label_items[i]
+                ci = content_items[i]
+                l.sheq([li.x, li.w, ci.x, ci.w],
+                       [1, 0.5, -1, -0.5], 0)
+            end
+        end
+
+
+
+        #Layout Custom Stuff
+        #buttonBox = button.layout(l)
+        #l.contains(titleBox,buttonBox)
+
+        #blist.each_with_index do |x, i|
+        #    blist.each_with_index do |y, j|
+        #        if(i!=j)
+        #            l.punish_difference(x.w,y.w)
+        #        end
+        #    end
+        #end
+        selfBox
+    }
+
+    function draw(vg)
+    {
+        #//paint the top half
+        pos = [0, 0, mod.w, mod.h]
+        pos[3] *= 0.2;
+        vg.path do |v|
+            border(pos[3]*0.01, pos);
+            vg.rect(*pos);
+            vg.fill_color(color("0A2E4C"))
+            vg.fill
+        end
+
+        #upperspace = [pos[0]+pos[2]*2.0f/3.0f, pos[1], pos[2]/3.0f, pos[3]];
+        #//upper.draw(upperspace);
+
+        pos2 = [*pos]
+        pos2[2] /= 3;
+        pad(0.9, pos2);
+        #drawLeftLabel(vg, str, SPLAT(pos2));
+
+
+
+        innerspace = [0, mod.h*0.2, mod.w, mod.h*0.8];
+        border(h*0.01, innerspace);
+        #//paint the inner panel
+        vg.path do |v|
+            v.rect(*innerspace)
+            paint = v.linear_gradient(0,0,0,h,
+            Theme::ModuleGrad1, Theme::ModuleGrad2)
+            v.fill_paint paint
+            v.fill
+        end
+
+    }
+
+    Widget {
+        id: titleW
+
+        function class_name() { "TitleBox" }
+
+        function layout(l)
+        {
+            selfBox = l.genBox :titleBox, titleW
+            t  = title.layout(l)
+            l.contains(selfBox,t)
+
+            bc = button_c.layout(l)
+            l.contains(selfBox,bc)
+
+            bp = button_p.layout(l)
+            l.contains(selfBox,bp)
+            l.rightOf(t,bc)
+            l.rightOf(bc,bp)
+            l.weak(bc.x)
+            selfBox
+        }
+
+        Text {
+            id: title
+            label: mod.label
+        }
+
+        Button {
+            //square
+            function layout(l)
+            {
+                selfBox = l.genBox :copyButton, button_c
+                l.aspect(selfBox, 1, 1)
+                selfBox
+            }
+            id: button_c
+            label: "C"
+        }
+        Button {
+            function layout(l)
+            {
+                selfBox = l.genBox :copyButton, button_p
+                l.aspect(selfBox, 1, 1)
+                selfBox
+            }
+            id: button_p
+            label: "P"
+        }
+    }
+    Widget {
+        id: content
+        function class_name() { "ContentBox" }
+    }
+    Widget {
+        id: labels
+        function class_name() { "LabelBox" }
+    }
+}

--- a/src/mruby-zest/qml/ParModuleRow.qml
+++ b/src/mruby-zest/qml/ParModuleRow.qml
@@ -1,0 +1,103 @@
+Widget {
+    id: row
+    property Float lsize: 0.3
+    property Int   whitespace: nil
+    property Symbol outer: nil
+    layoutOpts: [:fixed_width]
+
+
+    function onSetup(old=nil) {
+        mch = row.children
+        cch = content.children
+        if(mch.length > 2)
+            cch = cch+mch[2..-1]
+            mch = mch[0..1]
+            content.children = cch
+            row.children     = mch
+        else
+        end
+
+        n = content.children.length
+        labels.children = []
+        (0...n).each do |i|
+            label = createInstance("Text", labels, row.db)
+            label.height = 1.0
+            label.layoutOpts = [:ignoreAspect]
+            if(content.children[i].class_name != "Button")
+                label.label = content.children[i].label
+            end
+        end
+    }
+
+    function layout_hpack(l, selfBox, children, mode, breal=nil)
+    {
+        #Create A list of boxes
+        blist = []
+        return blist if children.empty?
+        weight_list = []
+        bbs = []
+        begin
+            prev = nil
+            n = children.length
+            children.each_with_index do |ch, i|
+                box = l.genConstBox(selfBox.w*i/n, 0,
+                selfBox.w/n, selfBox.h*1, ch)
+                bb = ch.layout(l, box)
+                bbs << bb
+                if(ch.layoutOpts.include? :weight)
+                    weight_list << ch.layoutOpts[:weight]
+                else
+                    weight_list << 1.0
+                end
+            end
+        end
+
+
+        heights = Hash.new
+        bbs.each do |b|
+            tp = b.info.class == Qml::Knob ? :knob : :other
+            heights[tp]  ||= b.h
+            heights[tp]    = b.h if b.h < heights[tp]
+        end
+
+        bbs.each do |b|
+            tp = b.info.class == Qml::Knob ? :knob : :other
+            b.y += (b.h-heights[tp])/2
+            b.h  = heights[tp]
+        end
+
+        content_items = blist
+    }
+
+    function layout(l, selfBox)
+    {
+        contentBox = content.fixed(l, selfBox, 0, 0, 1, (1-lsize))
+        labelBox   = labels.fixed(l,  selfBox, 0, (1-lsize), 1, lsize)
+
+        content_items = layout_hpack(l, contentBox, row.content.children, :normal)
+        label_items   = layout_hpack(l, labelBox,   row.labels.children,  :labels,
+                                     content_items)
+
+
+        if(label_items.length == content_items.length)
+            n = label_items.length
+            (0...n).each do |i|
+                li = label_items[i]
+                ci = content_items[i]
+                l.sheq([li.x, li.w, ci.x, ci.w],
+                       [1, 0.5, -1, -0.5], 0)
+            end
+        end
+        selfBox
+    }
+    function class_name() { "ParModuleRow" }
+
+    Widget {
+        id: content
+        function class_name() { "ContentBox" }
+    }
+    Widget {
+        id: labels
+        function class_name() { "LabelBox" }
+    }
+}

--- a/src/mruby-zest/qml/PowButton.qml
+++ b/src/mruby-zest/qml/PowButton.qml
@@ -1,0 +1,77 @@
+ToggleButton {
+    function class_name() {"powbutton"}
+    function draw(vg) {
+        #Draw background
+        on_color      = Theme::ButtonActive
+
+        vg.stroke_color color("000000", 0xa0)
+
+        vg.path do |v|
+            pad = 0
+            v.rounded_rect(pad,0,w,h,1)
+            if(self.value)
+                v.fill_color on_color
+            else
+                paint = v.linear_gradient(0,0,0,h,
+                Theme::ButtonGrad1, Theme::ButtonGrad2)
+                v.fill_paint paint
+            end
+            v.fill
+            v.stroke
+        end
+
+        #Draw power button
+        pi     = 3.141592653
+        cx     = w/2.0;
+        cy     = h/2.0;
+        center = pi/2.0;
+        sw     = [h,w].min/15.0;
+        r      = 0.195*[h,w].min
+
+        if(self.value)
+            power_sign_stroke_color = Theme::TextActiveColor
+        else
+            power_sign_stroke_color = Theme::TextColor
+        end
+
+        vg.line_cap(NVG::SQUARE);
+        vg.path do |vg|
+            vg.arc(cx, cy, r, center+pi*0.775, center-pi*0.775, 1);
+            vg.move_to(cx, 0.42*h);
+            vg.line_to(cx, 0.28*h);
+            vg.stroke_width(w/12.0);
+            vg.stroke_color(power_sign_stroke_color)
+            vg.stroke
+        end
+
+        vg.translate(0.5,0.5)
+
+        vg.path do |v|
+            hh = h/32
+            source_x = 1
+            source_y = (hh).round()
+            dest_x = (w-2).round()
+            dest_y = source_y
+
+            v.move_to(source_x, source_y)
+            v.line_to(dest_x, dest_y)
+
+            if(self.value)
+                v.stroke_color color("16a39c")
+            else
+                v.stroke_color color("5c5c5c")
+            end
+
+            v.stroke_width 1
+            v.stroke
+        end
+
+        vg.translate(-0.5,-0.5)
+    }
+
+    function layout(l, selfBox)
+    {
+        l.aspect(selfBox, 1, 1)
+        selfBox
+    }
+}

--- a/src/mruby-zest/qml/RadialMenu.qml
+++ b/src/mruby-zest/qml/RadialMenu.qml
@@ -1,0 +1,128 @@
+Widget {
+    id: radial
+
+    //wouldn't you know, random just lands on the same value that you already
+    //had :p
+    property Array fields: ["Learn", "Rand", "Unlearn", "default"]
+
+    //The mouse's favorite flavor of pie (or shredded wheaties) 0=N,1=E,2=S,3=W
+    property Int   flavor: nil
+
+    property Function callback: nil
+
+    function draw(vg)
+    {
+        inner  = 0.1*[h,w].min
+        outer = 0.5*[h,w].min
+        cx = radial.w/2
+        cy = radial.h/2
+        pi = 3.14159
+        start = pi/4;
+        end_   = pi*3.0/4.0;
+        start = 0
+        end_  = -2.0*pi
+
+        vg.path do |v|
+            v.arc(cx, cy, outer, start, end_, 1);
+            v.arc(cx, cy, inner, end_, start, 2);
+            v.close_path
+            v.fill_color color("114575",205)
+            v.fill
+        end
+
+        if(self.flavor)
+            start = self.flavor*2*pi/4 - pi/4
+            end_  = start-pi/2
+            vg.path do |v|
+                v.arc(cx, cy, outer, start, end_, 1);
+                v.arc(cx, cy, inner, end_, start, 2);
+                v.close_path
+                v.fill_color color("2185F5", 205)
+                v.fill
+            end
+        end
+
+        vg.path do |v|
+            outer = 0.5*0.707*[h,w].min
+            v.move_to(cx-outer,cy-outer)
+            v.line_to(cx+outer,cy+outer)
+            v.move_to(cx+outer,cy-outer)
+            v.line_to(cx-outer,cy+outer)
+            v.stroke_color color("ffffff")
+            v.stroke
+        end
+
+        textColor = color("3AC5EC")
+
+        #Draw North
+        vg.font_face("bold")
+        vg.font_size h/8
+        vg.text_align NVG::ALIGN_CENTER | NVG::ALIGN_MIDDLE
+        vg.fill_color(textColor)
+        vg.text(w*0.5,h*0.2,fields[0].upcase)
+
+        #Draw East
+        vg.text(w*0.8,h*0.5,fields[1].upcase)
+
+        #Draw South
+        vg.text(w*0.5,h*0.8,fields[2].upcase)
+
+        #Draw West
+        vg.text(w*0.2,h*0.5,fields[3].upcase)
+    }
+
+    function abs(x)
+    {
+        if(x < 0)
+            return -x
+        else
+            return x
+        end
+    }
+
+    function onMouseMove(ev)
+    {
+        dx = ev.pos.x-self.global_x-radial.w/2
+        dy = ev.pos.y-self.global_y-radial.h/2
+        slice = find_slice(dx, dy)
+        if(slice != self.flavor)
+            self.flavor = slice
+            self.root.damage_item(self) if(self.root)
+        end
+    }
+
+    function onMouseRelease(ev) {
+        onMousePress(ev)
+    }
+
+    function find_slice(dx, dy)
+    {
+        dist     = (dx**2 + dy**2)**0.5
+        min_dist = 0.05*[self.w, self.h].min
+        return nil if dist < min_dist
+        if(abs(dx) > abs(dy))
+            #east vs west
+            if(dx > 0)
+                return 1
+            else
+                return 3
+            end
+        else
+            #north vs south
+            if(dy < 0)
+                return 0
+            else
+                return 2
+            end
+        end
+    }
+
+    function onMousePress(ev) {
+        dx = ev.pos.x-radial.w/2
+        dy = ev.pos.y-radial.h/2
+        slice = find_slice(dx, dy)
+        callback.call(self.flavor) if callback
+        rt = radial.root
+        rt.ego_death radial
+    }
+}

--- a/src/mruby-zest/qml/Selector.qml
+++ b/src/mruby-zest/qml/Selector.qml
@@ -1,0 +1,241 @@
+Widget {
+    id: selector
+    property Object valueRef: nil;
+    property String extern: ""
+    property Array  options: ["text", "test", "asdf"];
+    property Array  opt_vals: []
+    property Int    selected: 0
+    property Bool   active:   true
+    property Function whenValue: nil
+    property Int    max_text: 8
+
+    onExtern: {
+        meta = OSC::RemoteMetadata.new($remote,
+                                       selector.extern)
+        selector.label   = meta.short_name
+        selector.tooltip = meta.tooltip
+        if(meta.options)
+            nopts = []
+            vals  = []
+            meta.options.each do |x|
+                vals  << x[0]
+                nopts << x[1]
+            end
+            selector.options = nopts
+            selector.opt_vals = vals
+        end
+        selector.valueRef = OSC::RemoteParam.new($remote, selector.extern)
+        selector.valueRef.mode = :options
+        selector.valueRef.callback = Proc.new {|x| selector.set_value(x)}
+    }
+
+    function refresh() {
+        self.valueRef.refresh if self.valueRef
+    }
+
+    function set_value(x)
+    {
+        sel = 0
+        opt_vals.each_with_index do |i, ind|
+            sel = ind if i == x
+        end
+
+        self.selected = sel
+        rt = self.root
+        rt.damage_item self if rt
+        whenValue.call if whenValue
+    }
+
+    function aspect2(box, ww, hh)
+    {
+        provided    = box.w/box.h
+        recommended = ww/hh
+        if(recommended > provided)
+            #Decrease height
+            new_height = box.h*provided/recommended
+            box.y += (box.h-new_height)/2
+            box.h = new_height
+        else
+            new_width = box.w*recommended/provided
+            box.x += (box.w-new_width)/2
+            box.w  = new_width
+        end
+    }
+
+    function layout(l, selfBox)
+    {
+        if(!layoutOpts.include?(:no_constraint))
+            scale = 100
+            $vg.font_size scale
+            bb = 1
+            long_mode = layoutOpts.include?(:long_mode)
+            selector.options.each do |x|
+                x = x[0..self.max_text] if x.length > self.max_text && !long_mode
+                bbl  = $vg.text_bounds(0, 0, (x+"    ").upcase)
+                bb   = [bb, bbl].max
+            end
+            scale *= layoutOpts[0] if layoutOpts.include?(:rescale)
+            if(bb != 0)
+                #Width cannot be so small that letters overflow
+                self.aspect2(selfBox, bb, scale)
+            end
+        end
+        selfBox
+    }
+
+    function class_name()
+    {
+        "Selector"
+    }
+
+    function set_value_user(val)
+    {
+        if(val.nil?)
+            damage_self
+            return
+        end
+        return if(val == self.selected)
+        self.selected = val
+        if(self.valueRef && self.selected <= opt_vals.length)
+            self.valueRef.value = self.opt_vals[self.selected]
+        end
+        if(self.valueRef && self.root)
+            self.root.log(:user_value, self.valueRef.display_value, src=self.label)
+        end
+        whenValue.call if whenValue
+
+        damage_self
+    }
+
+    function onMousePress(ev)
+    {
+        create_menu if self.active && options.length != 1
+    }
+
+    function draw_strike(vg)
+    {
+        pad  = 1.0/64
+        pad2 = (1-2*pad)
+        vg.path do
+            vg.move_to(w*pad, h*pad)
+            vg.line_to(w*pad2, h*pad2)
+            vg.stroke_color Theme::TextColor
+            vg.stroke_width 1
+            vg.stroke
+        end
+    }
+
+    function draw_arrow(vg)
+    {
+        pad  = 1.0/64
+        pad2 = (1-2*pad)
+
+        vg.path do |v|
+            tx = w*pad2-h*pad2
+            tw = h*pad2
+            ty = h*pad
+            th = h*pad2
+
+            v.move_to(tx+0.25*tw, ty+0.3*th)
+            v.line_to(tx+0.50*tw, ty+0.7*th)
+            v.line_to(tx+0.75*tw, ty+0.3*th)
+            v.close_path
+
+            v.fill_color Theme::TextColor
+            v.fill
+        end
+    }
+
+    function draw_button(vg)
+    {
+        pad  = 1.0/64
+        pad2 = (1-2*pad)
+        vg.path do |v|
+            v.rounded_rect(w*pad, h*pad, w*(1-2*pad), h*(1-2*pad), 2)
+            paint = v.linear_gradient(0,0,0,h, Theme::ButtonGrad1, Theme::ButtonGrad2)
+            v.fill_paint paint
+            v.fill
+            v.stroke_width 1
+            v.stroke
+        end
+
+        vg.path do |v|
+            hh = h/20
+            v.move_to(w*pad+2,       h*pad+hh)
+            v.line_to(w*(1-2*pad)+1, h*pad+hh)
+            v.stroke_color color("5c5c5c")
+            v.stroke_width hh
+            v.stroke
+        end
+    }
+
+    function draw(vg)
+    {
+        draw_button(vg)
+
+        draw_arrow(vg) if options.length != 1
+
+        draw_strike(vg) if !self.active
+
+        return if options[selected].nil?
+
+        pad  = 1.0/64
+        text_color = Theme::TextColor
+
+        vg.font_face("bold")
+        vg.font_size h*0.8
+        vg.text_align NVG::ALIGN_LEFT | NVG::ALIGN_MIDDLE
+        vg.fill_color text_color
+
+        long_mode = layoutOpts.include?(:long_mode)
+        str = options[selected].upcase
+        str = str[0..self.max_text] if str.length > self.max_text && !long_mode
+
+        vg.text(3+w*pad*2,h/2, str)
+    }
+
+    function onScroll(ev)
+    {
+        return if !self.active
+        i = self.selected
+        i = i + (ev.dy > 0 ? -1 : 1)
+        if ((i > -1) && (i < opt_vals.length))
+            set_value_user(i)
+        end
+    }
+
+    function create_menu()
+    {
+        n = options.length
+        return if n < 1
+        widget = Qml::DropDown.new(self.db)
+        widget.w = self.w
+        widget.h = self.h*n
+        widget.x = 0
+        widget.y = 0
+        widget.layer = 2
+        widget.options = options
+        widget.callback = lambda { |v|
+            set_value_user(v)
+        }
+        #Check if it's too big
+        if(widget.h+global_y > window.h)
+            if(global_y - self.h*(n-1) < 0)
+                if(global_y > window.h*0.5)#upper
+                    widget.h = (global_y+self.h)
+                    widget.y = -global_y
+                else#lower
+                    widget.h = (window.h-global_y)
+                end
+            else
+                widget.y = -self.h*(n-1)
+            end
+        end
+        widget.prime(root())
+
+        Qml::add_child(self, widget)
+        root.smash_draw_seq
+        root.damage_item widget
+    }
+
+}

--- a/src/mruby-zest/qml/Slider.qml
+++ b/src/mruby-zest/qml/Slider.qml
@@ -1,0 +1,90 @@
+Valuator {
+    id: slider
+
+    property Float pad: 0.1
+    property Bool  centered: true
+    property Bool  visual:   false
+
+    function class_name()
+    {
+        "Slider"
+    }
+
+    function draw_centered(vg)
+    {
+        pad2 = (1-2*pad)
+        if(value > 0.5)
+            src = (h/2-h*pad2*(value-0.5))
+            dst = h/2
+            vg.path do |v|
+                v.rect(pad*w, src, pad2*w, (src-dst).abs)
+                v.fill_color Theme::SliderActive
+                v.fill
+            end
+        else
+            vg.path do |v|
+                v.rect(pad*w, h/2, pad2*w, pad2*h*(0.5-value))
+                v.fill_color Theme::SliderActive
+                v.fill
+            end
+        end
+    }
+
+    function draw_normal(vg)
+    {
+        col  = Theme::SliderActive
+        col  = Theme::SliderVisActive if visual
+        pad2 = (1-2*pad)
+        src  = (h-h*pad2*value)
+        dst  = h
+        vg.path do |v|
+            v.rect(pad*w, src, pad2*w, (src-dst).abs)
+            v.fill_color col
+            v.fill
+        end
+    }
+
+    function draw(vg)
+    {
+        self.dragScale = h
+        pad2 = (1-2*pad)
+        vg.path do |v|
+            v.rect(pad*w, pad*h, pad2*w, pad2*h)
+            v.fill_color Theme::SliderBackground
+            v.fill
+        end
+
+        vg.path do |v|
+            v.move_to(pad* w, pad* h)
+            v.line_to(pad* w, pad2*h)
+            v.move_to(pad2*w, pad* h)
+            v.line_to(pad2*w, pad2*h)
+            v.stroke_color color(:black)
+            v.stroke
+        end
+
+        return if value.class != Float
+
+        draw_centered(vg) if  centered
+        draw_normal(vg)   if !centered
+
+
+        vg.path do |v|
+            yloc = (h-h*pad2*value)
+            v.move_to(w*pad,  yloc)
+            v.line_to(w*pad2, yloc)
+            v.stroke_color Theme::SliderStroke
+            v.stroke_width 2.0
+            v.stroke
+        end
+    }
+
+    function onScroll(ev) {
+        super(ev) if !visual
+    }
+
+    function onMousePress(ev) {
+        mouse_handle(ev) if !visual
+    }
+}
+

--- a/src/mruby-zest/qml/Swappable.qml
+++ b/src/mruby-zest/qml/Swappable.qml
@@ -1,0 +1,158 @@
+Widget {
+    id: swappable
+    property String content: nil
+    property Callback whenSwapped: nil
+
+    function rec_del_props(widget, plist=[])
+    {
+        return plist if widget.nil?
+        #Add all properties to the delete list
+        widget.properties.each do |k,v|
+            plist << v
+        end
+        #Add all children properties to the list
+        widget.children.each do |ch|
+            rec_del_props(ch, plist)
+        end
+        plist
+    }
+
+    function rec_clean_cbs(widget)
+    {
+        if(widget.respond_to? :valueRef)
+            v = widget.valueRef
+            if(v.class == Array)
+                v.each do |vv|
+                    vv.clean
+                end
+            else
+                v.clean if v.respond_to? :clean
+            end
+        end
+        widget.children.each do |ch|
+            rec_clean_cbs(ch)
+        end
+    }
+
+    function dump_plist()
+    {
+        plist = swappable.db.instance_eval{@plist}
+        plist.each_with_index do |x, idx|
+            if(idx<50)
+                print idx
+                print " "
+                puts x.to_s
+            end
+        end
+        puts plist.length
+    }
+
+    function remove_old_child()
+    {
+        #it should only be possible that there is a single child
+        if(!self.children.empty?)
+            rec_clean_cbs(children[0])
+            del_list = rec_del_props(swappable.children[0])
+            @db.remove_properties del_list
+
+            root.damage_item(children[0], :all) if root
+            self.children = []
+        end
+    }
+
+    function setup_widget(w)
+    {
+        w.onSetup if w.respond_to?(:onSetup)
+        w.children.each do |c|
+            setup_widget c
+        end
+    }
+
+    function onSetup(old=nil)
+    {
+        create_new_child
+    }
+
+
+    function create_new_child()
+    {
+        return if self.content.nil?
+        return if !self.children.empty?
+
+        t1=Time.new
+        widget = swappable.content.new(swappable.db)
+        t2=Time.new
+        widget.x = 0
+        widget.y = 0
+        widget.w = self.w
+        widget.h = self.h
+        widget.extern = self.extern if !self.extern.empty?
+        Qml::add_child(self, widget)
+        t3=Time.new
+        self.db.update_values
+        t4=Time.new
+        setup_widget widget
+        self.db.update_values
+        t5=Time.new
+
+        if(root)
+            root.smash_layout
+            root.damage_item widget
+        end
+        self.whenSwapped.call if self.whenSwapped
+        [t2-t1, t4-t3, t5-t4]
+    }
+
+    function onMerge(val)
+    {
+        self.content = val.content if(val.respond_to?(:content))
+    }
+
+    function force_update()
+    {
+        cls = "nil"
+        cls = children[0].class if !children.empty?
+        ext = ""
+        ext = children[0].extern if !children.empty?
+        srt = Time.new
+        swappable.remove_old_child
+        #mid = Time.new
+        d2 = swappable.create_new_child
+        dne = Time.new
+        tot = dne-srt
+        #scl = 100/tot
+        #puts("[INFO] Content chagned to #{swappable.content} from #{cls} in #{1000*tot}ms")
+        #puts("[INFO] <#{ext}> => <#{extern}>") if ext != extern
+        #puts("[INFO] Content swap took #{1000*tot}ms (#{(scl*(mid-srt)).to_i}% remove) (#{(scl*(dne-mid)).to_i}% add)")
+        #puts("[INFO]                                 (#{(scl*d2[0]).to_i}% init) (#{(scl*d2[1]).to_i}% update) (#{(scl*d2[2]).to_i}% setup)")
+    }
+
+    onContent: {
+        return if(!swappable.children.empty? &&
+            swappable.children[0].class == swappable.content &&
+            (swappable.extern.empty? || swappable.extern == swappable.children[0].extern))
+        swappable.force_update
+    }
+
+    function layout(l,selfBox)
+    {
+        if(selfBox.nil?)
+            t = self.class_name.to_sym
+            selfBox = l.genBox t, widget
+        end
+
+        return if children.empty?
+
+        child = children[0]
+        if(selfBox.class == LayoutConstBox)
+            box = l.genConstBox(0, 0, selfBox.w, selfBox.h,
+                        child)
+            child.layout(l, box)
+        else
+            box = child.layout(l, nil)
+            l.contains(selfBox, box)
+        end
+
+        selfBox
+    }
+}

--- a/src/mruby-zest/qml/TabButton.qml
+++ b/src/mruby-zest/qml/TabButton.qml
@@ -1,0 +1,80 @@
+Widget {
+    id: button
+    property Function whenClick:     nil
+    property Symbol   highlight_pos: :bottom
+    property Bool     value:    false;
+    property Widget   tabbox: nil
+
+    function onMerge(val) {
+        button.value = val.value if(val.respond_to?(:value))
+    }
+
+    function onMousePress(ev) {
+        button.value = !button.value
+        damage_self
+        whenClick.call if whenClick
+        parent.set_tab(self) if parent.respond_to?(:set_tab)
+    }
+
+    function draw(vg)
+    {
+        bg_color      = color("424B56")
+        bg_on_color   = color("00818E")
+        outline_color = color("000000")
+        dark_off      = color("325A6E")
+        text_color1   = color("52FAFE")
+        text_color2   = Theme::TextColor
+        vg.path do |v|
+            v.rect(0, 0, w, h)
+            if(button.value)
+                v.fill_color(bg_on_color)
+            else
+                paint = v.linear_gradient(0,0,0,h,Theme::ButtonGrad1, Theme::ButtonGrad2)
+                v.fill_paint paint
+            end
+            v.fill
+        end
+        vg.path do |v|
+            v.rect(0,0,w,h)
+            v.stroke_color(outline_color)
+            v.stroke_width 1
+            v.stroke
+        end
+
+        begin
+            pos = 0
+            if(button.highlight_pos == :bottom)
+                pos = h*7/8
+            end
+            vg.path do |v|
+                v.rect(0,pos,w,h/8)
+                v.fill_color(text_color1) if  button.value
+                v.fill_color(dark_off)    if !button.value
+                v.fill
+            end
+        end
+
+
+        vg.font_face("bold")
+        vg.font_size h*0.65
+        vg.text_align NVG::ALIGN_CENTER | NVG::ALIGN_MIDDLE
+        if(button.value)
+            vg.fill_color(text_color1)
+        else
+            vg.fill_color(text_color2)
+        end
+        vg.text(w/2,h/2,button.label.upcase)
+    }
+
+    function layout(l, selfBox) {
+        return selfBox if layoutOpts.include? :no_constraint
+        scale = 100
+        $vg.font_size scale
+        bb = $vg.text_bounds(0, 0, label.upcase)
+        if(bb != 0)
+            #Width cannot be so small that letters overflow
+            l.aspect(selfBox, bb, scale)
+        end
+        selfBox
+    }
+}

--- a/src/mruby-zest/qml/Text.qml
+++ b/src/mruby-zest/qml/Text.qml
@@ -1,0 +1,51 @@
+Widget {
+    id: text
+    property Color textColor: Theme::TextColor
+    property Float height: 0.5
+    property Symbol align: :center
+
+    function class_name()
+    {
+        "Text"
+    }
+
+    function draw(vg)
+    {
+        scale = 100
+        $vg.font_size scale
+        bb = $vg.text_bounds(0, 0, label.upcase)
+
+
+        vg.font_face("bold")
+        if(w/(self.height*h) < bb)
+            vg.font_size self.height*h
+        else
+            vg.font_size self.height*h
+        end
+        vg.fill_color(self.textColor)
+        if(align == :center)
+            vg.text_align NVG::ALIGN_CENTER | NVG::ALIGN_MIDDLE
+            vg.text(w/2,h/2,label.upcase)
+        else
+            vg.text_align NVG::ALIGN_LEFT | NVG::ALIGN_MIDDLE
+            vg.text(0,h/2,label.upcase)
+        end
+    }
+
+    function layout(l, selfBox)
+    {
+        scale = 100
+        $vg.font_size scale
+        bb = $vg.text_bounds(0, 0, label.upcase)
+        if(bb != 0 && !self.layoutOpts.include?(:ignoreAspect) &&
+           !self.layoutOpts.include?(:no_constraint))
+            #Width cannot be so small that letters overflow
+            if(height == 0.5)
+                l.aspect(selfBox, bb, 1.5*scale)
+            else
+                l.aspect(selfBox, bb, scale)
+            end
+        end
+        selfBox
+    }
+}

--- a/src/mruby-zest/qml/TextEdit.qml
+++ b/src/mruby-zest/qml/TextEdit.qml
@@ -1,0 +1,120 @@
+Widget {
+    id: text
+    property signal action: nil;
+    property Color  textColor: Theme::TextColor
+    property Float  height: 0.1
+    property Object valueRef: nil
+
+    function animate()
+    {
+        if(root.key_widget != self)
+            @next = nil
+            if(@state)
+                @state = nil
+                damage_self
+            end
+            return
+        end
+        now = Time.new
+        if(@next.nil?)
+            @next = now + 0.1
+            return
+        elsif(@next < now)
+            @state = !@state
+            @next = now + 0.7
+            damage_self
+        end
+    }
+
+    onExtern: {
+        text.valueRef = OSC::RemoteParam.new($remote, text.extern)
+        text.valueRef.callback = Proc.new {|x|
+            text.label = x;
+            text.damage_self}
+    }
+
+    function class_name()
+    {
+        "Text"
+    }
+
+    function onSpecial(k, mode)
+    {
+        return if @edit.nil?
+        return if mode != :press
+        if(k == :up)
+            @edit.up
+        elsif(k == :down)
+            @edit.down
+        elsif(k == :left)
+            @edit.left
+        elsif(k == :right)
+            @edit.right
+        end
+        @state = true
+        now = Time.new
+        @next = now + 0.7
+        damage_self
+    }
+
+    function onKey(k, mode)
+    {
+        return if mode != "press"
+        pos = self.label.length
+        pos = @edit.pos if @edit
+        ll = self.label
+        if(k.ord == 8)
+            pos -= 1
+            if(pos >= ll.length)
+                self.label = ll.slice(0, ll.length-1)
+            elsif(pos >= 0)
+                self.label = ll.slice(0, pos) + ll.slice(pos+1, ll.length)
+            end
+        else
+            self.label = ll.insert(pos, k)
+        end
+        ll = self.label
+        self.valueRef.value = ll if self.valueRef
+        @edit     = EditRegion.new($vg, ll, w-20, height*h)
+        if(k.ord == 8)
+            @edit.pos = pos
+        else
+            @edit.pos = pos+1
+        end
+        damage_self
+    }
+
+    function draw(vg)
+    {
+        background Theme::VisualBackground
+        input  = self.label
+        if(input.nil?)
+            input  = "This is some random text which is hopefully "
+            input += "is long enough to span a few different lines"
+            input += ". I need it to in order to test multi-line "
+            input += "rendering."
+        end
+
+        vg.font_face("bold")
+        vg.font_size height*h
+        vg.text_align NVG::ALIGN_LEFT | NVG::ALIGN_MIDDLE
+        vg.fill_color(textColor)
+        ypos = height*h/2
+        lasty = ypos
+        lastx = 0
+
+        #Break into lines
+        @edit     ||= EditRegion.new(vg, input, w-20, height*h)
+
+        @edit.each_string do |x, y, str, cursor|
+            if(cursor == false)
+                vg.text(x+10, y, str)
+            else
+                if(@state)
+                vg.text_align NVG::ALIGN_CENTER | NVG::ALIGN_MIDDLE
+                    vg.text(x+10, y, str)
+                end
+            end
+        end
+    }
+}

--- a/src/mruby-zest/qml/TextScroll.qml
+++ b/src/mruby-zest/qml/TextScroll.qml
@@ -1,0 +1,87 @@
+Widget {
+    id: text
+    property signal action: nil;
+    property Color  textColor: Theme::TextColor
+    // Number of text lines visible in the widget.
+    property Int    lines: 30
+    property Object valueRef: nil
+    property Int    off: 0
+
+    // Internal property, not meant to be changed from outside.
+    property Int _content_lines: -1
+
+    function class_name() { "TextScroll" }
+
+    ScrollBar {
+        id: scroll
+        bar_size: scrollbar_size()
+        whenValue: lambda { text.tryScroll }
+    }
+
+    function scrollbar_size()
+    {
+        compute_content_lines()
+        ratio = [0.05, [1.0, lines.to_f / _content_lines].min].max
+        ratio
+    }
+    
+    function onScroll(ev)
+    {
+        return if !scroll.active
+        scroll.updatePos(-ev.dy.to_f/(_content_lines-lines))
+    }
+
+    function compute_content_lines()
+    {
+        if (self._content_lines > -1)
+          return
+        end
+        self._content_lines = 0
+        self.label.each_line do |l|
+            self._content_lines += 1
+        end
+        self._content_lines
+    }
+
+    function tryScroll()
+    {
+        if ((_content_lines - lines) <= 0)
+          self.off = 0
+          damage_self
+          return
+        end
+        start = (1.0-scroll.value)*(_content_lines-lines) + 0.5
+        start = start.to_i
+        if(start != self.off)
+            self.off = start
+            damage_self
+        end
+    }
+
+    function layout(l, selfBox)
+    {
+        children[0].fixed(l, selfBox, 0.00, 0, 0.02, 1.0)
+        selfBox
+    }
+
+    function draw(vg)
+    {
+        background Theme::VisualBackground
+        input  = self.label
+
+        hh = h/lines
+        vg.font_face("bold")
+        vg.font_size hh
+        vg.text_align NVG::ALIGN_LEFT | NVG::ALIGN_MIDDLE
+        vg.fill_color(textColor)
+
+        ind = 0
+        input.each_line do |l|
+            ii = ind-self.off
+            break if ii >= self.lines
+            vg.text(10+0.02*w, hh/2+hh*ii, l) if ii >= 0
+            ind += 1
+        end
+
+    }
+}

--- a/src/mruby-zest/qml/TextSel.qml
+++ b/src/mruby-zest/qml/TextSel.qml
@@ -1,0 +1,80 @@
+Widget {
+    id: textsel
+    property Object valueRef: nil;
+    property String extern: ""
+    property Array  options: ["text", "test", "asdf"];
+    property Array  opt_vals: []
+    property Int    selected: 0
+    property Function whenValue: nil
+
+    onExtern: {
+        meta = OSC::RemoteMetadata.new($remote,
+                                       textsel.extern)
+        textsel.label   = meta.short_name
+        textsel.tooltip = meta.tooltip
+        if(meta.options)
+            nopts = []
+            vals  = []
+            meta.options.each do |x|
+                vals  << x[0]
+                nopts << x[1]
+            end
+            textsel.options = nopts
+            textsel.opt_vals = vals
+        end
+        textsel.valueRef = OSC::RemoteParam.new($remote, textsel.extern)
+        textsel.valueRef.mode = :options
+        textsel.valueRef.callback = Proc.new {|x| textsel.set_value(x)}
+    }
+
+    function set_value(x)
+    {
+        sel = 0
+        opt_vals.each_with_index do |i, ind|
+            sel = ind if i == x
+        end
+
+        self.selected = sel
+        rt = self.root
+        rt.damage_item self if rt
+    }
+
+    function layout(l, selfBox)
+    {
+        if(!layoutOpts.include?(:no_constraint))
+            scale = 100
+            $vg.font_size scale
+            bb = 1
+            textsel.options.each do |x|
+                x = x[0..8] if x.length > 8
+                bbl  = $vg.text_bounds(0, 0, (x+"    ").upcase)
+                bb   = [bb, bbl].max
+            end
+            scale *= layoutOpts[0] if layoutOpts.include?(:rescale)
+            if(bb != 0)
+                #Width cannot be so small that letters overflow
+                l.aspect(selfBox, scale, bb)
+            end
+        end
+        selfBox
+    }
+
+    function class_name()
+    {
+        "TextSel"
+    }
+
+    function draw(vg)
+    {
+        text_color = Theme::TextColor
+        pad  = 1.0/64
+        pad2 = (1-2*pad)
+        return if options[selected].nil?
+
+        vg.font_face("bold")
+        vg.font_size h*0.8
+        vg.text_align NVG::ALIGN_LEFT | NVG::ALIGN_MIDDLE
+        vg.fill_color text_color
+        vg.text(3+w*pad*2,h/2,(options[selected]).upcase)
+    }
+}

--- a/src/mruby-zest/qml/ThemeOld.qml
+++ b/src/mruby-zest/qml/ThemeOld.qml
@@ -1,0 +1,31 @@
+Object {
+    id: theme
+    const Color global_dim:       color("#114575")
+    const Color global_bright:    color("#3ac5ec")
+
+
+    const Color env_background:   color("#808080")
+    const Color env_fill_color:   color("#0d0d0d")
+    const Color env_stroke_color: color("#014767")
+    const Color env_light_fill:   color("#114575", 55)
+    const Color env_bright:       theme.global_bright
+    const Color env_dim:          theme.global_dim
+    const Color env_sel:          color("#00ff00")
+
+    const Color knob_bright:      theme.global_bright
+    const Color knob_dim:         theme.global_dim
+
+    const Color button_on:        color("#00ff00")
+    const Color button_off:       color("#04375e")
+    const Color button_outline:   color("#0089b9")
+    const Color button_text1:     color("#00c2ea")
+    const Color button_text2:     color("#00c2ea")
+
+    const Color dropdown_color:   color("#000080")
+
+    function color(x, alpha=255)
+    {
+        nil
+    }
+
+}

--- a/src/mruby-zest/qml/ToggleButton.qml
+++ b/src/mruby-zest/qml/ToggleButton.qml
@@ -1,0 +1,45 @@
+Button {
+    id: toggle
+    property Object valueRef: nil
+    onExtern: {
+        meta = OSC::RemoteMetadata.new($remote, toggle.extern)
+        toggle.label   = meta.short_name if toggle.label.empty?
+        toggle.tooltip = meta.tooltip
+        toggle.valueRef.clean if toggle.valueRef
+        toggle.valueRef = OSC::RemoteParam.new($remote, toggle.extern)
+        toggle.valueRef.callback = lambda {|x| toggle.setValue(x)}
+    }
+
+    function setValue(x)
+    {
+        self.value = x
+        whenValue.call if whenValue
+        damage_self
+    }
+
+    function refresh() {
+        self.valueRef.refresh if self.valueRef
+    }
+
+    function onMousePress(ev) {
+        return if !self.active
+        if(root.learn_mode && extern)
+            $remote.automate(extern)
+            root.log(:tooltip, "Learning #{extern}")
+            return
+        end
+        self.value = !self.value
+        self.valueRef.value = self.value if self.valueRef
+        damage_self
+        whenValue.call if whenValue
+    }
+
+    function onMouseEnter(ev)
+    {
+        if(self.tooltip.nil? || self.tooltip.empty?)
+            self.root.log(:tooltip, "extern = <" + self.extern + ">")
+        else
+            self.root.log(:tooltip, self.tooltip)
+        end
+    }
+}

--- a/src/mruby-zest/qml/TriggerButton.qml
+++ b/src/mruby-zest/qml/TriggerButton.qml
@@ -1,0 +1,18 @@
+Button {
+    function onMousePress(ev) {
+        return if !self.active
+        self.value = 1.0
+        whenValue.call if whenValue
+        damage_self
+    }
+
+    function animate()
+    {
+        return if self.value == 0
+        return if self.value == false
+        return if self.value == true
+        self.value *= 0.9
+        self.value  = 0 if self.value < 0.02
+        damage_self
+    }
+}

--- a/src/mruby-zest/qml/VSlider.qml
+++ b/src/mruby-zest/qml/VSlider.qml
@@ -1,0 +1,8 @@
+Valuator {
+    id: slider
+
+    function draw(vg)
+    {
+        vg.drawVZSlider(slider.t, *slider.bbox)
+    }
+}

--- a/src/mruby-zest/qml/Valuator.qml
+++ b/src/mruby-zest/qml/Valuator.qml
@@ -1,0 +1,207 @@
+Widget {
+    id: valuator
+    property Object valueRef: nil;
+    property Object prev:     nil;
+
+    property Float value: 1.0;
+
+    property Float dragScale: 200.0;
+    property Bool  vertical: true
+
+    property Function whenValue: nil;
+
+    property Bool active: true
+
+    property Symbol type: nil
+
+    property String units: nil
+
+    onExtern: {
+        meta = OSC::RemoteMetadata.new($remote, valuator.extern)
+        valuator.label   = meta.short_name if valuator.label == ""
+        valuator.tooltip = meta.tooltip
+        valuator.units   = meta.units
+
+        valuator.valueRef = OSC::RemoteParam.new($remote, valuator.extern)
+        valuator.valueRef.set_min(meta.min)
+        valuator.valueRef.set_max(meta.max)
+        valuator.valueRef.set_scale(meta.scale)
+        valuator.valueRef.type     = "f" if valuator.type
+        valuator.valueRef.callback = Proc.new {|x| valuator.setValue(x)}
+
+    }
+
+    //Callback function which does not propagate info to remote API
+    function setValue(v) {
+        self.value = lim(v, 0.0, 1.0)
+        damage_self
+    }
+
+    function refresh() { valueRef.refresh if valueRef }
+
+    function create_radial()
+    {
+        return
+        gbl_cx = valuator.global_x + 0.5*valuator.w
+        gbl_cy = valuator.global_y + 0.5*valuator.h
+        gbl_w  = window.w
+        gbl_h  = window.h
+
+        ropt = [gbl_cx, gbl_cy, gbl_w-gbl_cx, gbl_h-gbl_cy].min
+
+        diameter = [2.0*ropt, 3.0*0.5*(valuator.w+valuator.h)].min
+
+        widget = RadialMenu.new(valuator.db)
+        widget.w = diameter
+        widget.h = diameter
+        widget.x = valuator.w/2-diameter/2
+        widget.y = valuator.h/2-diameter/2
+        widget.layer = 2
+        widget.callback = lambda {|sel|
+            case sel
+            when 0
+                valueRef.midi_learn if valueRef
+            when 1
+                valueRef.rand if valueRef
+            when 2
+                valueRef.midi_unlearn if valueRef
+            when 3
+                valueRef.default if valueRef
+            end
+        }
+
+        Qml::add_child(valuator, widget)
+        valuator.root.smash_draw_seq
+        valuator.root.damage_item widget
+    }
+
+    function onScroll(ev)
+    {
+        return if !self.active
+        fine = root.fine_mode ? 0.2 : 1.0
+        updatePos(-fine*ev.dy/50.0)
+    }
+
+    function reset() {
+        reset_value = 64.01/127.0
+        if(valueRef)
+            old_dsp = self.valueRef.display_value
+
+            self.valueRef.value = reset_value
+            self.value = reset_value
+            new_dsp = self.valueRef.display_value
+            whenValue.call if whenValue && (new_dsp.nil? || old_dsp != new_dsp)
+            valuator.root.log(:user_value, valuator.valueRef.display_value, src=valuator.label)
+        else
+            self.value = reset_value
+        end
+        damage_self
+    }
+
+    function onMousePress(ev) {
+        mouse_handle(ev)
+    }
+
+    function mouse_handle(ev) {
+        return if !self.active
+        if(root.learn_mode && extern)
+            $remote.automate(extern)
+            root.log(:tooltip, "Learning #{extern}")
+        end
+        if(ev.buttons.include? :leftButton)
+            valuator.prev = ev.pos
+            now = Time.new
+            #400 ms delta for double click
+            if(@click_time && (now-@click_time) < 0.400)
+                $remote.default(extern) if extern
+                whenValue.call if whenValue
+                if (valuator.valueRef)
+                    dsp = displayValueToText(valuator.valueRef.display_value)
+                    self.root.log(:tooltip, dsp)
+                end
+            end
+            @click_time = now
+        elsif(ev.buttons.include? :rightButton)
+            if(children.empty?)
+                create_radial
+            end
+        elsif(ev.buttons.include? :middleButton)
+            reset
+        elsif(ev.buttons.include? :drag_and_drop)
+            puts "sending dnd event..."
+            $remote.action("/last_dnd", self.extern)
+        else
+            valuator.prev = nil
+        end
+    }
+
+    function onMouseMove(ev) {
+        return if !self.active
+        fine = root.fine_mode ? 0.05 : 1.0
+        if(prev)
+            delta = if(vertical)
+                +(ev.pos.y - self.prev.y)
+            else
+                -(ev.pos.x - self.prev.x)
+            end
+            updatePos(fine*delta/dragScale)
+            self.prev = ev.pos
+        end
+    }
+
+    function onMouseEnter(ev) {
+        dsp = self.tooltip
+        if (valuator.valueRef)
+            dsp = displayValueToText(valuator.valueRef.display_value) + "   " +
+              dsp
+        end
+        self.root.log(:tooltip, dsp)
+    }
+
+    function lim(x, low, high)
+    {
+        [low, [x, high].min].max
+    }
+
+    function displayValueToText(dval) {
+        if (dval.class == Float)
+            tval = dval.round(2)
+        else
+            tval = dval
+        end
+        tval = tval.to_s
+        if(valuator.units && valuator.units != "none")
+            tval += " "
+            tval += valuator.units
+        end
+        return tval
+    }
+
+    function updatePosAbs(tmp) {
+        nvalue = lim(tmp, 0.0, 1.0)
+        if(valuator.valueRef)
+            old_dsp = valuator.valueRef.display_value
+            valuator.valueRef.value = nvalue
+            valuator.value = nvalue
+            new_dsp = valuator.valueRef.display_value
+            whenValue.call if whenValue && (new_dsp.nil? || old_dsp != new_dsp)
+            out_value = displayValueToText(valuator.valueRef.display_value)
+            valuator.root.log(:user_value, out_value, src=valuator.label)
+        else
+            valuator.value = nvalue
+            whenValue.call if whenValue
+        end
+        damage_self
+    }
+
+    function updatePos(delta) {
+        updatePosAbs(valuator.value - delta)
+    }
+
+    function onMerge(val)
+    {
+        return if self.class != val.class
+        valuator.value = val.value if(val.respond_to?(:value))
+    }
+
+}

--- a/src/mruby-zest/qml/Widget.qml
+++ b/src/mruby-zest/qml/Widget.qml
@@ -1,0 +1,164 @@
+Object {
+    //property Layout layout: parent.layout
+    id: widget
+
+    property Object parent: nil
+
+    property Array children: []
+
+    property String label: ""
+
+    property String tooltip: ""
+
+    property Array layoutOpts: []
+
+    property String extern: ""
+
+    property Int layer: 0;
+
+    property Int x: nil;
+    property Int y: nil;
+    property Int w: nil;
+    property Int h: nil;
+
+    function draw(vg)
+    {}
+
+    function onSetup(old=nil)
+    {
+    }
+
+    function layout(l, selfBox)
+    {
+        widget.children.each do |child|
+            if(child.respond_to?(:layout))
+                nbox = l.genConstBox(0, 0,
+                    selfBox.w, selfBox.h, child)
+                child.layout(l, nbox)
+            end
+        end
+
+        selfBox
+    }
+
+    function fixed(l, pbox, xc, yc, wc, hc)
+    {
+        box = nil
+        selfBox = l.genConstBox(pbox.w*xc, pbox.h*yc, pbox.w*wc, pbox.h*hc, self)
+        box = self.layout(l, selfBox)
+        box
+    }
+
+    function fixed_long(l, pbox, xc, yc, wc, hc, xf, yf, wf, hf)
+    {
+        l.fixed_long(self, pbox, xc, yc, wc, hc, xf, yf, wf, hf)
+    }
+
+    function damage_self(all=nil)
+    {
+        rt = self.root
+        rt.damage_item(self, all) if rt
+    }
+
+    //Utility methods
+    function background(c)
+    {
+        $vg.path do |v|
+            v.rect(0,0,w,h)
+            v.fill_color c
+            v.fill
+        end
+    }
+
+    function class_name() {
+        "Widget"
+    }
+
+    function window() {
+        if(parent.respond_to?(:root))
+            parent.window
+        else
+            self
+        end
+    }
+
+    function root() {
+        if(parent.respond_to?(:root))
+            parent.root
+        else
+            parent
+        end
+    }
+
+    function global_x() {
+        par = 0
+        if(parent.respond_to?(:global_x))
+            par = parent.global_x
+        end
+        par + widget.x
+    }
+
+    function global_y() {
+        par = 0
+        if(parent.respond_to?(:global_y))
+            par = parent.global_y
+        end
+        par + widget.y
+    }
+
+    //(defun print-tree (tree &optional (offset 0))
+    //  (loop for node in tree do
+    //         (terpri)
+    //                (loop repeat offset do (princ " |"))
+    //                       (format t "-~a" (car node))
+    //                              (print-tree (cdr node) (1+ offset))))
+    function to_s(i=0)
+    {
+        out = ""
+        i.times do
+            out += " |"
+        end
+
+        out += "- <"+widget.class_name()+"##{widget.ui_path}:" + widget.label
+        out += ">\n"
+        widget.children.each do |x|
+            out += x.to_s(i+1)
+        end
+
+        out
+    }
+
+    function abs_x()
+    {
+        p = parent
+        if(p.respond_to?(:root))
+            widget.x + p.abs_x
+        else
+            widget.x
+        end
+    }
+
+    function abs_y()
+    {
+        p = parent
+        if(p.respond_to?(:root))
+            widget.y + p.abs_y
+        else
+            widget.y
+        end
+    }
+    
+    function onMouseEnter(ev) {
+        if(self.tooltip != "" and self.root.respond_to?(:log))
+            self.root.log(:tooltip, self.tooltip)
+        end
+    }
+
+    function onMouseLeave(ev)
+    {
+        if (self.root.respond_to?(:log))
+            self.root.log(:tooltip, "")
+        end
+    }
+
+}

--- a/src/mruby-zest/qml/Window.qml
+++ b/src/mruby-zest/qml/Window.qml
@@ -1,0 +1,9 @@
+Widget {
+    function class_name()
+    {
+        "Window"
+    }
+    function draw(vg)
+    {
+    }
+}

--- a/src/mruby-zest/src/quickdraw.c
+++ b/src/mruby-zest/src/quickdraw.c
@@ -1,0 +1,328 @@
+#include <mruby.h>
+#include <mruby/variable.h>
+#include <mruby/array.h>
+#include <mruby/object.h>
+#include <math.h>
+//def self.normalize(seq)
+//    min = 1
+//    max = -1
+//    seq.each do |x|
+//        min = x if x < min
+//        max = x if x > max
+//    end
+//    mag = [max,-min].max
+//    mag = 1.0 if mag == 0.0
+//    (0...seq.length).each do |i|
+//        seq[i] /= mag
+//    end
+//    seq
+//end
+static void
+normalize(float *f, int n)
+{
+    float min = 1;
+    float max = -1;
+    for(int i=0; i<n; ++i) {
+        if(f[i] < min)
+            min = f[i];
+        if(f[i] > max)
+            max = f[i];
+    }
+    float mag = max > -min ? max : -min;
+    if(mag == 0)
+        mag = 1.0;
+    for(int i=0; i<n; ++i)
+        f[i] /= mag;
+}
+
+float
+get(mrb_state *mrb, mrb_value v, const char *field)
+{
+    mrb_value asdf = mrb_funcall(mrb, v, field, 0);
+    if(asdf.tt == MRB_TT_FIXNUM)
+        return asdf.value.i;
+    else
+        return asdf.value.f;
+}
+
+//def self.plot(vg, ypts, bb, do_norm=true, phase=0)
+//    ypts = DSP::normalize(ypts) if do_norm
+//    #xpts = Draw::DSP::linspace(0,1,ypts.length)
+//    off = (phase * (ypts.length-1)).to_i
+//    vg.path do |v|
+//        ypos = bb.y+bb.h/2-bb.h/2*ypts[off]
+//        ypos = [bb.y, [ypos, bb.y+bb.h].min].max
+//        vg.move_to(bb.x, ypos)
+//
+//        x_m = bb.w
+//        x_b = bb.x
+//
+//        y_m = -bb.h/2
+//        y_b = bb.y+bb.h/2
+//        mx = bb.y+bb.h
+//        mn = bb.y
+//        
+//        n = ypts.length
+//        (1...n).each do |pt|
+//            ii = (off+pt)%n
+//            ypos = y_m*ypts[ii] + y_b
+//            ypos = mx if ypos > mx
+//            ypos = mn if ypos < mn
+//            vg.line_to(x_m*pt/n + x_b, ypos)
+//        end
+//        v.stroke_color Theme::VisualLine
+//        v.stroke_width 2.0
+//        v.stroke
+//    end
+//end
+mrb_value
+draw_oscil_plot(mrb_state *mrb, mrb_value self)
+{
+    mrb_value vg;
+    mrb_value ypts;
+    mrb_value bb;
+    mrb_value do_norm;
+    mrb_float phase;
+    mrb_bool under_highlight;
+
+    mrb_get_args(mrb, "oooofb", &vg, &ypts, &bb, &do_norm, &phase, &under_highlight);
+
+    int n = RARRAY_LEN(ypts);
+    float *f = (float*)mrb_malloc(mrb, n*sizeof(float));
+    for(int i=0; i<n; ++i)
+        f[i] = mrb_ary_ref(mrb, ypts, i).value.f;
+
+    if(mrb_obj_equal(mrb, mrb_true_value(), do_norm))
+        normalize(f, n);
+
+    const float bound_x = get(mrb, bb, "x");
+    const float bound_y = get(mrb, bb, "y");
+    const float bound_w = get(mrb, bb, "w");
+    const float bound_h = get(mrb, bb, "h");
+
+    int off = phase * (n-1);
+
+    const int min_y = bound_y;
+    const int max_y = bound_y + bound_h;
+
+    int ii = off%n;
+    float initial_y = -bound_h/2*f[ii] + bound_y+bound_h/2.0;
+    float ypos = initial_y;
+
+    if(ypos > max_y) ypos = max_y;
+    if(ypos < min_y) ypos = min_y;
+    
+    float y_peak = ypos;
+
+    int stage;
+
+    // If under-highlight is activated, we need to render the graph in two stages
+    // First stage is the highlight fill
+    // Second stage is the function's stroke
+    if (under_highlight) {
+        stage = 1;
+    }
+    else {
+        stage = 2;
+    }
+
+    struct RClass *theme       = mrb_module_get(mrb, "Theme");
+    mrb_value linecolor        = mrb_mod_cv_get(mrb, theme, mrb_intern_cstr(mrb,
+                                                "VisualLine"));
+    mrb_value highlight_grad_1 = mrb_mod_cv_get(mrb, theme, mrb_intern_cstr(mrb,
+                                                "FilterHighlight1"));
+    mrb_value highlight_grad_2 = mrb_mod_cv_get(mrb, theme, mrb_intern_cstr(mrb,
+                                                "FilterHighlight2"));
+
+    for (; stage <= 2; ++stage) {
+        mrb_funcall(mrb, vg, "begin_path", 0);
+
+        mrb_funcall(mrb, vg, "move_to", 2,
+                mrb_float_value(mrb, bound_x),
+                mrb_float_value(mrb, initial_y));
+
+        for(int i=1; i<n; ++i) {
+            ii = (off+i)%n;
+            ypos = -bound_h/2*f[ii] + bound_y+bound_h/2.0;
+
+            if(ypos > max_y) ypos = max_y;
+            if(ypos < min_y) ypos = min_y;
+
+            mrb_funcall(mrb, vg, "line_to", 2,
+                    mrb_float_value(mrb, bound_w*ii/n + bound_x),
+                    mrb_float_value(mrb, ypos));
+
+            if (ypos < y_peak)
+                y_peak = ypos;
+        }
+
+        if (stage == 1) {
+            y_peak = fmax(y_peak, (bound_y + bound_h) / 2.0f);
+
+            mrb_funcall(mrb, vg, "line_to", 2,
+                    mrb_float_value(mrb, bound_x + bound_w),
+                    mrb_float_value(mrb, bound_y + bound_h));
+
+            mrb_funcall(mrb, vg, "line_to", 2,
+                    mrb_float_value(mrb, bound_x),
+                    mrb_float_value(mrb, bound_y + bound_h));
+
+            mrb_funcall(mrb, vg, "line_to", 2,
+                    mrb_float_value(mrb, bound_x),
+                    mrb_float_value(mrb, initial_y));
+
+            mrb_value gradient_paint = mrb_funcall(mrb, vg, "linear_gradient", 6,
+                    mrb_float_value(mrb, bound_x),
+                    mrb_float_value(mrb, bound_y + bound_h),
+                    mrb_float_value(mrb, bound_x),
+                    mrb_float_value(mrb, y_peak),
+                    highlight_grad_1,
+                    highlight_grad_2);
+
+            mrb_funcall(mrb, vg, "fill_paint", 1, gradient_paint);
+
+            mrb_funcall(mrb, vg, "fill", 0);
+        }
+        else {
+            mrb_funcall(mrb, vg, "stroke_color", 1, linecolor);
+            mrb_funcall(mrb, vg, "stroke_width", 1, mrb_float_value(mrb, 2.0));
+            mrb_funcall(mrb, vg, "stroke", 0);
+        }
+
+        mrb_funcall(mrb, vg, "close_path", 0);
+    }
+
+    mrb_free(mrb, f);
+    return self;
+}
+
+//def self.norm_harmonics(seq)
+//    (0...seq.length).each do |i|
+//        seq[i] = -seq[i] if seq[i] < 0
+//    end
+//    max = -1
+//    seq.each do |x|
+//        max = x if x > max
+//    end
+//    (0...seq.length).each do |i|
+//        seq[i] = (seq[i]/max)**0.1
+//    end
+//    seq
+//end
+static mrb_value
+norm_harmonics(mrb_state *mrb, mrb_value self)
+{
+    mrb_value ary;
+    mrb_get_args(mrb, "o", &ary);
+    int n = RARRAY_LEN(ary);
+    float *f = (float*)mrb_malloc(mrb, n*sizeof(float));
+    for(int i=0; i<n; ++i)
+        f[i] = mrb_ary_ref(mrb, ary, i).value.f;
+
+    float max = -1.0;
+    for(int i=0; i<n; ++i) {
+        if(f[i] < 0)
+            f[i] *= -1;
+        if(f[i] > max)
+            max = f[i];
+    }
+
+    for(int i=0; i<n; ++i)
+        mrb_ary_set(mrb, ary, i,
+                mrb_float_value(mrb, powf(f[i]/max, 0.1)));
+    return ary;
+}
+
+//def self.bar(vg, data, bb, bar_color, xx=nil)
+//    n    = data.length
+//    xpts = Draw::DSP::linspace(0,1,n)
+//    bx   = bb.x
+//    bw   = bb.w
+//    by   = bb.y
+//    bh   = bb.h 
+//
+//    y  = by+bh
+//
+//    vg.stroke_color bar_color
+//    vg.stroke_width 1.0
+//    (0...n).each do |i|
+//        x  = bx + xpts[i]*bw      if !xx
+//        x  = bx + xx[i]  *bw/64.0 if  xx
+//        vg.path do
+//            vg.move_to(x, y)
+//            vg.line_to(x, y-bh*data[i])
+//            vg.stroke
+//        end
+//    end
+//end
+static mrb_value
+bar(mrb_state *mrb, mrb_value self)
+{
+    mrb_value vg;
+    mrb_value ypts;
+    mrb_value bb;
+    mrb_value color;
+    mrb_value xx;
+
+    mrb_get_args(mrb, "ooooo", &vg, &ypts, &bb, &color, &xx);
+
+    int n = RARRAY_LEN(ypts);
+    float *f = (float*)mrb_malloc(mrb, n*sizeof(float));
+    for(int i=0; i<n; ++i)
+        f[i] = mrb_ary_ref(mrb, ypts, i).value.f;
+
+    const float bound_x = get(mrb, bb, "x");
+    const float bound_y = get(mrb, bb, "y");
+    const float bound_w = get(mrb, bb, "w");
+    const float bound_h = get(mrb, bb, "h");
+
+    const float y  = round(bound_y+bound_h);
+    mrb_funcall(mrb, vg, "stroke_color", 1, color);
+    mrb_funcall(mrb, vg, "stroke_width", 1, mrb_float_value(mrb, 1.0));
+
+    mrb_funcall(mrb, vg, "translate", 2,
+        mrb_float_value(mrb, 0.5f),
+        mrb_float_value(mrb, 0.5f));
+
+    for(int i=0; i<n; ++i)
+    {
+        float x;
+        if(mrb_obj_equal(mrb, mrb_nil_value(), xx)) {
+            x = bound_x + i*1.0/(n-1)*bound_w;
+        } else {
+            x = bound_x + mrb_ary_ref(mrb, xx, i).value.f*bound_w/64.0;
+        }
+
+        x = round(x);
+
+        const int target_y = round(y-bound_h*f[i]);
+
+        mrb_funcall(mrb, vg, "begin_path", 0);
+        mrb_funcall(mrb, vg, "move_to", 2,
+                mrb_float_value(mrb, x),
+                mrb_float_value(mrb, y));
+        mrb_funcall(mrb, vg, "line_to", 2,
+                mrb_float_value(mrb, x),
+                mrb_float_value(mrb, target_y));
+        mrb_funcall(mrb, vg, "stroke", 0);
+        mrb_funcall(mrb, vg, "close_path", 0);
+    }
+
+    mrb_funcall(mrb, vg, "translate", 2,
+            mrb_float_value(mrb, -0.5f),
+            mrb_float_value(mrb, -0.5f));
+
+    mrb_free(mrb, f);
+    return self;
+}
+
+void
+mrb_mruby_zest_gem_init(mrb_state *mrb) {
+    struct RClass *module = mrb_define_module(mrb, "Draw");
+    mrb_define_class_method(mrb, module, "opt_plot", draw_oscil_plot, MRB_ARGS_REQ(6));
+    mrb_define_class_method(mrb, module, "opt_norm_harmonics", norm_harmonics, MRB_ARGS_REQ(1));
+    mrb_define_class_method(mrb, module, "opt_bar", bar, MRB_ARGS_REQ(5));
+}
+void
+mrb_mruby_zest_gem_final(mrb_state* mrb) {
+}

--- a/src/mruby-zest/test/IndentTest.qml
+++ b/src/mruby-zest/test/IndentTest.qml
@@ -1,0 +1,22 @@
+Widget {
+    id: ident
+
+    function class_name() { "Indent" }
+    function layout(l)
+    {
+        selfBox = l.genBox :indent, ident
+        if(!indent.children.empty?)
+            ch = indent.children[0].layout l
+            l.contains selfBox, ch
+        end
+        selfBox
+    }
+
+    function draw(vg) { 
+        vg.path do |v|
+            v.rounded_rect(0, 0, w, h, 10)
+            v.fill_color(NVG.rgba(9, 0, 0, 255))
+            v.fill
+        end
+    }
+}

--- a/src/mruby-zest/test/OverlayBox.qml
+++ b/src/mruby-zest/test/OverlayBox.qml
@@ -1,0 +1,36 @@
+Widget {
+    id: overlaybox
+
+    function draw(vg)
+    {
+        vg.path do |v|
+            v.rect(0,0,w,h)
+            v.fill_color(NVG.rgba(0xff,0xff,0xff,0x80))
+            v.fill
+        end
+        vg.path do |v|
+            v.move_to(0,0)
+            v.line_to(w,h)
+            v.move_to(w,0)
+            v.line_to(0,h)
+            v.stroke_color(NVG.rgba(0xff,0xff,0xff,0xff))
+            v.stroke
+        end
+    }
+    
+    function onMousePress(ev) {
+        puts "I got a mouse press (overlaybox)"
+        rt = overlaybox.root
+        rt.ego_death overlaybox
+        #puts test.root
+        #if(children.empty?)
+        #    widget = OverlayBox.new(test.db)
+        #    widget.w = test.w
+        #    widget.h = test.h
+        #    widget.x = 0
+        #    widget.y = 0
+        #    Qml::add_child(test, widget)
+        #end
+        #test.root.damage_item(test)
+    }
+}

--- a/src/mruby-zest/test/OverlayTest.qml
+++ b/src/mruby-zest/test/OverlayTest.qml
@@ -1,0 +1,48 @@
+Widget {
+    id: test
+    function draw(vg)
+    {
+        pi = 3.14159
+        start = pi/4;
+        end_   = pi*3.0/4.0;
+        inner  = 0.2*[h,w].min
+        outer = 0.4*[h,w].min
+        cy = h/2;
+        cx = w/2;
+        kr = h/4;
+        vg.path do |v|
+            v.arc(cx, cy, outer, start, end_, 1);
+            v.arc(cx, cy, inner, end_, start, 2);
+            v.close_path
+            v.fill_color(NVG.rgba(0x11,0x45,0x75,255));
+            v.fill
+        end
+
+        len = (3.0/2.0*pi)*0.5;
+        startt = end_ + len;
+
+        vg.path do |v|
+            v.arc(cx, cy, inner, end_, startt, 2);
+            v.arc(cx, cy, outer, startt, end_, 1);
+            v.close_path
+            v.fill_color(NVG.rgba(0x3a,0xc5,0xec,255));
+            v.fill
+        end
+    }
+    
+    function onMousePress(ev) {
+        puts "I got a mouse press (overlaytest)"
+        puts test.root
+        if(children.empty?)
+            widget = OverlayBox.new(test.db)
+            widget.w = test.w
+            widget.h = test.h
+            widget.x = 0
+            widget.y = 0
+            Qml::add_child(test, widget)
+            test.root.smash_draw_seq
+        end
+        test.root.damage_item(test)
+    }
+
+}

--- a/src/mruby-zest/test/TestLfoVis.qml
+++ b/src/mruby-zest/test/TestLfoVis.qml
@@ -1,0 +1,3 @@
+LfoVis {
+    extern: "/part0/kit0/adpars/GlobalPar/FreqLfo/out"
+}

--- a/src/mruby-zest/test/TestRows.qml
+++ b/src/mruby-zest/test/TestRows.qml
@@ -1,0 +1,34 @@
+Group {
+    id: box
+    label: "LFO"
+    property String extern: "/part0/kit0/adpars/GlobalPar/FreqLfo/"
+
+    //function layout(l)
+    //{
+    //    selfBox = l.genBox :test, box
+    //    topBox  = top.layout(l)
+    //    botBox  = bot.layout(l)
+    //    l.contains(selfBox, topBox)
+    //    l.contains(selfBox, botBox)
+    //    l.topOf(topBox, botBox)
+    //    l.sheq([topBox.h, selfBox.h], [1, -0.5], 0)
+    //    selfBox
+    //}
+    ParModuleRow {
+        id: top
+        Knob { extern: box.extern+"Pfreq" }
+        Knob { extern: box.extern+"Pintensity"}
+        Knob { extern: box.extern+"Pstartphase"}
+        Knob { extern: box.extern+"Pstretch"}
+
+    }
+    ParModuleRow {
+        id: bot
+        Knob     {extern: box.extern+"Prandomness"}
+        Knob     {extern: box.extern+"Pfreqrand"}
+        Col {
+            Selector {extern: box.extern+"PLFOtype"}
+            Button   {extern: box.extern+"Pcontinous"; label: "C"}
+        }
+    }
+}

--- a/src/mruby-zest/test/TestSwap.qml
+++ b/src/mruby-zest/test/TestSwap.qml
@@ -1,0 +1,36 @@
+Widget {
+    id: container
+
+    function layout(l)
+    {
+        selfBox = l.genBox :testRoot, self
+        swapBox = swap.layout(l)
+        buttBox = but.layout(l)
+
+        l.fixed(swapBox, selfBox, 0,0,0.5,1)
+        l.fixed(buttBox, selfBox, 0.5,0,0.5,1)
+        selfBox
+    }
+    Swappable {
+        id: swap
+        content: Qml::Knob
+    }
+
+    Button {
+        id: but
+
+        layoutOpts: [:no_constraint]
+
+        onValue: {
+            puts "value changed..."
+            if(swap.content == Qml::Knob)
+                swap.content = Qml::DropDown
+            else
+                swap.content = Qml::Knob
+            end
+        }
+
+        label: "swap"
+    }
+}
+

--- a/src/mruby-zest/test/VolumeKnob.qml
+++ b/src/mruby-zest/test/VolumeKnob.qml
@@ -1,0 +1,3 @@
+Knob {
+    extern: "/Pvolume"
+}

--- a/src/mruby-zest/test/macro-01-inst.qml
+++ b/src/mruby-zest/test/macro-01-inst.qml
@@ -1,0 +1,23 @@
+Widget {
+    Macro {
+        id: spawn
+        field: "off"
+        value: [0,1,2,3,4]
+        property Object dep: [:zero, :one, :two, :three, :four]
+
+
+        Widget {
+            id: k$off
+            property Object value: $off;
+            property Object dependent: spawn.dep[k$off.value]
+
+            function class_name() {
+                "macro_sub$off"
+            }
+
+            function to_s() {
+                "<"+class_name() + ":" + dependent.to_s + ">"
+            }
+        }
+    }
+}

--- a/src/mruby-zest/test/macro-02-grid.qml
+++ b/src/mruby-zest/test/macro-02-grid.qml
@@ -1,0 +1,4 @@
+KitButtons {
+    w: 800
+    h: 800
+}

--- a/src/mruby-zest/test/module-01-layout.qml
+++ b/src/mruby-zest/test/module-01-layout.qml
@@ -1,0 +1,10 @@
+Module {
+    label: "module-01-layout"
+    w: 1200
+    h: 400
+    Knob {}
+    Slider {}
+    Knob {}
+    Knob {}
+    Slider {}
+}

--- a/src/mruby-zest/test/module-02-pair.qml
+++ b/src/mruby-zest/test/module-02-pair.qml
@@ -1,0 +1,43 @@
+Window {
+    id: win
+    label: "module-02-pair"
+    function layout(l)
+    {
+        puts "Window Layout..."
+        sb = l.genBox :window, win
+        mt = modTop.layout(l)
+        mb = modBot.layout(l)
+        l.contains(sb, mt)
+        l.contains(sb, mb)
+        l.topOf(mt,mb)
+        l.sheq([mb.h, mt.h], [1, -1], 0)
+        sb
+    }
+    Module {
+        id: modTop
+        label: "module-01-layout"
+        w: 1200
+        h: 400
+        Knob {label: "knob1"}
+        Knob {label: "knob1"}
+        Knob {label: "knob1"}
+        Knob {label: "knob1"}
+        Knob {label: "knob1"}
+        Knob {label: "knob1"}
+        Slider {label: "slider1"}
+        Knob {label: "knob2"}
+        Knob {label: "knob3"}
+        Slider {label: "slider2"}
+    }
+    Module {
+        id: modBot
+        label: "module-01-layout"
+        w: 1200
+        h: 400
+        Knob {}
+        Slider {}
+        Knob {}
+        Knob {}
+        Slider {label: "slider4"}
+    }
+}

--- a/src/mruby-zest/test/slider-01-empty.qml
+++ b/src/mruby-zest/test/slider-01-empty.qml
@@ -1,0 +1,3 @@
+Slider {
+    label: "Slider-01-empty"
+}

--- a/src/mruby-zest/test/slider-02-osc.qml
+++ b/src/mruby-zest/test/slider-02-osc.qml
@@ -1,0 +1,4 @@
+Slider {
+    label: "Slider-02-osc"
+    valueRef: Osc.new("/test/value1-float")
+}

--- a/src/mruby-zest/test/test-database.rb
+++ b/src/mruby-zest/test/test-database.rb
@@ -1,0 +1,59 @@
+require '../mrblib/database.rb'
+#Test
+#Load Widget.qml
+#Create property instances
+
+pd = PropertyDatabase.new
+p1 = Property.new("/foobar",   Proc.new {"hello"})
+p2 = Property.new("/barfoo",   Proc.new {pd.load_id("/foobar") + " world"})
+p3 = Property.new("/blam",     Proc.new {pd.load_id("/foobar") + " bob"})
+p4 = Property.new("/blamblam", Proc.new {23})
+p5 = Property.new("/yadayada", Proc.new {pd.load_id("/foobar") + " " + pd.load_id("/blamblam").to_s})
+
+pp p1
+pp p2
+pp p3
+pp p4
+pp p5
+puts
+
+pd.add_property p1
+pd.add_property p2
+pd.add_property p3
+pd.add_property p4
+pd.add_property p5
+
+puts "First load..."
+print "Expect: \"hello world\"\nGot:    "
+pp pd.load_id("/barfoo")
+
+puts
+puts "Second load..."
+print "Expect: \"hello 23\"\nGot:    "
+pp pd.load_id("/yadayada")
+
+pd.write("/foobar", Proc.new {"goodbye"})
+
+pp p1
+pp p2
+pp p3
+pp p4
+pp p5
+
+puts "========P1"
+pp pd.load_property p1
+puts "========P2"
+pp pd.load_property p2
+puts "========P3"
+pp pd.load_property p3
+puts "========P4"
+pp pd.load_property p4
+puts "========P5"
+pp pd.load_property p5
+puts "========end"
+
+pp p1
+pp p2
+pp p3
+pp p4
+pp p5

--- a/src/mruby-zest/test/window-01-empty.qml
+++ b/src/mruby-zest/test/window-01-empty.qml
@@ -1,0 +1,5 @@
+Window {
+    label: "Window-01-empty.qml"
+    w: 120
+    h: 200
+}

--- a/src/mruby-zest/test/window-02-basic.qml
+++ b/src/mruby-zest/test/window-02-basic.qml
@@ -1,0 +1,20 @@
+Window {
+    label: "Window-02-basic.qml"
+    w: 120
+    h: 200
+    id: window
+    Slider {
+        label: "slider1"
+        x: 0
+        y: 0
+        w: window.w/2
+        h: window.h
+    }
+    Slider {
+        label: "slider2"
+        x: window.w/2
+        y: 0
+        w: window.w/2
+        h: window.h
+    }
+}

--- a/src/mruby-zest/tmp/FilterView.qml
+++ b/src/mruby-zest/tmp/FilterView.qml
@@ -1,0 +1,51 @@
+import QtQuick 2.2
+import ZynAddSubFX 1.0
+import "qrc:/qml/"
+
+Widget {
+    layoutOpts: [:vertical]
+    Module {
+        label: "filter"
+        Knob {
+            label: "c.freq"
+        }
+        Knob {
+            label: "q"
+        }
+        Knob {
+            label: "v.sns a."
+        }
+        Knob {
+            label: "freq.tr"
+        }
+        Knob {
+            label: "gain"
+        }
+        DropDown {
+            label: "st"
+            text:  "2x"
+        }
+        DropDown {
+            label: "category"
+            text:  "analog"
+        }
+        DropDown {
+            label: "f.type"
+            text:  "lpf2"
+        }
+    }
+    Module {
+        label: "filter envelope"
+        copyable: true
+        editable: true
+        Repeater {
+            model: ["a.val", "a.dt", "d.val",
+            "d.dt", "r.dt", "r.val", "stretch"]
+            Knob { label: modelData }
+        }
+        Button {
+            label: "frcr"
+        }
+    }
+}
+

--- a/src/osc-bridge/.gitignore
+++ b/src/osc-bridge/.gitignore
@@ -1,0 +1,4 @@
+libosc-bridge.a
+mock-test
+remote-test
+*.o

--- a/src/osc-bridge/.gitrepo
+++ b/src/osc-bridge/.gitrepo
@@ -1,0 +1,12 @@
+; DO NOT EDIT (unless you know what you are doing)
+;
+; This subdirectory is a git "subrepo", and this file is maintained by the
+; git-subrepo command. See https://github.com/git-commands/git-subrepo#readme
+;
+[subrepo]
+	remote = git@github.com:mruby-zest/osc-bridge.git
+	branch = master
+	commit = c678428bf164fc732ab4c7ee903bc8952bff6fbc
+	parent = 2a60e81eb72ec4e6cbf074461d93950be09677a0
+	method = merge
+	cmdver = 0.4.3

--- a/src/osc-bridge/.travis.yml
+++ b/src/osc-bridge/.travis.yml
@@ -1,0 +1,20 @@
+language: c
+
+sudo: false
+
+before_script:
+    - mkdir uv-setup
+    - cd uv-setup
+    - wget http://dist.libuv.org/dist/v1.9.1/libuv-v1.9.1.tar.gz
+    - tar xvf libuv*.tar.gz
+    - cd libuv*
+    - ./autogen.sh
+    - CFLAGS=-fPIC ./configure --prefix=/tmp/
+    - CFLAGS=-fPIC make
+    - make install
+    - cd ../..
+script:
+  - export CFLAGS="-I/tmp/include/ -L/tmp/lib/"
+  - export LD_LIBRARY_PATH="/tmp/lib"
+  - make
+  - ./mock-test

--- a/src/osc-bridge/Makefile
+++ b/src/osc-bridge/Makefile
@@ -1,0 +1,17 @@
+SRC = src/bridge.c src/cache.c src/parse-schema.c src/schema.c rtosc/rtosc.c
+CFLAGS_ = -std=gnu99 -Wall -Wextra -I .
+
+all: mock-test remote-test lib
+
+mock-test: $(SRC) test/mock-test.c
+	$(CC) $(CFLAGS) $(CFLAGS_) -o mock-test $(SRC) test/mock-test.c -luv -g -O0
+
+remote-test: $(SRC) test/basic-remote.c
+	$(CC) $(CFLAGS) $(CFLAGS_) -o remote-test $(SRC) test/basic-remote.c -luv -g -O0
+
+lib: $(SRC)
+	$(CC) $(CFLAGS) $(CFLAGS_) -O3 -g -fPIC -c $(SRC)
+	$(AR) rcs libosc-bridge.a bridge.o cache.o parse-schema.o schema.o rtosc.o
+
+clean:
+	rm -f libosc-bridge.a bridge.o cache.o parse-schema.o schema.o remote-test mock-test

--- a/src/osc-bridge/README.adoc
+++ b/src/osc-bridge/README.adoc
@@ -1,0 +1,73 @@
+OSC-Bridge
+==========
+
+OSC-Bridge is a library for managing state stored in a remote OSC
+aware application. OSC-Bridge uses UDP to communicate with remote
+(or local) applications using libuv for cross platform portability.
+
+OSC-Bridge manages:
+
+- Loading an OSC API specification in the form of an OSC schema
+- Fetching parameters stored in a remote OSC client
+- Caching OSC parameters in sync with remote application for low
+  latency lookups
+- Managing callbacks for when parameter values change
+- Invoking arbitrary OSC actions
+- Repeating parameter requests if UDP packets are lost
+- Debouncing parameter values when remote application responds with a
+  notable delay
+- Simple parameter invalidation when presets are loaded
+- Setting up data watch points [ZynAddSubFX Specific]
+
+Roadmap
+-------
+
+Most of the intended functionality is implemented at the time of
+writing this README, though several additions are planed.
+
+Paths to OSC Schema files should not be assumed
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Currently 'schema/test.json' is assumed to be the only valid OSC
+schema. Custom paths should be usable and for embedding purposes it
+should be possible to load directly from a preloaded const char *.
+
+OSC actions should be verified to be valid when they're sent
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Currently, OSC mapped parameters are specified in the schema, but
+actions (basically remote procedure calls which can emit parameter
+changes or '/damage' messages).
+Actions aren't specified in the schema at all, but once they're sent,
+then br_action() should be capiable of verifying if an OSC message is
+going to be sent to a valid non-parameter OSC port.
+
+Loading default values from OSC schema
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Many OSC parameters have either a default value or at least a default
+value dependent on another parameter.
+Default values make it possible to mitigate some of the overhead of
+latency introduced by OSC clients across the network.
+Current schema revisions don't include default values, but work is
+being done to draft an implementation.
+
+More efficient parameter lookup
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Finding a parameter in the OSC schema is currently O(n) when it could
+be much closer to O(log(n)) as the current implementation iterates
+through all leaf nodes of the OSC tree and checks for matches, when it's
+possible to search one OSC path level at a time.
+
+Parameter randomization
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Parameters provide a range of valid values, so (mostly a a fun option)
+it should be possible to apply a random value to any parameter.
+
+LICENSE
+-------
+
+OSC-Bridge was written by Mark McCurry and is available under the
+MIT License.

--- a/src/osc-bridge/rtosc/rtosc.c
+++ b/src/osc-bridge/rtosc/rtosc.c
@@ -1,0 +1,781 @@
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <ctype.h>
+#include <assert.h>
+
+#include <rtosc/rtosc.h>
+
+const char *rtosc_argument_string(const char *msg)
+{
+    assert(msg && *msg);
+    while(*++msg); //skip pattern
+    while(!*++msg);//skip null
+    return msg+1;  //skip comma
+}
+
+unsigned rtosc_narguments(const char *msg)
+{
+    const char *args = rtosc_argument_string(msg);
+    int nargs = 0;
+    while(*args++)
+        nargs += (*args == ']' || *args == '[') ? 0 : 1;
+    return nargs;
+}
+
+static int has_reserved(char type)
+{
+    switch(type)
+    {
+        case 'i'://official types
+        case 's':
+        case 'b':
+        case 'f':
+
+        case 'h'://unofficial
+        case 't':
+        case 'd':
+        case 'S':
+        case 'r':
+        case 'm':
+        case 'c':
+            return 1;
+        case 'T':
+        case 'F':
+        case 'N':
+        case 'I':
+        case '[':
+        case ']':
+            return 0;
+    }
+
+    //Should not happen
+    return 0;
+}
+
+static unsigned nreserved(const char *args)
+{
+    unsigned res = 0;
+    for(;*args;++args)
+        res += has_reserved(*args);
+
+    return res;
+}
+
+char rtosc_type(const char *msg, unsigned nargument)
+{
+    assert(nargument < rtosc_narguments(msg));
+    const char *arg = rtosc_argument_string(msg);
+    while(1) {
+        if(*arg == '[' || *arg == ']')
+            ++arg;
+        else if(!nargument || !*arg)
+            return *arg;
+        else
+            ++arg, --nargument;
+    }
+}
+
+static unsigned arg_start(const char *msg_)
+{
+    const uint8_t *msg = (const uint8_t*)msg_;
+    //Iterate to the right position
+    const uint8_t *args = (const uint8_t*) rtosc_argument_string(msg_);
+    const uint8_t *aligned_ptr = args-1;
+    const uint8_t *arg_pos = args;
+
+    while(*++arg_pos);
+    //Alignment
+    arg_pos += 4-(arg_pos-aligned_ptr)%4;
+    return arg_pos-msg;
+}
+
+static unsigned arg_size(const uint8_t *arg_mem, char type)
+{
+    if(!has_reserved(type))
+        return 0;
+    const uint8_t  *arg_pos=arg_mem;
+    uint32_t blob_length = 0;
+    switch(type)
+    {
+        case 'h':
+        case 't':
+        case 'd':
+            return 8;
+        case 'm':
+        case 'r':
+        case 'f':
+        case 'c':
+        case 'i':
+            return 4;
+        case 'S':
+        case 's':
+            while(*++arg_pos);
+            arg_pos += 4-(arg_pos-arg_mem)%4;
+            return arg_pos-arg_mem;
+        case 'b':
+            blob_length |= (*arg_pos++ << 24);
+            blob_length |= (*arg_pos++ << 16);
+            blob_length |= (*arg_pos++ << 8);
+            blob_length |= (*arg_pos++);
+            if(blob_length%4)
+                blob_length += 4-blob_length%4;
+            arg_pos += blob_length;
+            return arg_pos-arg_mem;
+        default:
+            assert("Invalid Type");
+    }
+    return -1;
+}
+
+static unsigned arg_off(const char *msg, unsigned idx)
+{
+    if(!has_reserved(rtosc_type(msg,idx)))
+        return 0;
+
+    //Iterate to the right position
+    const uint8_t *args = (const uint8_t*) rtosc_argument_string(msg);
+    const uint8_t *aligned_ptr = args-1;
+    const uint8_t *arg_pos = args;
+
+    while(*++arg_pos);
+    //Alignment
+    arg_pos += 4-(arg_pos-((uint8_t*)aligned_ptr))%4;
+
+    //ignore any leading '[' or ']'
+    while(*args == '[' || *args == ']')
+        ++args;
+
+    while(idx--) {
+        char type = *args++;
+        if(type == '[' || type == ']')
+            idx++;//not a valid arg idx
+        else
+            arg_pos += arg_size(arg_pos, type);
+    }
+    return arg_pos-(uint8_t*)msg;
+}
+
+size_t rtosc_message(char   *buffer,
+                     size_t      len,
+                     const char *address,
+                     const char *arguments,
+                     ...)
+{
+    va_list va;
+    va_start(va, arguments);
+    size_t result = rtosc_vmessage(buffer, len, address, arguments, va);
+    va_end(va);
+    return result;
+}
+
+//Calculate the size of the message without writing to a buffer
+static size_t vsosc_null(const char        *address,
+                         const char        *arguments,
+                         const rtosc_arg_t *args)
+{
+    unsigned pos = 0;
+    pos += strlen(address);
+    pos += 4-pos%4;//get 32 bit alignment
+    pos += 1+strlen(arguments);
+    pos += 4-pos%4;
+
+    unsigned toparse = nreserved(arguments);
+    unsigned arg_pos = 0;
+
+    //Take care of varargs
+    while(toparse)
+    {
+        char arg = *arguments++;
+        assert(arg);
+        int i;
+        const char *s;
+        switch(arg) {
+            case 'h':
+            case 't':
+            case 'd':
+                ++arg_pos;
+                pos += 8;
+                --toparse;
+                break;
+            case 'm':
+            case 'r':
+            case 'c':
+            case 'f':
+            case 'i':
+                ++arg_pos;
+                pos += 4;
+                --toparse;
+                break;
+            case 's':
+            case 'S':
+                s = args[arg_pos++].s;
+                assert(s && "Input strings CANNOT be NULL");
+                pos += strlen(s);
+                pos += 4-pos%4;
+                --toparse;
+                break;
+            case 'b':
+                i = args[arg_pos++].b.len;
+                pos += 4 + i;
+                if(pos%4)
+                    pos += 4-pos%4;
+                --toparse;
+                break;
+            default:
+                ;
+        }
+    }
+
+    return pos;
+}
+size_t rtosc_vmessage(char   *buffer,
+                      size_t      len,
+                      const char *address,
+                      const char *arguments,
+                      va_list ap)
+{
+    const unsigned nargs = nreserved(arguments);
+    if(!nargs)
+        return rtosc_amessage(buffer,len,address,arguments,NULL);
+
+    rtosc_arg_t args[nargs];
+
+    unsigned arg_pos = 0;
+    const char *arg_str = arguments;
+    uint8_t *midi_tmp;
+    while(arg_pos < nargs)
+    {
+        switch(*arg_str++) {
+            case 'h':
+            case 't':
+                args[arg_pos++].h = va_arg(ap, int64_t);
+                break;
+            case 'd':
+                args[arg_pos++].d = va_arg(ap, double);
+                break;
+            case 'c':
+            case 'i':
+            case 'r':
+                args[arg_pos++].i = va_arg(ap, int);
+                break;
+            case 'm':
+                midi_tmp = va_arg(ap, uint8_t *);
+                args[arg_pos].m[0] = midi_tmp[0];
+                args[arg_pos].m[1] = midi_tmp[1];
+                args[arg_pos].m[2] = midi_tmp[2];
+                args[arg_pos++].m[3] = midi_tmp[3];
+                break;
+            case 'S':
+            case 's':
+                args[arg_pos++].s = va_arg(ap, const char *);
+                break;
+            case 'b':
+                args[arg_pos].b.len = va_arg(ap, int);
+                args[arg_pos].b.data = va_arg(ap, unsigned char *);
+                arg_pos++;
+                break;
+            case 'f':
+                args[arg_pos++].f = va_arg(ap, double);
+                break;
+            default:
+                ;
+        }
+    }
+
+    return rtosc_amessage(buffer,len,address,arguments,args);
+}
+
+size_t rtosc_amessage(char              *buffer,
+                      size_t             len,
+                      const char        *address,
+                      const char        *arguments,
+                      const rtosc_arg_t *args)
+{
+    const size_t total_len = vsosc_null(address, arguments, args);
+
+    if(!buffer)
+        return total_len;
+
+    //Abort if the message cannot fit
+    if(total_len>len) {
+        memset(buffer, 0, len);
+        return 0;
+    }
+
+    memset(buffer, 0, total_len);
+
+    unsigned pos = 0;
+    while(*address)
+        buffer[pos++] = *address++;
+
+    //get 32 bit alignment
+    pos += 4-pos%4;
+
+    buffer[pos++] = ',';
+
+    const char *arg_str = arguments;
+    while(*arg_str)
+        buffer[pos++] = *arg_str++;
+
+    pos += 4-pos%4;
+
+    unsigned toparse = nreserved(arguments);
+    unsigned arg_pos = 0;
+    while(toparse)
+    {
+        char arg = *arguments++;
+        assert(arg);
+        int32_t i;
+        int64_t d;
+        const uint8_t *m;
+        const char *s;
+        const unsigned char *u;
+        rtosc_blob_t b;
+        switch(arg) {
+            case 'h':
+            case 't':
+            case 'd':
+                d = args[arg_pos++].t;
+                buffer[pos++] = ((d>>56) & 0xff);
+                buffer[pos++] = ((d>>48) & 0xff);
+                buffer[pos++] = ((d>>40) & 0xff);
+                buffer[pos++] = ((d>>32) & 0xff);
+                buffer[pos++] = ((d>>24) & 0xff);
+                buffer[pos++] = ((d>>16) & 0xff);
+                buffer[pos++] = ((d>>8) & 0xff);
+                buffer[pos++] = (d & 0xff);
+                --toparse;
+                break;
+            case 'r':
+            case 'f':
+            case 'c':
+            case 'i':
+                i = args[arg_pos++].i;
+                buffer[pos++] = ((i>>24) & 0xff);
+                buffer[pos++] = ((i>>16) & 0xff);
+                buffer[pos++] = ((i>>8) & 0xff);
+                buffer[pos++] = (i & 0xff);
+                --toparse;
+                break;
+            case 'm':
+                //TODO verify ordering of spec
+                m = args[arg_pos++].m;
+                buffer[pos++] = m[0];
+                buffer[pos++] = m[1];
+                buffer[pos++] = m[2];
+                buffer[pos++] = m[3];
+                --toparse;
+                break;
+            case 'S':
+            case 's':
+                s = args[arg_pos++].s;
+                while(*s)
+                    buffer[pos++] = *s++;
+                pos += 4-pos%4;
+                --toparse;
+                break;
+            case 'b':
+                b = args[arg_pos++].b;
+                i = b.len;
+                buffer[pos++] = ((i>>24) & 0xff);
+                buffer[pos++] = ((i>>16) & 0xff);
+                buffer[pos++] = ((i>>8) & 0xff);
+                buffer[pos++] = (i & 0xff);
+                u = b.data;
+                if(u) {
+                    while(i--)
+                        buffer[pos++] = *u++;
+                }
+                else
+                    pos += i;
+                if(pos%4)
+                    pos += 4-pos%4;
+                --toparse;
+                break;
+            default:
+                ;
+        }
+    }
+
+    return pos;
+}
+
+static rtosc_arg_t extract_arg(const uint8_t *arg_pos, char type)
+{
+    rtosc_arg_t result = {0};
+    //trivial case
+    if(!has_reserved(type)) {
+        switch(type)
+        {
+            case 'T':
+                result.T = true;
+                break;
+            case 'F':
+                result.T = false;
+                break;
+            default:
+                ;
+        }
+    } else {
+        switch(type)
+        {
+            case 'h':
+            case 't':
+            case 'd':
+                result.t |= (((uint64_t)*arg_pos++) << 56);
+                result.t |= (((uint64_t)*arg_pos++) << 48);
+                result.t |= (((uint64_t)*arg_pos++) << 40);
+                result.t |= (((uint64_t)*arg_pos++) << 32);
+                result.t |= (((uint64_t)*arg_pos++) << 24);
+                result.t |= (((uint64_t)*arg_pos++) << 16);
+                result.t |= (((uint64_t)*arg_pos++) << 8);
+                result.t |= (((uint64_t)*arg_pos++));
+                break;
+            case 'r':
+            case 'f':
+            case 'c':
+            case 'i':
+                result.i |= (*arg_pos++ << 24);
+                result.i |= (*arg_pos++ << 16);
+                result.i |= (*arg_pos++ << 8);
+                result.i |= (*arg_pos++);
+                break;
+            case 'm':
+                result.m[0] = *arg_pos++;
+                result.m[1] = *arg_pos++;
+                result.m[2] = *arg_pos++;
+                result.m[3] = *arg_pos++;
+                break;
+            case 'b':
+                result.b.len |= (*arg_pos++ << 24);
+                result.b.len |= (*arg_pos++ << 16);
+                result.b.len |= (*arg_pos++ << 8);
+                result.b.len |= (*arg_pos++);
+                result.b.data = (unsigned char *)arg_pos;
+                break;
+            case 'S':
+            case 's':
+                result.s = (char *)arg_pos;
+                break;
+        }
+    }
+
+    return result;
+}
+
+static const char *advance_past_dummy_args(const char *args)
+{
+    while(*args == '[' || *args == ']')
+        args++;
+    return args;
+}
+
+rtosc_arg_itr_t rtosc_itr_begin(const char *msg)
+{
+    rtosc_arg_itr_t itr;
+    itr.type_pos  = advance_past_dummy_args(rtosc_argument_string(msg));
+    itr.value_pos = (uint8_t*)(msg+arg_start(msg));
+
+    return itr;
+}
+
+rtosc_arg_val_t rtosc_itr_next(rtosc_arg_itr_t *itr)
+{
+    //current position provides the value
+    rtosc_arg_val_t result = {0,{0}};
+    result.type = *itr->type_pos;
+    if(result.type)
+        result.val = extract_arg(itr->value_pos, result.type);
+
+    //advance
+    itr->type_pos = advance_past_dummy_args(itr->type_pos+1);
+    char type = result.type;
+    int size  = arg_size(itr->value_pos, type);
+    itr->value_pos += size;
+
+
+    return result;
+}
+
+int rtosc_itr_end(rtosc_arg_itr_t itr)
+{
+    return !itr.type_pos  || !*itr.type_pos;
+}
+
+rtosc_arg_t rtosc_argument(const char *msg, unsigned idx)
+{
+    char type = rtosc_type(msg, idx);
+    uint8_t *arg_mem = (uint8_t*)msg + arg_off(msg, idx);
+    return extract_arg(arg_mem, type);
+}
+
+static unsigned char deref(unsigned pos, ring_t *ring)
+{
+    return pos<ring[0].len ? ring[0].data[pos] :
+        ((pos-ring[0].len)<ring[1].len ? ring[1].data[pos-ring[0].len] : 0x00);
+}
+
+static size_t bundle_ring_length(ring_t *ring)
+{
+    unsigned pos = 8+8;//goto first length field
+    uint32_t advance = 0;
+    do {
+        advance = deref(pos+0, ring) << (8*3) |
+                  deref(pos+1, ring) << (8*2) |
+                  deref(pos+2, ring) << (8*1) |
+                  deref(pos+3, ring) << (8*0);
+        if(advance)
+            pos += 4+advance;
+    } while(advance);
+
+    return pos <= (ring[0].len+ring[1].len) ? pos : 0;
+}
+
+//Zero means no full message present
+size_t rtosc_message_ring_length(ring_t *ring)
+{
+    //Check if the message is a bundle
+    if(deref(0,ring) == '#' &&
+            deref(1,ring) == 'b' &&
+            deref(2,ring) == 'u' &&
+            deref(3,ring) == 'n' &&
+            deref(4,ring) == 'd' &&
+            deref(5,ring) == 'l' &&
+            deref(6,ring) == 'e' &&
+            deref(7,ring) == '\0')
+        return bundle_ring_length(ring);
+
+    //Proceed for normal messages
+    //Consume path
+    unsigned pos = 0;
+    while(deref(pos++,ring));
+    pos--;
+
+    //Travel through the null word end [1..4] bytes
+    for(int i=0; i<4; ++i)
+        if(deref(++pos, ring))
+            break;
+
+    if(deref(pos, ring) != ',')
+        return 0;
+
+    unsigned aligned_pos = pos;
+    int arguments = pos+1;
+    while(deref(++pos,ring));
+    pos += 4-(pos-aligned_pos)%4;
+
+    unsigned toparse = 0;
+    {
+        int arg = arguments-1;
+        while(deref(++arg,ring))
+            toparse += has_reserved(deref(arg,ring));
+    }
+
+    //Take care of varargs
+    while(toparse)
+    {
+        char arg = deref(arguments++,ring);
+        assert(arg);
+        uint32_t i;
+        switch(arg) {
+            case 'h':
+            case 't':
+            case 'd':
+                pos += 8;
+                --toparse;
+                break;
+            case 'm':
+            case 'r':
+            case 'c':
+            case 'f':
+            case 'i':
+                pos += 4;
+                --toparse;
+                break;
+            case 'S':
+            case 's':
+                while(deref(++pos,ring));
+                pos += 4-(pos-aligned_pos)%4;
+                --toparse;
+                break;
+            case 'b':
+                i = 0;
+                i |= (deref(pos++,ring) << 24);
+                i |= (deref(pos++,ring) << 16);
+                i |= (deref(pos++,ring) << 8);
+                i |= (deref(pos++,ring));
+                pos += i;
+                if((pos-aligned_pos)%4)
+                    pos += 4-(pos-aligned_pos)%4;
+                --toparse;
+                break;
+            default:
+                ;
+        }
+    }
+
+
+    return pos <= (ring[0].len+ring[1].len) ? pos : 0;
+}
+
+size_t rtosc_message_length(const char *msg, size_t len)
+{
+    ring_t ring[2] = {{(char*)msg,len},{NULL,0}};
+    return rtosc_message_ring_length(ring);
+}
+
+bool rtosc_valid_message_p(const char *msg, size_t len)
+{
+    //Validate Path Characters (assumes printable characters are sufficient)
+    if(*msg != '/')
+        return false;
+    const char *tmp = msg;
+    for(unsigned i=0; i<len; ++i) {
+        if(*tmp == 0)
+            break;
+        if(!isprint(*tmp))
+            return false;
+        tmp++;
+    }
+
+    //tmp is now either pointing to a null or the end of the string
+    const size_t offset1 = tmp-msg;
+    size_t       offset2 = tmp-msg;
+    for(; offset2<len; offset2++) {
+        if(*tmp == ',')
+            break;
+        tmp++;
+    }
+
+    //Too many NULL bytes
+    if(offset2-offset1 > 4)
+        return false;
+
+    if((offset2 % 4) != 0)
+        return false;
+
+    size_t observed_length = rtosc_message_length(msg, len);
+    return observed_length == len;
+}
+static uint64_t extract_uint64(const uint8_t *arg_pos)
+{
+    uint64_t arg = 0;
+    arg |= (((uint64_t)*arg_pos++) << 56);
+    arg |= (((uint64_t)*arg_pos++) << 48);
+    arg |= (((uint64_t)*arg_pos++) << 40);
+    arg |= (((uint64_t)*arg_pos++) << 32);
+    arg |= (((uint64_t)*arg_pos++) << 24);
+    arg |= (((uint64_t)*arg_pos++) << 16);
+    arg |= (((uint64_t)*arg_pos++) << 8);
+    arg |= (((uint64_t)*arg_pos++));
+    return arg;
+}
+
+static uint32_t extract_uint32(const uint8_t *arg_pos)
+{
+    uint32_t arg = 0;
+    arg |= (((uint32_t)*arg_pos++) << 24);
+    arg |= (((uint32_t)*arg_pos++) << 16);
+    arg |= (((uint32_t)*arg_pos++) << 8);
+    arg |= (((uint32_t)*arg_pos++));
+    return arg;
+}
+
+static void emplace_uint64(uint8_t *buffer, uint64_t d)
+{
+    buffer[0] = ((d>>56) & 0xff);
+    buffer[1] = ((d>>48) & 0xff);
+    buffer[2] = ((d>>40) & 0xff);
+    buffer[3] = ((d>>32) & 0xff);
+    buffer[4] = ((d>>24) & 0xff);
+    buffer[5] = ((d>>16) & 0xff);
+    buffer[6] = ((d>>8)  & 0xff);
+    buffer[7] = ((d>>0)  & 0xff);
+}
+
+static void emplace_uint32(uint8_t *buffer, uint32_t d)
+{
+    buffer[0] = ((d>>24) & 0xff);
+    buffer[1] = ((d>>16) & 0xff);
+    buffer[2] = ((d>>8)  & 0xff);
+    buffer[3] = ((d>>0)  & 0xff);
+}
+
+size_t rtosc_bundle(char *buffer, size_t len, uint64_t tt, int elms, ...)
+{
+    char *_buffer = buffer;
+    memset(buffer, 0, len);
+    strcpy(buffer, "#bundle");
+    buffer += 8;
+    emplace_uint64((uint8_t*)buffer, tt);
+    buffer += 8;
+    va_list va;
+    va_start(va, elms);
+    for(int i=0; i<elms; ++i) {
+        const char   *msg  = va_arg(va, const char*);
+        //It is assumed that any passed message/bundle is valid
+        size_t        size = rtosc_message_length(msg, -1);
+        emplace_uint32((uint8_t*)buffer, size);
+        buffer += 4;
+        memcpy(buffer, msg, size);
+        buffer+=size;
+    }
+    va_end(va);
+
+    return buffer-_buffer;
+}
+
+
+#define POS ((size_t)(((const char *)lengths) - buffer))
+size_t rtosc_bundle_elements(const char *buffer, size_t len)
+{
+    const uint32_t *lengths = (const uint32_t*) (buffer+16);
+    size_t elms = 0;
+    while(POS < len && extract_uint32((const uint8_t*)lengths)) {
+        lengths += extract_uint32((const uint8_t*)lengths)/4+1;
+
+        if(POS > len)
+            break;
+        ++elms;
+    }
+    return elms;
+}
+#undef POS
+
+const char *rtosc_bundle_fetch(const char *buffer, unsigned elm)
+{
+    const uint32_t *lengths = (const uint32_t*) (buffer+16);
+    size_t elm_pos = 0;
+    while(elm_pos!=elm && extract_uint32((const uint8_t*)lengths)) {
+        ++elm_pos;
+        lengths += extract_uint32((const uint8_t*)lengths)/4+1;
+    }
+
+    return (const char*) (elm==elm_pos?lengths+1:NULL);
+}
+
+size_t rtosc_bundle_size(const char *buffer, unsigned elm)
+{
+    const uint32_t *lengths = (const uint32_t*) (buffer+16);
+    size_t elm_pos = 0;
+    size_t last_len = 0;
+    while(elm_pos!=elm && extract_uint32((const uint8_t*)lengths)) {
+        last_len = extract_uint32((const uint8_t*)lengths);
+        ++elm_pos, lengths+=extract_uint32((const uint8_t*)lengths)/4+1;
+    }
+
+    return last_len;
+}
+
+int rtosc_bundle_p(const char *msg)
+{
+    return !strcmp(msg,"#bundle");
+}
+
+uint64_t rtosc_bundle_timetag(const char *msg)
+{
+    return extract_uint64((const uint8_t*)msg+8);
+}

--- a/src/osc-bridge/rtosc/rtosc.h
+++ b/src/osc-bridge/rtosc/rtosc.h
@@ -1,0 +1,269 @@
+/*
+ * Copyright (c) 2012 Mark McCurry
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ * @file rtosc.h
+ */
+#ifndef RTOSC_H
+#define RTOSC_H
+#include <stdarg.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    int32_t len;
+    uint8_t *data;
+} rtosc_blob_t;
+
+typedef union {
+    int32_t       i;   //i,c,r
+    char          T;   //I,T,F,N
+    float         f;   //f
+    double        d;   //d
+    int64_t       h;   //h
+    uint64_t      t;   //t
+    uint8_t       m[4];//m
+    const char   *s;   //s,S
+    rtosc_blob_t  b;   //b
+} rtosc_arg_t;
+
+/**
+ * Write OSC message to fixed length buffer
+ *
+ * On error, buffer will be zeroed.
+ * When buffer is NULL, the function returns the size of the buffer required to
+ * store the message
+ *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ * //Example messages
+ * char buffer[128];
+ * rtosc_message(buffer,128,"/path","TFI");
+ * rtosc_message(buffer,128,"/path","s","foobar");
+ * rtosc_message(buffer,128,"/path","i",128);
+ * rtosc_message(buffer,128,"/path","f",128.0);
+ * const char blob[4] = {'a','b','c','d'};
+ * rtosc_message(buffer,128,"/path","b",4,blob);
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ *
+ * @param buffer    Memory to write to
+ * @param len       Length of buffer
+ * @param address   OSC pattern to send message to
+ * @param arguments String consisting of the types of the following arguments
+ * @param ...       OSC arguments to pass forward
+ * @returns length of resulting message or zero if bounds exceeded
+ */
+size_t rtosc_message(char   *buffer,
+        size_t      len,
+        const char *address,
+        const char *arguments,
+        ...);
+
+/**
+ * @see rtosc_message()
+ */
+size_t rtosc_vmessage(char   *buffer,
+        size_t      len,
+        const char *address,
+        const char *arguments,
+        va_list va);
+
+/**
+ * @see rtosc_message()
+ */
+size_t rtosc_amessage(char        *buffer,
+                      size_t       len,
+                      const char  *address,
+                      const char  *arguments,
+                      const rtosc_arg_t *args);
+
+/**
+ * Returns the number of arguments found in a given message
+ *
+ * @param msg well formed OSC message
+ * @returns number of arguments in message
+ */
+unsigned rtosc_narguments(const char *msg);
+
+/**
+ * @param msg well formed OSC message
+ * @param i   index of argument
+ * @returns the type of the ith argument in msg
+ */
+char rtosc_type(const char *msg, unsigned i);
+
+typedef struct {
+    const char    *type_pos;
+    const uint8_t *value_pos;
+} rtosc_arg_itr_t;
+
+typedef struct {
+    char type;
+    rtosc_arg_t val;
+} rtosc_arg_val_t;
+
+/**
+ * Create an argument iterator for a message
+ * @param msg OSC message
+ * @returns an initialized iterator
+ */
+rtosc_arg_itr_t rtosc_itr_begin(const char *msg);
+
+/**
+ * Gets the next argument in a message
+ * @param itr OSC message iterator
+ * @returns a type value pair from the message
+ */
+rtosc_arg_val_t rtosc_itr_next(rtosc_arg_itr_t *itr);
+
+/**
+ * Determines if the iterator is at the end of the argument list
+ * @param itr OSC message iterator
+ * @returns 1 if there are no more elements, 0 otherwise
+ */
+int rtosc_itr_end(rtosc_arg_itr_t itr);
+
+/**
+ * Blob data may be safely written to
+ * @param msg OSC message
+ * @param i   index of argument
+ * @returns an argument by value via the rtosc_arg_t union
+ */
+rtosc_arg_t rtosc_argument(const char *msg, unsigned i);
+
+/**
+ * @param msg OSC message
+ * @param len Message length upper bound
+ * @returns the size of a message given a chunk of memory.
+ */
+size_t rtosc_message_length(const char *msg, size_t len);
+
+typedef struct {
+    char *data;
+    size_t len;
+} ring_t;
+
+/**
+ * Finds the length of the next message inside a ringbuffer structure.
+ * 
+ * @param ring The addresses and lengths of the split buffer, in a compatible
+ *             format to jack's ringbuffer
+ * @returns size of message stored in ring datastructure
+ */
+size_t rtosc_message_ring_length(ring_t *ring);
+
+
+/**
+ * Validate if an arbitrary byte sequence is an OSC message.
+ * @param msg pointer to memory buffer
+ * @param len length of buffer
+ */
+bool rtosc_valid_message_p(const char *msg, size_t len);
+
+/**
+ * @param OSC message
+ * @returns the argument string of a given message
+ */
+const char *rtosc_argument_string(const char *msg);
+
+/**
+ * Generate a bundle from sub-messages
+ *
+ * @param buffer Destination buffer
+ * @param len    Length of buffer
+ * @param tt     OSC time tag
+ * @param elms   Number of sub messages
+ * @param ...    Messages
+ * @returns legnth of generated bundle or zero on failure
+ */
+size_t rtosc_bundle(char *buffer, size_t len, uint64_t tt, int elms, ...);
+
+/**
+ * Find the elements in a bundle
+ *
+ * @param msg OSC bundle
+ * @param len Upper bound on the length of the bundle
+ * @returns The number of messages contained within the bundle
+ */
+size_t rtosc_bundle_elements(const char *msg, size_t len);
+
+/**
+ * Fetch a message within the bundle
+ *
+ * @param msg OSC bundle
+ * @param i      index of sub-message
+ * @returns The ith message within the bundle
+ */
+const char *rtosc_bundle_fetch(const char *msg, unsigned i);
+
+/**
+ * Get the size of a particular bundle element
+ *
+ * @param msg OSC bundle
+ * @param i   Index of sub-message
+ * @returns   The size of the ith sub-message in bytes
+ */
+size_t rtosc_bundle_size(const char *msg, unsigned i);
+
+/**
+ * Test if the buffer contains a bundle
+ *
+ * @param msg OSC message
+ * @returns true if message is a bundle
+ */
+int rtosc_bundle_p(const char *msg);
+
+/**
+ * @returns Time Tag for a bundle
+ */
+uint64_t rtosc_bundle_timetag(const char *msg);
+
+
+/**
+ * This is a non-compliant pattern matcher for dispatching OSC messages
+ *
+ * Overall the pattern specification is
+ *   (normal-path)(\#digit-specifier)?(/)?(:argument-restrictor)*
+ *
+ * @param pattern The pattern string stored in the Port
+ * @param msg     The OSC message to be matched
+ * @returns true if a normal match and false if unmatched
+ */
+bool rtosc_match(const char *pattern, const char *msg);
+
+
+/**
+ * Attempt to match a rtosc style path while ignoring arguments
+ *
+ * @param pattern rtosc pattern
+ * @param msg a normal C string or a rtosc message
+ */
+const char *rtosc_match_path(const char *pattern, const char *msg);
+
+#ifdef __cplusplus
+};
+#endif
+#endif

--- a/src/osc-bridge/schema/test-schema.json
+++ b/src/osc-bridge/schema/test-schema.json
@@ -1,0 +1,33 @@
+{
+    "parameters" : [
+        { "path":      "/part[0-15]/Pvolume",
+          "name":      "Part Volume",
+          "shortname": "Vol.",
+          "tooltip":   "Volume Applied to a whole instrument",
+          "type":      "int",
+          "domain":    [0,127]},
+        { "path":      "/part[0-15]/Penabled",
+          "name":      "Part Enable",
+          "shortname": "Enable",
+          "tooltip":   "Enable Processing For Part",
+          "type":      "boolean"},
+        { "path":      "/part[0,15]/Pname",
+          "name":      "Instrument Name",
+          "shortname": "Name",
+          "tooltip":   "Name To Save Instrument As",
+          "type":      "string"}],
+    "actions" : [
+        { "path":      "/noteOn",
+          "args": [
+            { "type":   "int",
+              "domain": [0,127]},
+            { "type":   "int",
+              "domain": [0,127]},
+            { "type":   "int",
+              "domain": [0,127]}]},
+        { "path":      "/noteOff",
+          "args": [
+            { "type":   "int",
+              "domain": [0,127]},
+            { "type":   "int",
+              "domain": [0,127]}]}]}

--- a/src/osc-bridge/schema/test.json
+++ b/src/osc-bridge/schema/test.json
@@ -1,0 +1,14256 @@
+{
+    "parameter" : [
+    {
+        "path"     : "/last_xmz",
+        "name"     : "last_xmz",
+        "tooltip"  : "File name for last name loaded if any.",
+        "type"     : "s"
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/FreqLfo/freq",
+        "shortname": "freq",
+        "name"     : "freq",
+        "tooltip"  : "frequency of LFO\nlfo frequency = Pfreq * stretch\ntrue frequency is [0,85.25] Hz",
+        "units"    : "HZ",
+        "scale"    : "logarithmic",
+        "type"     : "f",
+        "range"    : [0.0775679,85.25]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/FreqLfo/Pintensity",
+        "shortname": "depth",
+        "name"     : "Pintensity",
+        "tooltip"  : "Intensity of LFO",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/FreqLfo/Pstartphase",
+        "shortname": "start",
+        "name"     : "Pstartphase",
+        "tooltip"  : "Starting Phase",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/FreqLfo/PLFOtype",
+        "shortname": "type",
+        "name"     : "PLFOtype",
+        "tooltip"  : "Shape of LFO",
+        "type"     : "i",
+        "default"  : "sine"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "sine"
+        },
+        {
+            "id"     : 1,
+            "value"  : "triangle"
+        },
+        {
+            "id"     : 2,
+            "value"  : "square"
+        },
+        {
+            "id"     : 3,
+            "value"  : "up"
+        },
+        {
+            "id"     : 4,
+            "value"  : "down"
+        },
+        {
+            "id"     : 5,
+            "value"  : "exp1"
+        },
+        {
+            "id"     : 6,
+            "value"  : "exp2"
+        },
+        {
+            "id"     : 7,
+            "value"  : "random"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/FreqLfo/Prandomness",
+        "shortname": "a.r.",
+        "name"     : "Prandomness",
+        "tooltip"  : "Amplitude Randomness (calculated uniformly at each cycle)",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/FreqLfo/Pfreqrand",
+        "shortname": "f.r.",
+        "name"     : "Pfreqrand",
+        "tooltip"  : "Frequency Randomness (calculated uniformly at each cycle)",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/FreqLfo/delay",
+        "shortname": "delay",
+        "name"     : "delay",
+        "tooltip"  : "Delay before LFO start\n0..4 second delay",
+        "units"    : "S",
+        "scale"    : "linear",
+        "type"     : "f",
+        "range"    : [0.0,4.0],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/FreqLfo/Pcontinous",
+        "shortname": "c",
+        "name"     : "Pcontinous",
+        "tooltip"  : "Enable for global operation",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/FreqLfo/Pstretch",
+        "shortname": "str",
+        "name"     : "Pstretch",
+        "tooltip"  : "Note frequency stretch",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/AmpLfo/freq",
+        "shortname": "freq",
+        "name"     : "freq",
+        "tooltip"  : "frequency of LFO\nlfo frequency = Pfreq * stretch\ntrue frequency is [0,85.25] Hz",
+        "units"    : "HZ",
+        "scale"    : "logarithmic",
+        "type"     : "f",
+        "range"    : [0.0775679,85.25]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/AmpLfo/Pintensity",
+        "shortname": "depth",
+        "name"     : "Pintensity",
+        "tooltip"  : "Intensity of LFO",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/AmpLfo/Pstartphase",
+        "shortname": "start",
+        "name"     : "Pstartphase",
+        "tooltip"  : "Starting Phase",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/AmpLfo/PLFOtype",
+        "shortname": "type",
+        "name"     : "PLFOtype",
+        "tooltip"  : "Shape of LFO",
+        "type"     : "i",
+        "default"  : "sine"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "sine"
+        },
+        {
+            "id"     : 1,
+            "value"  : "triangle"
+        },
+        {
+            "id"     : 2,
+            "value"  : "square"
+        },
+        {
+            "id"     : 3,
+            "value"  : "up"
+        },
+        {
+            "id"     : 4,
+            "value"  : "down"
+        },
+        {
+            "id"     : 5,
+            "value"  : "exp1"
+        },
+        {
+            "id"     : 6,
+            "value"  : "exp2"
+        },
+        {
+            "id"     : 7,
+            "value"  : "random"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/AmpLfo/Prandomness",
+        "shortname": "a.r.",
+        "name"     : "Prandomness",
+        "tooltip"  : "Amplitude Randomness (calculated uniformly at each cycle)",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/AmpLfo/Pfreqrand",
+        "shortname": "f.r.",
+        "name"     : "Pfreqrand",
+        "tooltip"  : "Frequency Randomness (calculated uniformly at each cycle)",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/AmpLfo/delay",
+        "shortname": "delay",
+        "name"     : "delay",
+        "tooltip"  : "Delay before LFO start\n0..4 second delay",
+        "units"    : "S",
+        "scale"    : "linear",
+        "type"     : "f",
+        "range"    : [0.0,4.0],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/AmpLfo/Pcontinous",
+        "shortname": "c",
+        "name"     : "Pcontinous",
+        "tooltip"  : "Enable for global operation",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/AmpLfo/Pstretch",
+        "shortname": "str",
+        "name"     : "Pstretch",
+        "tooltip"  : "Note frequency stretch",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/FilterLfo/freq",
+        "shortname": "freq",
+        "name"     : "freq",
+        "tooltip"  : "frequency of LFO\nlfo frequency = Pfreq * stretch\ntrue frequency is [0,85.25] Hz",
+        "units"    : "HZ",
+        "scale"    : "logarithmic",
+        "type"     : "f",
+        "range"    : [0.0775679,85.25]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/FilterLfo/Pintensity",
+        "shortname": "depth",
+        "name"     : "Pintensity",
+        "tooltip"  : "Intensity of LFO",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/FilterLfo/Pstartphase",
+        "shortname": "start",
+        "name"     : "Pstartphase",
+        "tooltip"  : "Starting Phase",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/FilterLfo/PLFOtype",
+        "shortname": "type",
+        "name"     : "PLFOtype",
+        "tooltip"  : "Shape of LFO",
+        "type"     : "i",
+        "default"  : "sine"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "sine"
+        },
+        {
+            "id"     : 1,
+            "value"  : "triangle"
+        },
+        {
+            "id"     : 2,
+            "value"  : "square"
+        },
+        {
+            "id"     : 3,
+            "value"  : "up"
+        },
+        {
+            "id"     : 4,
+            "value"  : "down"
+        },
+        {
+            "id"     : 5,
+            "value"  : "exp1"
+        },
+        {
+            "id"     : 6,
+            "value"  : "exp2"
+        },
+        {
+            "id"     : 7,
+            "value"  : "random"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/FilterLfo/Prandomness",
+        "shortname": "a.r.",
+        "name"     : "Prandomness",
+        "tooltip"  : "Amplitude Randomness (calculated uniformly at each cycle)",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/FilterLfo/Pfreqrand",
+        "shortname": "f.r.",
+        "name"     : "Pfreqrand",
+        "tooltip"  : "Frequency Randomness (calculated uniformly at each cycle)",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/FilterLfo/delay",
+        "shortname": "delay",
+        "name"     : "delay",
+        "tooltip"  : "Delay before LFO start\n0..4 second delay",
+        "units"    : "S",
+        "scale"    : "linear",
+        "type"     : "f",
+        "range"    : [0.0,4.0],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/FilterLfo/Pcontinous",
+        "shortname": "c",
+        "name"     : "Pcontinous",
+        "tooltip"  : "Enable for global operation",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/FilterLfo/Pstretch",
+        "shortname": "str",
+        "name"     : "Pstretch",
+        "tooltip"  : "Note frequency stretch",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/FreqEnvelope/Pfreemode",
+        "name"     : "Pfreemode",
+        "tooltip"  : "Complex Envelope Definitions",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/FreqEnvelope/Penvsustain",
+        "name"     : "Penvsustain",
+        "tooltip"  : "Location of the sustain point",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "2"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/FreqEnvelope/Penvdt[0,39]",
+        "name"     : "Penvdt#40",
+        "tooltip"  : "Envelope Delay Times",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/FreqEnvelope/Penvval[0,39]",
+        "name"     : "Penvval#40",
+        "tooltip"  : "Envelope Values",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/FreqEnvelope/Penvstretch",
+        "shortname": "stretch",
+        "name"     : "Penvstretch",
+        "tooltip"  : "Stretch with respect to frequency",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/FreqEnvelope/Pforcedrelease",
+        "shortname": "frcr",
+        "name"     : "Pforcedrelease",
+        "tooltip"  : "Force Envelope to fully evaluate",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/FreqEnvelope/Plinearenvelope",
+        "shortname": "lin/log",
+        "name"     : "Plinearenvelope",
+        "tooltip"  : "Linear or Logarithmic Envelopes",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/FreqEnvelope/PA_dt",
+        "shortname": "a.dt",
+        "name"     : "PA_dt",
+        "tooltip"  : "Attack Time",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/FreqEnvelope/A_dt",
+        "shortname": "a.dt",
+        "name"     : "A_dt",
+        "tooltip"  : "Attack Time",
+        "scale"    : "logarithmic",
+        "type"     : "f",
+        "range"    : [0.0f,41.0f],
+        "default"  : "0.00"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/FreqEnvelope/PA_val",
+        "shortname": "a.val",
+        "name"     : "PA_val",
+        "tooltip"  : "Attack Value",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/FreqEnvelope/PD_dt",
+        "shortname": "d.dt",
+        "name"     : "PD_dt",
+        "tooltip"  : "Decay Time",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/FreqEnvelope/D_dt",
+        "shortname": "d.dt",
+        "name"     : "D_dt",
+        "tooltip"  : "Decay Time",
+        "scale"    : "logarithmic",
+        "type"     : "f",
+        "range"    : [0.0f,41.0f],
+        "default"  : "0.00925031"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/FreqEnvelope/PD_val",
+        "shortname": "d.val",
+        "name"     : "PD_val",
+        "tooltip"  : "Decay Value",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/FreqEnvelope/PS_val",
+        "shortname": "s.val",
+        "name"     : "PS_val",
+        "tooltip"  : "Sustain Value",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/FreqEnvelope/PR_dt",
+        "shortname": "r.dt",
+        "name"     : "PR_dt",
+        "tooltip"  : "Release Time",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/FreqEnvelope/R_dt",
+        "shortname": "r.dt",
+        "name"     : "R_dt",
+        "tooltip"  : "Release Time",
+        "scale"    : "logarithmic",
+        "type"     : "f",
+        "range"    : [0.01f,41.0f],
+        "default"  : "0.498893"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/FreqEnvelope/PR_val",
+        "shortname": "r.val",
+        "name"     : "PR_val",
+        "tooltip"  : "Release Value",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/AmpEnvelope/Pfreemode",
+        "name"     : "Pfreemode",
+        "tooltip"  : "Complex Envelope Definitions",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/AmpEnvelope/Penvsustain",
+        "name"     : "Penvsustain",
+        "tooltip"  : "Location of the sustain point",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "2"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/AmpEnvelope/Penvdt[0,39]",
+        "name"     : "Penvdt#40",
+        "tooltip"  : "Envelope Delay Times",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/AmpEnvelope/Penvval[0,39]",
+        "name"     : "Penvval#40",
+        "tooltip"  : "Envelope Values",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/AmpEnvelope/Penvstretch",
+        "shortname": "stretch",
+        "name"     : "Penvstretch",
+        "tooltip"  : "Stretch with respect to frequency",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/AmpEnvelope/Pforcedrelease",
+        "shortname": "frcr",
+        "name"     : "Pforcedrelease",
+        "tooltip"  : "Force Envelope to fully evaluate",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/AmpEnvelope/Plinearenvelope",
+        "shortname": "lin/log",
+        "name"     : "Plinearenvelope",
+        "tooltip"  : "Linear or Logarithmic Envelopes",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/AmpEnvelope/PA_dt",
+        "shortname": "a.dt",
+        "name"     : "PA_dt",
+        "tooltip"  : "Attack Time",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/AmpEnvelope/A_dt",
+        "shortname": "a.dt",
+        "name"     : "A_dt",
+        "tooltip"  : "Attack Time",
+        "scale"    : "logarithmic",
+        "type"     : "f",
+        "range"    : [0.0f,41.0f],
+        "default"  : "0.00"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/AmpEnvelope/PA_val",
+        "shortname": "a.val",
+        "name"     : "PA_val",
+        "tooltip"  : "Attack Value",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/AmpEnvelope/PD_dt",
+        "shortname": "d.dt",
+        "name"     : "PD_dt",
+        "tooltip"  : "Decay Time",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/AmpEnvelope/D_dt",
+        "shortname": "d.dt",
+        "name"     : "D_dt",
+        "tooltip"  : "Decay Time",
+        "scale"    : "logarithmic",
+        "type"     : "f",
+        "range"    : [0.0f,41.0f],
+        "default"  : "0.00925031"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/AmpEnvelope/PD_val",
+        "shortname": "d.val",
+        "name"     : "PD_val",
+        "tooltip"  : "Decay Value",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/AmpEnvelope/PS_val",
+        "shortname": "s.val",
+        "name"     : "PS_val",
+        "tooltip"  : "Sustain Value",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/AmpEnvelope/PR_dt",
+        "shortname": "r.dt",
+        "name"     : "PR_dt",
+        "tooltip"  : "Release Time",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/AmpEnvelope/R_dt",
+        "shortname": "r.dt",
+        "name"     : "R_dt",
+        "tooltip"  : "Release Time",
+        "scale"    : "logarithmic",
+        "type"     : "f",
+        "range"    : [0.01f,41.0f],
+        "default"  : "0.498893"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/AmpEnvelope/PR_val",
+        "shortname": "r.val",
+        "name"     : "PR_val",
+        "tooltip"  : "Release Value",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/FilterEnvelope/Pfreemode",
+        "name"     : "Pfreemode",
+        "tooltip"  : "Complex Envelope Definitions",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/FilterEnvelope/Penvsustain",
+        "name"     : "Penvsustain",
+        "tooltip"  : "Location of the sustain point",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "2"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/FilterEnvelope/Penvdt[0,39]",
+        "name"     : "Penvdt#40",
+        "tooltip"  : "Envelope Delay Times",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/FilterEnvelope/Penvval[0,39]",
+        "name"     : "Penvval#40",
+        "tooltip"  : "Envelope Values",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/FilterEnvelope/Penvstretch",
+        "shortname": "stretch",
+        "name"     : "Penvstretch",
+        "tooltip"  : "Stretch with respect to frequency",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/FilterEnvelope/Pforcedrelease",
+        "shortname": "frcr",
+        "name"     : "Pforcedrelease",
+        "tooltip"  : "Force Envelope to fully evaluate",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/FilterEnvelope/Plinearenvelope",
+        "shortname": "lin/log",
+        "name"     : "Plinearenvelope",
+        "tooltip"  : "Linear or Logarithmic Envelopes",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/FilterEnvelope/PA_dt",
+        "shortname": "a.dt",
+        "name"     : "PA_dt",
+        "tooltip"  : "Attack Time",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/FilterEnvelope/A_dt",
+        "shortname": "a.dt",
+        "name"     : "A_dt",
+        "tooltip"  : "Attack Time",
+        "scale"    : "logarithmic",
+        "type"     : "f",
+        "range"    : [0.0f,41.0f],
+        "default"  : "0.00"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/FilterEnvelope/PA_val",
+        "shortname": "a.val",
+        "name"     : "PA_val",
+        "tooltip"  : "Attack Value",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/FilterEnvelope/PD_dt",
+        "shortname": "d.dt",
+        "name"     : "PD_dt",
+        "tooltip"  : "Decay Time",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/FilterEnvelope/D_dt",
+        "shortname": "d.dt",
+        "name"     : "D_dt",
+        "tooltip"  : "Decay Time",
+        "scale"    : "logarithmic",
+        "type"     : "f",
+        "range"    : [0.0f,41.0f],
+        "default"  : "0.00925031"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/FilterEnvelope/PD_val",
+        "shortname": "d.val",
+        "name"     : "PD_val",
+        "tooltip"  : "Decay Value",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/FilterEnvelope/PS_val",
+        "shortname": "s.val",
+        "name"     : "PS_val",
+        "tooltip"  : "Sustain Value",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/FilterEnvelope/PR_dt",
+        "shortname": "r.dt",
+        "name"     : "PR_dt",
+        "tooltip"  : "Release Time",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/FilterEnvelope/R_dt",
+        "shortname": "r.dt",
+        "name"     : "R_dt",
+        "tooltip"  : "Release Time",
+        "scale"    : "logarithmic",
+        "type"     : "f",
+        "range"    : [0.01f,41.0f],
+        "default"  : "0.498893"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/FilterEnvelope/PR_val",
+        "shortname": "r.val",
+        "name"     : "PR_val",
+        "tooltip"  : "Release Value",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/GlobalFilter/Pcategory",
+        "shortname": "class",
+        "name"     : "Pcategory",
+        "tooltip"  : "Class of filter",
+        "type"     : "i",
+        "default"  : "analog"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "analog"
+        },
+        {
+            "id"     : 1,
+            "value"  : "formant"
+        },
+        {
+            "id"     : 2,
+            "value"  : "st.var."
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/GlobalFilter/Ptype",
+        "shortname": "type",
+        "name"     : "Ptype",
+        "tooltip"  : "Filter Type",
+        "type"     : "i",
+        "default"  : "LP2"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "LP1"
+        },
+        {
+            "id"     : 1,
+            "value"  : "HP1"
+        },
+        {
+            "id"     : 2,
+            "value"  : "LP2"
+        },
+        {
+            "id"     : 3,
+            "value"  : "HP2"
+        },
+        {
+            "id"     : 4,
+            "value"  : "BP"
+        },
+        {
+            "id"     : 5,
+            "value"  : "notch"
+        },
+        {
+            "id"     : 6,
+            "value"  : "peak"
+        },
+        {
+            "id"     : 7,
+            "value"  : "l.shelf"
+        },
+        {
+            "id"     : 8,
+            "value"  : "h.shelf"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/GlobalFilter/Pstages",
+        "shortname": "stages",
+        "name"     : "Pstages",
+        "tooltip"  : "Filter Stages",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,5],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/GlobalFilter/baseq",
+        "shortname": "q",
+        "name"     : "baseq",
+        "tooltip"  : "Quality Factor (resonance/bandwidth)",
+        "units"    : "none",
+        "scale"    : "logarithmic",
+        "type"     : "f",
+        "range"    : [0.1,1000]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/GlobalFilter/basefreq",
+        "shortname": "cutoff",
+        "name"     : "basefreq",
+        "tooltip"  : "Base cutoff frequency",
+        "units"    : "Hz",
+        "scale"    : "logarithmic",
+        "type"     : "f",
+        "range"    : [31.25,32000]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/GlobalFilter/freqtracking",
+        "shortname": "f.track",
+        "name"     : "freqtracking",
+        "tooltip"  : "Frequency Tracking amount",
+        "units"    : "%",
+        "scale"    : "linear",
+        "type"     : "f",
+        "range"    : [-100,100],
+        "default"  : "0.0f"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/GlobalFilter/gain",
+        "shortname": "gain",
+        "name"     : "gain",
+        "tooltip"  : "Output Gain",
+        "units"    : "dB",
+        "scale"    : "linear",
+        "type"     : "f",
+        "range"    : [-30,30],
+        "default"  : "0.0f"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/GlobalFilter/Pnumformants",
+        "shortname": "formants",
+        "name"     : "Pnumformants",
+        "tooltip"  : "Number of formants to be used",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [1,12],
+        "default"  : "3"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/GlobalFilter/Pformantslowness",
+        "shortname": "slew",
+        "name"     : "Pformantslowness",
+        "tooltip"  : "Rate that formants change",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/GlobalFilter/Pvowelclearness",
+        "shortname": "clarity",
+        "name"     : "Pvowelclearness",
+        "tooltip"  : "How much each vowel is smudged with the next in sequence. A high clarity will avoid smudging.",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/GlobalFilter/Pcenterfreq",
+        "shortname": "cutoff",
+        "name"     : "Pcenterfreq",
+        "tooltip"  : "Center Freq (formant)",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/GlobalFilter/Poctavesfreq",
+        "shortname": "octaves",
+        "name"     : "Poctavesfreq",
+        "tooltip"  : "Number of octaves for formant",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/GlobalFilter/Psequencesize",
+        "shortname": "seq.size",
+        "name"     : "Psequencesize",
+        "tooltip"  : "Length of vowel sequence",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,8],
+        "default"  : "3"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/GlobalFilter/Psequencestretch",
+        "shortname": "seq.str",
+        "name"     : "Psequencestretch",
+        "tooltip"  : "How modulators stretch the sequence",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "40"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/GlobalFilter/Psequencereversed",
+        "shortname": "reverse",
+        "name"     : "Psequencereversed",
+        "tooltip"  : "If the modulator input is inverted",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/GlobalFilter/type-svf",
+        "shortname": "type",
+        "name"     : "type-svf",
+        "tooltip"  : "Filter Type",
+        "type"     : "i",
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "low"
+        },
+        {
+            "id"     : 1,
+            "value"  : "high"
+        },
+        {
+            "id"     : 2,
+            "value"  : "band"
+        },
+        {
+            "id"     : 3,
+            "value"  : "notch"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/GlobalFilter/Pvowels[0,5]/Pformants[0,11]/freq",
+        "shortname": "f.freq",
+        "name"     : "freq",
+        "tooltip"  : "Formant frequency",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/GlobalFilter/Pvowels[0,5]/Pformants[0,11]/amp",
+        "shortname": "f.str",
+        "name"     : "amp",
+        "tooltip"  : "Strength of formant",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "127"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/GlobalFilter/Pvowels[0,5]/Pformants[0,11]/q",
+        "shortname": "f.q",
+        "name"     : "q",
+        "tooltip"  : "The formant's quality factor, also known as resonance bandwidth or Q for short",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/PStereo",
+        "shortname": "stereo",
+        "name"     : "PStereo",
+        "tooltip"  : "Stereo/Mono Mode",
+        "type"     : "t",
+        "default"  : "true"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/PPanning",
+        "shortname": "panning",
+        "name"     : "PPanning",
+        "tooltip"  : "Left Right Panning",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/PVolume",
+        "shortname": "vol",
+        "name"     : "PVolume",
+        "tooltip"  : "Synth Volume",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "90"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/PAmpVelocityScaleFunction",
+        "shortname": "sense",
+        "name"     : "PAmpVelocityScaleFunction",
+        "tooltip"  : "Amplitude Velocity Sensing function",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/Fadein_adjustment",
+        "shortname": "a.pop.",
+        "name"     : "Fadein_adjustment",
+        "tooltip"  : "Adjustment for anti-pop strategy.",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "20"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/PPunchStrength",
+        "shortname": "strength",
+        "name"     : "PPunchStrength",
+        "tooltip"  : "Punch Strength",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/PPunchTime",
+        "shortname": "time",
+        "name"     : "PPunchTime",
+        "tooltip"  : "Length of punch",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "60"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/PPunchStretch",
+        "shortname": "stretch",
+        "name"     : "PPunchStretch",
+        "tooltip"  : "How Punch changes with note frequency",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/PPunchVelocitySensing",
+        "shortname": "sense",
+        "name"     : "PPunchVelocitySensing",
+        "tooltip"  : "Punch Velocity control",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "72"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/PFilterVelocityScale",
+        "shortname": "scale",
+        "name"     : "PFilterVelocityScale",
+        "tooltip"  : "Filter Velocity Magnitude",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/PFilterVelocityScaleFunction",
+        "shortname": "sense",
+        "name"     : "PFilterVelocityScaleFunction",
+        "tooltip"  : "Filter Velocity Function Shape",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/Pfixedfreq",
+        "shortname": "fixed",
+        "name"     : "Pfixedfreq",
+        "tooltip"  : "Base frequency fixed frequency enable",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/PfixedfreqET",
+        "shortname": "f.ET",
+        "name"     : "PfixedfreqET",
+        "tooltip"  : "Equal temeperate control for fixed frequency operation",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/PBendAdjust",
+        "name"     : "PBendAdjust",
+        "tooltip"  : "Pitch bend adjustment",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "88"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/POffsetHz",
+        "shortname": "offset",
+        "name"     : "POffsetHz",
+        "tooltip"  : "Voice constant offset",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/PDetune",
+        "shortname": "fine",
+        "name"     : "PDetune",
+        "tooltip"  : "Fine Detune",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,16383],
+        "default"  : "8192"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/PCoarseDetune",
+        "shortname": "coarse",
+        "name"     : "PCoarseDetune",
+        "tooltip"  : "Coarse Detune",
+        "type"     : "i",
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/PDetuneType",
+        "shortname": "type",
+        "name"     : "PDetuneType",
+        "tooltip"  : "Magnitude of Detune",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "L10cents"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "L35cents"
+        },
+        {
+            "id"     : 1,
+            "value"  : "L10cents"
+        },
+        {
+            "id"     : 2,
+            "value"  : "E100cents"
+        },
+        {
+            "id"     : 3,
+            "value"  : "E1200cents"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/octave",
+        "shortname": "octave",
+        "name"     : "octave",
+        "tooltip"  : "Octave note offset",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [-8,7]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/coarsedetune",
+        "shortname": "coarse",
+        "name"     : "coarsedetune",
+        "tooltip"  : "Coarse note detune",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [-64,63]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/oscilgen/Prand",
+        "shortname": "phase rnd",
+        "name"     : "Prand",
+        "tooltip"  : "Oscillator Phase Randomness: smaller than 0 is \"group\", larger than 0 is for each harmonic",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/oscilgen/Pamprandpower",
+        "shortname": "variance",
+        "name"     : "Pamprandpower",
+        "tooltip"  : "Variance of harmonic randomness",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/oscilgen/Pamprandtype",
+        "shortname": "distribution",
+        "name"     : "Pamprandtype",
+        "tooltip"  : "Harmonic random distribution to select from",
+        "type"     : "i",
+        "default"  : "None"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "None"
+        },
+        {
+            "id"     : 1,
+            "value"  : "Pow"
+        },
+        {
+            "id"     : 2,
+            "value"  : "Sin"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/oscilgen/Padaptiveharmonics",
+        "shortname": "adapt",
+        "name"     : "Padaptiveharmonics",
+        "tooltip"  : "Adaptive Harmonics Mode",
+        "type"     : "i",
+        "default"  : "OFF"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "OFF"
+        },
+        {
+            "id"     : 1,
+            "value"  : "ON"
+        },
+        {
+            "id"     : 2,
+            "value"  : "Square"
+        },
+        {
+            "id"     : 3,
+            "value"  : "2xSub"
+        },
+        {
+            "id"     : 4,
+            "value"  : "2xAdd"
+        },
+        {
+            "id"     : 5,
+            "value"  : "3xSub"
+        },
+        {
+            "id"     : 6,
+            "value"  : "3xAdd"
+        },
+        {
+            "id"     : 7,
+            "value"  : "4xSub"
+        },
+        {
+            "id"     : 8,
+            "value"  : "4xAdd"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/oscilgen/Padaptiveharmonicsbasefreq",
+        "shortname": "c. freq",
+        "name"     : "Padaptiveharmonicsbasefreq",
+        "tooltip"  : "Base frequency of adaptive harmonic (30..3000Hz)",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,255],
+        "default"  : "128"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/oscilgen/Padaptiveharmonicspower",
+        "shortname": "amount",
+        "name"     : "Padaptiveharmonicspower",
+        "tooltip"  : "Adaptive Harmonic Strength",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,200],
+        "default"  : "100"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/oscilgen/Padaptiveharmonicspar",
+        "shortname": "power",
+        "name"     : "Padaptiveharmonicspar",
+        "tooltip"  : "Adaptive Harmonics Postprocessing Power",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,100],
+        "default"  : "50"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/oscilgen/Phmagtype",
+        "shortname": "scale",
+        "name"     : "Phmagtype",
+        "tooltip"  : "Type of magnitude for harmonics",
+        "type"     : "i",
+        "default"  : "linear"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "linear"
+        },
+        {
+            "id"     : 1,
+            "value"  : "dB scale (-40)"
+        },
+        {
+            "id"     : 2,
+            "value"  : "dB scale (-60)"
+        },
+        {
+            "id"     : 3,
+            "value"  : "dB scale (-80)"
+        },
+        {
+            "id"     : 4,
+            "value"  : "dB scale (-100)"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/oscilgen/Pcurrentbasefunc",
+        "shortname": "base",
+        "name"     : "Pcurrentbasefunc",
+        "tooltip"  : "Base Waveform for harmonics",
+        "type"     : "i",
+        "default"  : "sine"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "sine"
+        },
+        {
+            "id"     : 1,
+            "value"  : "triangle"
+        },
+        {
+            "id"     : 2,
+            "value"  : "pulse"
+        },
+        {
+            "id"     : 3,
+            "value"  : "saw"
+        },
+        {
+            "id"     : 4,
+            "value"  : "power"
+        },
+        {
+            "id"     : 5,
+            "value"  : "gauss"
+        },
+        {
+            "id"     : 6,
+            "value"  : "diode"
+        },
+        {
+            "id"     : 7,
+            "value"  : "abssine"
+        },
+        {
+            "id"     : 8,
+            "value"  : "pulsesine"
+        },
+        {
+            "id"     : 9,
+            "value"  : "stretchsine"
+        },
+        {
+            "id"     : 10,
+            "value"  : "chirp"
+        },
+        {
+            "id"     : 11,
+            "value"  : "absstretchsine"
+        },
+        {
+            "id"     : 12,
+            "value"  : "chebyshev"
+        },
+        {
+            "id"     : 13,
+            "value"  : "sqr"
+        },
+        {
+            "id"     : 14,
+            "value"  : "spike"
+        },
+        {
+            "id"     : 15,
+            "value"  : "circle"
+        },
+        {
+            "id"     : 127,
+            "value"  : "use-as-base waveform"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/oscilgen/Pbasefuncpar",
+        "shortname": "shape",
+        "name"     : "Pbasefuncpar",
+        "tooltip"  : "Morph between possible base function shapes (e.g. rising sawtooth vs a falling sawtooth)",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/oscilgen/Pbasefuncmodulation",
+        "shortname": "mod",
+        "name"     : "Pbasefuncmodulation",
+        "tooltip"  : "Modulation applied to Base function spectra",
+        "type"     : "i",
+        "default"  : "None"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "None"
+        },
+        {
+            "id"     : 1,
+            "value"  : "Rev"
+        },
+        {
+            "id"     : 2,
+            "value"  : "Sine"
+        },
+        {
+            "id"     : 3,
+            "value"  : "Power"
+        },
+        {
+            "id"     : 4,
+            "value"  : "Chop"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/oscilgen/Pbasefuncmodulationpar1",
+        "shortname": "p1",
+        "name"     : "Pbasefuncmodulationpar1",
+        "tooltip"  : "Base function modulation parameter",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/oscilgen/Pbasefuncmodulationpar2",
+        "shortname": "p2",
+        "name"     : "Pbasefuncmodulationpar2",
+        "tooltip"  : "Base function modulation parameter",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/oscilgen/Pbasefuncmodulationpar3",
+        "shortname": "p3",
+        "name"     : "Pbasefuncmodulationpar3",
+        "tooltip"  : "Base function modulation parameter",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "32"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/oscilgen/Pwaveshaping",
+        "shortname": "amount",
+        "name"     : "Pwaveshaping",
+        "tooltip"  : "Degree Of Waveshaping",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/oscilgen/Pwaveshapingfunction",
+        "shortname": "distort",
+        "name"     : "Pwaveshapingfunction",
+        "tooltip"  : "Shape of distortion to be applied",
+        "type"     : "i",
+        "default"  : "Undistorted"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "Undistorted"
+        },
+        {
+            "id"     : 1,
+            "value"  : "Arctangent"
+        },
+        {
+            "id"     : 2,
+            "value"  : "Asymmetric"
+        },
+        {
+            "id"     : 3,
+            "value"  : "Pow"
+        },
+        {
+            "id"     : 4,
+            "value"  : "Sine"
+        },
+        {
+            "id"     : 5,
+            "value"  : "Quantisize"
+        },
+        {
+            "id"     : 6,
+            "value"  : "Zigzag"
+        },
+        {
+            "id"     : 7,
+            "value"  : "Limiter"
+        },
+        {
+            "id"     : 8,
+            "value"  : "Upper Limiter"
+        },
+        {
+            "id"     : 9,
+            "value"  : "Lower Limiter"
+        },
+        {
+            "id"     : 10,
+            "value"  : "Inverse Limiter"
+        },
+        {
+            "id"     : 11,
+            "value"  : "Clip"
+        },
+        {
+            "id"     : 12,
+            "value"  : "Asym2"
+        },
+        {
+            "id"     : 13,
+            "value"  : "Pow2"
+        },
+        {
+            "id"     : 14,
+            "value"  : "sigmoid"
+        },
+        {
+            "id"     : 15,
+            "value"  : "Tanh"
+        },
+        {
+            "id"     : 16,
+            "value"  : "Cubic"
+        },
+        {
+            "id"     : 17,
+            "value"  : "Square"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/oscilgen/Pfiltertype",
+        "shortname": "filter",
+        "name"     : "Pfiltertype",
+        "tooltip"  : "Harmonic Filter",
+        "type"     : "i",
+        "default"  : "\"No Filter\"S"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "No Filter"
+        },
+        {
+            "id"     : 1,
+            "value"  : "lp"
+        },
+        {
+            "id"     : 2,
+            "value"  : "hp1"
+        },
+        {
+            "id"     : 3,
+            "value"  : "hp1b"
+        },
+        {
+            "id"     : 4,
+            "value"  : "bp1"
+        },
+        {
+            "id"     : 5,
+            "value"  : "bs1"
+        },
+        {
+            "id"     : 6,
+            "value"  : "lp2"
+        },
+        {
+            "id"     : 7,
+            "value"  : "hp2"
+        },
+        {
+            "id"     : 8,
+            "value"  : "bp2"
+        },
+        {
+            "id"     : 9,
+            "value"  : "bs2"
+        },
+        {
+            "id"     : 10,
+            "value"  : "cos"
+        },
+        {
+            "id"     : 11,
+            "value"  : "sin"
+        },
+        {
+            "id"     : 12,
+            "value"  : "low_shelf"
+        },
+        {
+            "id"     : 13,
+            "value"  : "s"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/oscilgen/Pfilterpar1",
+        "shortname": "p1",
+        "name"     : "Pfilterpar1",
+        "tooltip"  : "Filter parameter",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/oscilgen/Pfilterpar2",
+        "shortname": "p2",
+        "name"     : "Pfilterpar2",
+        "tooltip"  : "Filter parameter",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/oscilgen/Pfilterbeforews",
+        "shortname": "pre/post",
+        "name"     : "Pfilterbeforews",
+        "tooltip"  : "Filter before waveshaping spectra;When enabled oscilfilter(freqs); then waveshape(freqs);, otherwise waveshape(freqs); then oscilfilter(freqs);",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/oscilgen/Psatype",
+        "shortname": "spec. adj.",
+        "name"     : "Psatype",
+        "tooltip"  : "Spectral Adjustment Type",
+        "type"     : "i",
+        "default"  : "None"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "None"
+        },
+        {
+            "id"     : 1,
+            "value"  : "Pow"
+        },
+        {
+            "id"     : 2,
+            "value"  : "ThrsD"
+        },
+        {
+            "id"     : 3,
+            "value"  : "ThrsU"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/oscilgen/Psapar",
+        "shortname": "p1",
+        "name"     : "Psapar",
+        "tooltip"  : "Spectral Adjustment Parameter",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/oscilgen/Pharmonicshift",
+        "shortname": "shift",
+        "name"     : "Pharmonicshift",
+        "tooltip"  : "Amount of shift on harmonics",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [-64,64],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/oscilgen/Pharmonicshiftfirst",
+        "shortname": "pre/post",
+        "name"     : "Pharmonicshiftfirst",
+        "tooltip"  : "If harmonics are shifted before waveshaping/filtering",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/oscilgen/Pmodulation",
+        "shortname": "FM",
+        "name"     : "Pmodulation",
+        "tooltip"  : "Frequency Modulation To Combined Spectra",
+        "type"     : "i",
+        "default"  : "None"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "None"
+        },
+        {
+            "id"     : 1,
+            "value"  : "Rev"
+        },
+        {
+            "id"     : 2,
+            "value"  : "Sine"
+        },
+        {
+            "id"     : 3,
+            "value"  : "Power"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/oscilgen/Pmodulationpar1",
+        "shortname": "p1",
+        "name"     : "Pmodulationpar1",
+        "tooltip"  : "modulation parameter",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/oscilgen/Pmodulationpar2",
+        "shortname": "p2",
+        "name"     : "Pmodulationpar2",
+        "tooltip"  : "modulation parameter",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/oscilgen/Pmodulationpar3",
+        "shortname": "p3",
+        "name"     : "Pmodulationpar3",
+        "tooltip"  : "modulation parameter",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "32"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/oscilgen/ADvsPAD",
+        "shortname": "If it is used by PADSynth",
+        "name"     : "ADvsPAD",
+        "tooltip"  : "If it is used by PADSynth (and not ADSynth)",
+        "type"     : "t"
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/oscilgen/phase[0,127]",
+        "name"     : "phase#128",
+        "tooltip"  : "Sets harmonic phase",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "[64 ...]"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/oscilgen/magnitude[0,127]",
+        "name"     : "magnitude#128",
+        "tooltip"  : "Sets harmonic magnitude",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "[127 64 64 ...]"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/resonance/Penabled",
+        "shortname": "enable",
+        "name"     : "Penabled",
+        "tooltip"  : "resonance enable",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/resonance/Pprotectthefundamental",
+        "shortname": "p.fund.",
+        "name"     : "Pprotectthefundamental",
+        "tooltip"  : "Disable resonance filter on first harmonic",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/resonance/Prespoints[0,255]",
+        "name"     : "Prespoints#256",
+        "tooltip"  : "Resonance data points",
+        "type"     : "i",
+        "default"  : "[64 ...]"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/resonance/PmaxdB",
+        "shortname": "max",
+        "name"     : "PmaxdB",
+        "tooltip"  : "how many dB the signal may be amplified",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "20"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/resonance/Pcenterfreq",
+        "shortname": "c.freq",
+        "name"     : "Pcenterfreq",
+        "tooltip"  : "Center frequency",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/resonance/Poctavesfreq",
+        "shortname": "oct",
+        "name"     : "Poctavesfreq",
+        "tooltip"  : "The number of octaves...",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/Pmode",
+        "shortname": "distribution",
+        "name"     : "Pmode",
+        "tooltip"  : "Harmonic Distribution Model",
+        "type"     : "i",
+        "range"    : [0,2],
+        "default"  : "bandwidth"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "bandwidth"
+        },
+        {
+            "id"     : 1,
+            "value"  : "discrete"
+        },
+        {
+            "id"     : 2,
+            "value"  : "continious"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/Php.base.type",
+        "shortname": "shape",
+        "name"     : "Php.base.type",
+        "tooltip"  : "Harmonic profile shape",
+        "type"     : "i",
+        "default"  : "Gaussian"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "Gaussian"
+        },
+        {
+            "id"     : 1,
+            "value"  : "Rectanglar"
+        },
+        {
+            "id"     : 2,
+            "value"  : "Double Exponential"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/Php.base.par1",
+        "shortname": "warp",
+        "name"     : "Php.base.par1",
+        "tooltip"  : "Harmonic shape distribution parameter",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "80"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/Php.freqmult",
+        "shortname": "clone",
+        "name"     : "Php.freqmult",
+        "tooltip"  : "Frequency multiplier on distribution",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/Php.modulator.par1",
+        "shortname": "p1",
+        "name"     : "Php.modulator.par1",
+        "tooltip"  : "Distribution modulator parameter",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/Php.modulator.freq",
+        "shortname": "freq",
+        "name"     : "Php.modulator.freq",
+        "tooltip"  : "Frequency of modulator parameter",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "30"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/Php.width",
+        "shortname": "bandwidth",
+        "name"     : "Php.width",
+        "tooltip"  : "Width of base harmonic",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "127"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/Php.amp.mode",
+        "shortname": "mode",
+        "name"     : "Php.amp.mode",
+        "tooltip"  : "Amplitude harmonic multiplier type",
+        "type"     : "i",
+        "default"  : "Sum"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "Sum"
+        },
+        {
+            "id"     : 1,
+            "value"  : "Mult"
+        },
+        {
+            "id"     : 2,
+            "value"  : "Div1"
+        },
+        {
+            "id"     : 3,
+            "value"  : "Div2"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/Php.amp.type",
+        "shortname": "mult",
+        "name"     : "Php.amp.type",
+        "tooltip"  : "Type of amplitude multipler",
+        "type"     : "i",
+        "default"  : "Off"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "Off"
+        },
+        {
+            "id"     : 1,
+            "value"  : "Gauss"
+        },
+        {
+            "id"     : 2,
+            "value"  : "Sine"
+        },
+        {
+            "id"     : 3,
+            "value"  : "Flat"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/Php.amp.par1",
+        "shortname": "p1",
+        "name"     : "Php.amp.par1",
+        "tooltip"  : "Amplitude multiplier parameter",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "80"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/Php.amp.par2",
+        "shortname": "p2",
+        "name"     : "Php.amp.par2",
+        "tooltip"  : "Amplitude multiplier parameter",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "60"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/Php.autoscale",
+        "shortname": "auto",
+        "name"     : "Php.autoscale",
+        "tooltip"  : "Autoscaling Harmonics",
+        "type"     : "t",
+        "default"  : "true"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/Php.onehalf",
+        "shortname": "side",
+        "name"     : "Php.onehalf",
+        "tooltip"  : ":default",
+        "type"     : "i",
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "Full"
+        },
+        {
+            "id"     : 1,
+            "value"  : "Upper Half"
+        },
+        {
+            "id"     : 2,
+            "value"  : "Lower Half"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/Pbwscale",
+        "shortname": "bw scale",
+        "name"     : "Pbwscale",
+        "tooltip"  : "Bandwidth scaling",
+        "type"     : "i",
+        "default"  : "Normal"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "Normal"
+        },
+        {
+            "id"     : 1,
+            "value"  : "EqualHz"
+        },
+        {
+            "id"     : 2,
+            "value"  : "Quarter"
+        },
+        {
+            "id"     : 3,
+            "value"  : "Half"
+        },
+        {
+            "id"     : 4,
+            "value"  : "75%"
+        },
+        {
+            "id"     : 5,
+            "value"  : "150%"
+        },
+        {
+            "id"     : 6,
+            "value"  : "Double"
+        },
+        {
+            "id"     : 7,
+            "value"  : "Inv. Half"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/Phrpos.type",
+        "name"     : "Phrpos.type",
+        "tooltip"  : ":default",
+        "type"     : "i",
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "Harmonic"
+        },
+        {
+            "id"     : 1,
+            "value"  : "ShiftU"
+        },
+        {
+            "id"     : 2,
+            "value"  : "ShiftL"
+        },
+        {
+            "id"     : 3,
+            "value"  : "PowerU"
+        },
+        {
+            "id"     : 4,
+            "value"  : "PowerL"
+        },
+        {
+            "id"     : 5,
+            "value"  : "Sine"
+        },
+        {
+            "id"     : 6,
+            "value"  : "Power"
+        },
+        {
+            "id"     : 7,
+            "value"  : "Shift"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/Phrpos.par1",
+        "shortname": "p1",
+        "name"     : "Phrpos.par1",
+        "tooltip"  : "Harmonic position parameter",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,255],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/Phrpos.par2",
+        "shortname": "p2",
+        "name"     : "Phrpos.par2",
+        "tooltip"  : "Harmonic position parameter",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,255],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/Phrpos.par3",
+        "shortname": "force h.",
+        "name"     : "Phrpos.par3",
+        "tooltip"  : "Harmonic position parameter",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,255],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/Pquality.samplesize",
+        "shortname": "quality",
+        "name"     : "Pquality.samplesize",
+        "tooltip"  : "Size of each wavetable element",
+        "type"     : "i",
+        "default"  : "\"128k\"S"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "16k (Tiny)"
+        },
+        {
+            "id"     : 1,
+            "value"  : "32k"
+        },
+        {
+            "id"     : 2,
+            "value"  : "64k (Small)"
+        },
+        {
+            "id"     : 3,
+            "value"  : "128k"
+        },
+        {
+            "id"     : 4,
+            "value"  : "256k (Normal)"
+        },
+        {
+            "id"     : 5,
+            "value"  : "512k"
+        },
+        {
+            "id"     : 6,
+            "value"  : "1M (Big)"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/Pquality.basenote",
+        "shortname": "basenote",
+        "name"     : "Pquality.basenote",
+        "tooltip"  : "Base note for wavetable",
+        "type"     : "i",
+        "default"  : "\"C-4\"S"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "C-2"
+        },
+        {
+            "id"     : 1,
+            "value"  : "G-2"
+        },
+        {
+            "id"     : 2,
+            "value"  : "C-3"
+        },
+        {
+            "id"     : 3,
+            "value"  : "G-3"
+        },
+        {
+            "id"     : 4,
+            "value"  : "C-4"
+        },
+        {
+            "id"     : 5,
+            "value"  : "G-4"
+        },
+        {
+            "id"     : 6,
+            "value"  : "C-5"
+        },
+        {
+            "id"     : 7,
+            "value"  : "G-5"
+        },
+        {
+            "id"     : 8,
+            "value"  : "G-6"
+        },
+        {
+            "id"     : 9,
+            "value"  : ""
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/Pquality.smpoct",
+        "shortname": "smp/oct",
+        "name"     : "Pquality.smpoct",
+        "tooltip"  : "Samples per octave",
+        "type"     : "i",
+        "default"  : "2"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "0.5"
+        },
+        {
+            "id"     : 1,
+            "value"  : "1"
+        },
+        {
+            "id"     : 2,
+            "value"  : "2"
+        },
+        {
+            "id"     : 3,
+            "value"  : "3"
+        },
+        {
+            "id"     : 4,
+            "value"  : "4"
+        },
+        {
+            "id"     : 5,
+            "value"  : "6"
+        },
+        {
+            "id"     : 6,
+            "value"  : "12"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/Pquality.oct",
+        "shortname": "octaves",
+        "name"     : "Pquality.oct",
+        "tooltip"  : "Number of octaves to sample (above the first sample",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,7],
+        "default"  : "3"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/padpars/Pbandwidth",
+        "shortname": "bandwidth",
+        "name"     : "Pbandwidth",
+        "tooltip"  : "Bandwidth Of Harmonics",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,1000],
+        "default"  : "500"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/OscilSmp/Prand",
+        "shortname": "phase rnd",
+        "name"     : "Prand",
+        "tooltip"  : "Oscillator Phase Randomness: smaller than 0 is \"group\", larger than 0 is for each harmonic",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/OscilSmp/Pamprandpower",
+        "shortname": "variance",
+        "name"     : "Pamprandpower",
+        "tooltip"  : "Variance of harmonic randomness",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/OscilSmp/Pamprandtype",
+        "shortname": "distribution",
+        "name"     : "Pamprandtype",
+        "tooltip"  : "Harmonic random distribution to select from",
+        "type"     : "i",
+        "default"  : "None"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "None"
+        },
+        {
+            "id"     : 1,
+            "value"  : "Pow"
+        },
+        {
+            "id"     : 2,
+            "value"  : "Sin"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/OscilSmp/Padaptiveharmonics",
+        "shortname": "adapt",
+        "name"     : "Padaptiveharmonics",
+        "tooltip"  : "Adaptive Harmonics Mode",
+        "type"     : "i",
+        "default"  : "OFF"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "OFF"
+        },
+        {
+            "id"     : 1,
+            "value"  : "ON"
+        },
+        {
+            "id"     : 2,
+            "value"  : "Square"
+        },
+        {
+            "id"     : 3,
+            "value"  : "2xSub"
+        },
+        {
+            "id"     : 4,
+            "value"  : "2xAdd"
+        },
+        {
+            "id"     : 5,
+            "value"  : "3xSub"
+        },
+        {
+            "id"     : 6,
+            "value"  : "3xAdd"
+        },
+        {
+            "id"     : 7,
+            "value"  : "4xSub"
+        },
+        {
+            "id"     : 8,
+            "value"  : "4xAdd"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/OscilSmp/Padaptiveharmonicsbasefreq",
+        "shortname": "c. freq",
+        "name"     : "Padaptiveharmonicsbasefreq",
+        "tooltip"  : "Base frequency of adaptive harmonic (30..3000Hz)",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,255],
+        "default"  : "128"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/OscilSmp/Padaptiveharmonicspower",
+        "shortname": "amount",
+        "name"     : "Padaptiveharmonicspower",
+        "tooltip"  : "Adaptive Harmonic Strength",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,200],
+        "default"  : "100"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/OscilSmp/Padaptiveharmonicspar",
+        "shortname": "power",
+        "name"     : "Padaptiveharmonicspar",
+        "tooltip"  : "Adaptive Harmonics Postprocessing Power",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,100],
+        "default"  : "50"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/OscilSmp/Phmagtype",
+        "shortname": "scale",
+        "name"     : "Phmagtype",
+        "tooltip"  : "Type of magnitude for harmonics",
+        "type"     : "i",
+        "default"  : "linear"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "linear"
+        },
+        {
+            "id"     : 1,
+            "value"  : "dB scale (-40)"
+        },
+        {
+            "id"     : 2,
+            "value"  : "dB scale (-60)"
+        },
+        {
+            "id"     : 3,
+            "value"  : "dB scale (-80)"
+        },
+        {
+            "id"     : 4,
+            "value"  : "dB scale (-100)"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/OscilSmp/Pcurrentbasefunc",
+        "shortname": "base",
+        "name"     : "Pcurrentbasefunc",
+        "tooltip"  : "Base Waveform for harmonics",
+        "type"     : "i",
+        "default"  : "sine"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "sine"
+        },
+        {
+            "id"     : 1,
+            "value"  : "triangle"
+        },
+        {
+            "id"     : 2,
+            "value"  : "pulse"
+        },
+        {
+            "id"     : 3,
+            "value"  : "saw"
+        },
+        {
+            "id"     : 4,
+            "value"  : "power"
+        },
+        {
+            "id"     : 5,
+            "value"  : "gauss"
+        },
+        {
+            "id"     : 6,
+            "value"  : "diode"
+        },
+        {
+            "id"     : 7,
+            "value"  : "abssine"
+        },
+        {
+            "id"     : 8,
+            "value"  : "pulsesine"
+        },
+        {
+            "id"     : 9,
+            "value"  : "stretchsine"
+        },
+        {
+            "id"     : 10,
+            "value"  : "chirp"
+        },
+        {
+            "id"     : 11,
+            "value"  : "absstretchsine"
+        },
+        {
+            "id"     : 12,
+            "value"  : "chebyshev"
+        },
+        {
+            "id"     : 13,
+            "value"  : "sqr"
+        },
+        {
+            "id"     : 14,
+            "value"  : "spike"
+        },
+        {
+            "id"     : 15,
+            "value"  : "circle"
+        },
+        {
+            "id"     : 127,
+            "value"  : "use-as-base waveform"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/OscilSmp/Pbasefuncpar",
+        "shortname": "shape",
+        "name"     : "Pbasefuncpar",
+        "tooltip"  : "Morph between possible base function shapes (e.g. rising sawtooth vs a falling sawtooth)",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/OscilSmp/Pbasefuncmodulation",
+        "shortname": "mod",
+        "name"     : "Pbasefuncmodulation",
+        "tooltip"  : "Modulation applied to Base function spectra",
+        "type"     : "i",
+        "default"  : "None"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "None"
+        },
+        {
+            "id"     : 1,
+            "value"  : "Rev"
+        },
+        {
+            "id"     : 2,
+            "value"  : "Sine"
+        },
+        {
+            "id"     : 3,
+            "value"  : "Power"
+        },
+        {
+            "id"     : 4,
+            "value"  : "Chop"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/OscilSmp/Pbasefuncmodulationpar1",
+        "shortname": "p1",
+        "name"     : "Pbasefuncmodulationpar1",
+        "tooltip"  : "Base function modulation parameter",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/OscilSmp/Pbasefuncmodulationpar2",
+        "shortname": "p2",
+        "name"     : "Pbasefuncmodulationpar2",
+        "tooltip"  : "Base function modulation parameter",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/OscilSmp/Pbasefuncmodulationpar3",
+        "shortname": "p3",
+        "name"     : "Pbasefuncmodulationpar3",
+        "tooltip"  : "Base function modulation parameter",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "32"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/OscilSmp/Pwaveshaping",
+        "shortname": "amount",
+        "name"     : "Pwaveshaping",
+        "tooltip"  : "Degree Of Waveshaping",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/OscilSmp/Pwaveshapingfunction",
+        "shortname": "distort",
+        "name"     : "Pwaveshapingfunction",
+        "tooltip"  : "Shape of distortion to be applied",
+        "type"     : "i",
+        "default"  : "Undistorted"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "Undistorted"
+        },
+        {
+            "id"     : 1,
+            "value"  : "Arctangent"
+        },
+        {
+            "id"     : 2,
+            "value"  : "Asymmetric"
+        },
+        {
+            "id"     : 3,
+            "value"  : "Pow"
+        },
+        {
+            "id"     : 4,
+            "value"  : "Sine"
+        },
+        {
+            "id"     : 5,
+            "value"  : "Quantisize"
+        },
+        {
+            "id"     : 6,
+            "value"  : "Zigzag"
+        },
+        {
+            "id"     : 7,
+            "value"  : "Limiter"
+        },
+        {
+            "id"     : 8,
+            "value"  : "Upper Limiter"
+        },
+        {
+            "id"     : 9,
+            "value"  : "Lower Limiter"
+        },
+        {
+            "id"     : 10,
+            "value"  : "Inverse Limiter"
+        },
+        {
+            "id"     : 11,
+            "value"  : "Clip"
+        },
+        {
+            "id"     : 12,
+            "value"  : "Asym2"
+        },
+        {
+            "id"     : 13,
+            "value"  : "Pow2"
+        },
+        {
+            "id"     : 14,
+            "value"  : "sigmoid"
+        },
+        {
+            "id"     : 15,
+            "value"  : "Tanh"
+        },
+        {
+            "id"     : 16,
+            "value"  : "Cubic"
+        },
+        {
+            "id"     : 17,
+            "value"  : "Square"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/OscilSmp/Pfiltertype",
+        "shortname": "filter",
+        "name"     : "Pfiltertype",
+        "tooltip"  : "Harmonic Filter",
+        "type"     : "i",
+        "default"  : "\"No Filter\"S"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "No Filter"
+        },
+        {
+            "id"     : 1,
+            "value"  : "lp"
+        },
+        {
+            "id"     : 2,
+            "value"  : "hp1"
+        },
+        {
+            "id"     : 3,
+            "value"  : "hp1b"
+        },
+        {
+            "id"     : 4,
+            "value"  : "bp1"
+        },
+        {
+            "id"     : 5,
+            "value"  : "bs1"
+        },
+        {
+            "id"     : 6,
+            "value"  : "lp2"
+        },
+        {
+            "id"     : 7,
+            "value"  : "hp2"
+        },
+        {
+            "id"     : 8,
+            "value"  : "bp2"
+        },
+        {
+            "id"     : 9,
+            "value"  : "bs2"
+        },
+        {
+            "id"     : 10,
+            "value"  : "cos"
+        },
+        {
+            "id"     : 11,
+            "value"  : "sin"
+        },
+        {
+            "id"     : 12,
+            "value"  : "low_shelf"
+        },
+        {
+            "id"     : 13,
+            "value"  : "s"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/OscilSmp/Pfilterpar1",
+        "shortname": "p1",
+        "name"     : "Pfilterpar1",
+        "tooltip"  : "Filter parameter",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/OscilSmp/Pfilterpar2",
+        "shortname": "p2",
+        "name"     : "Pfilterpar2",
+        "tooltip"  : "Filter parameter",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/OscilSmp/Pfilterbeforews",
+        "shortname": "pre/post",
+        "name"     : "Pfilterbeforews",
+        "tooltip"  : "Filter before waveshaping spectra;When enabled oscilfilter(freqs); then waveshape(freqs);, otherwise waveshape(freqs); then oscilfilter(freqs);",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/OscilSmp/Psatype",
+        "shortname": "spec. adj.",
+        "name"     : "Psatype",
+        "tooltip"  : "Spectral Adjustment Type",
+        "type"     : "i",
+        "default"  : "None"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "None"
+        },
+        {
+            "id"     : 1,
+            "value"  : "Pow"
+        },
+        {
+            "id"     : 2,
+            "value"  : "ThrsD"
+        },
+        {
+            "id"     : 3,
+            "value"  : "ThrsU"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/OscilSmp/Psapar",
+        "shortname": "p1",
+        "name"     : "Psapar",
+        "tooltip"  : "Spectral Adjustment Parameter",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/OscilSmp/Pharmonicshift",
+        "shortname": "shift",
+        "name"     : "Pharmonicshift",
+        "tooltip"  : "Amount of shift on harmonics",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [-64,64],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/OscilSmp/Pharmonicshiftfirst",
+        "shortname": "pre/post",
+        "name"     : "Pharmonicshiftfirst",
+        "tooltip"  : "If harmonics are shifted before waveshaping/filtering",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/OscilSmp/Pmodulation",
+        "shortname": "FM",
+        "name"     : "Pmodulation",
+        "tooltip"  : "Frequency Modulation To Combined Spectra",
+        "type"     : "i",
+        "default"  : "None"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "None"
+        },
+        {
+            "id"     : 1,
+            "value"  : "Rev"
+        },
+        {
+            "id"     : 2,
+            "value"  : "Sine"
+        },
+        {
+            "id"     : 3,
+            "value"  : "Power"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/OscilSmp/Pmodulationpar1",
+        "shortname": "p1",
+        "name"     : "Pmodulationpar1",
+        "tooltip"  : "modulation parameter",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/OscilSmp/Pmodulationpar2",
+        "shortname": "p2",
+        "name"     : "Pmodulationpar2",
+        "tooltip"  : "modulation parameter",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/OscilSmp/Pmodulationpar3",
+        "shortname": "p3",
+        "name"     : "Pmodulationpar3",
+        "tooltip"  : "modulation parameter",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "32"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/OscilSmp/ADvsPAD",
+        "shortname": "If it is used by PADSynth",
+        "name"     : "ADvsPAD",
+        "tooltip"  : "If it is used by PADSynth (and not ADSynth)",
+        "type"     : "t"
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/OscilSmp/phase[0,127]",
+        "name"     : "phase#128",
+        "tooltip"  : "Sets harmonic phase",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "[64 ...]"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/OscilSmp/magnitude[0,127]",
+        "name"     : "magnitude#128",
+        "tooltip"  : "Sets harmonic magnitude",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "[127 64 64 ...]"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FMSmp/Prand",
+        "shortname": "phase rnd",
+        "name"     : "Prand",
+        "tooltip"  : "Oscillator Phase Randomness: smaller than 0 is \"group\", larger than 0 is for each harmonic",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FMSmp/Pamprandpower",
+        "shortname": "variance",
+        "name"     : "Pamprandpower",
+        "tooltip"  : "Variance of harmonic randomness",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FMSmp/Pamprandtype",
+        "shortname": "distribution",
+        "name"     : "Pamprandtype",
+        "tooltip"  : "Harmonic random distribution to select from",
+        "type"     : "i",
+        "default"  : "None"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "None"
+        },
+        {
+            "id"     : 1,
+            "value"  : "Pow"
+        },
+        {
+            "id"     : 2,
+            "value"  : "Sin"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FMSmp/Padaptiveharmonics",
+        "shortname": "adapt",
+        "name"     : "Padaptiveharmonics",
+        "tooltip"  : "Adaptive Harmonics Mode",
+        "type"     : "i",
+        "default"  : "OFF"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "OFF"
+        },
+        {
+            "id"     : 1,
+            "value"  : "ON"
+        },
+        {
+            "id"     : 2,
+            "value"  : "Square"
+        },
+        {
+            "id"     : 3,
+            "value"  : "2xSub"
+        },
+        {
+            "id"     : 4,
+            "value"  : "2xAdd"
+        },
+        {
+            "id"     : 5,
+            "value"  : "3xSub"
+        },
+        {
+            "id"     : 6,
+            "value"  : "3xAdd"
+        },
+        {
+            "id"     : 7,
+            "value"  : "4xSub"
+        },
+        {
+            "id"     : 8,
+            "value"  : "4xAdd"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FMSmp/Padaptiveharmonicsbasefreq",
+        "shortname": "c. freq",
+        "name"     : "Padaptiveharmonicsbasefreq",
+        "tooltip"  : "Base frequency of adaptive harmonic (30..3000Hz)",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,255],
+        "default"  : "128"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FMSmp/Padaptiveharmonicspower",
+        "shortname": "amount",
+        "name"     : "Padaptiveharmonicspower",
+        "tooltip"  : "Adaptive Harmonic Strength",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,200],
+        "default"  : "100"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FMSmp/Padaptiveharmonicspar",
+        "shortname": "power",
+        "name"     : "Padaptiveharmonicspar",
+        "tooltip"  : "Adaptive Harmonics Postprocessing Power",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,100],
+        "default"  : "50"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FMSmp/Phmagtype",
+        "shortname": "scale",
+        "name"     : "Phmagtype",
+        "tooltip"  : "Type of magnitude for harmonics",
+        "type"     : "i",
+        "default"  : "linear"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "linear"
+        },
+        {
+            "id"     : 1,
+            "value"  : "dB scale (-40)"
+        },
+        {
+            "id"     : 2,
+            "value"  : "dB scale (-60)"
+        },
+        {
+            "id"     : 3,
+            "value"  : "dB scale (-80)"
+        },
+        {
+            "id"     : 4,
+            "value"  : "dB scale (-100)"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FMSmp/Pcurrentbasefunc",
+        "shortname": "base",
+        "name"     : "Pcurrentbasefunc",
+        "tooltip"  : "Base Waveform for harmonics",
+        "type"     : "i",
+        "default"  : "sine"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "sine"
+        },
+        {
+            "id"     : 1,
+            "value"  : "triangle"
+        },
+        {
+            "id"     : 2,
+            "value"  : "pulse"
+        },
+        {
+            "id"     : 3,
+            "value"  : "saw"
+        },
+        {
+            "id"     : 4,
+            "value"  : "power"
+        },
+        {
+            "id"     : 5,
+            "value"  : "gauss"
+        },
+        {
+            "id"     : 6,
+            "value"  : "diode"
+        },
+        {
+            "id"     : 7,
+            "value"  : "abssine"
+        },
+        {
+            "id"     : 8,
+            "value"  : "pulsesine"
+        },
+        {
+            "id"     : 9,
+            "value"  : "stretchsine"
+        },
+        {
+            "id"     : 10,
+            "value"  : "chirp"
+        },
+        {
+            "id"     : 11,
+            "value"  : "absstretchsine"
+        },
+        {
+            "id"     : 12,
+            "value"  : "chebyshev"
+        },
+        {
+            "id"     : 13,
+            "value"  : "sqr"
+        },
+        {
+            "id"     : 14,
+            "value"  : "spike"
+        },
+        {
+            "id"     : 15,
+            "value"  : "circle"
+        },
+        {
+            "id"     : 127,
+            "value"  : "use-as-base waveform"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FMSmp/Pbasefuncpar",
+        "shortname": "shape",
+        "name"     : "Pbasefuncpar",
+        "tooltip"  : "Morph between possible base function shapes (e.g. rising sawtooth vs a falling sawtooth)",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FMSmp/Pbasefuncmodulation",
+        "shortname": "mod",
+        "name"     : "Pbasefuncmodulation",
+        "tooltip"  : "Modulation applied to Base function spectra",
+        "type"     : "i",
+        "default"  : "None"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "None"
+        },
+        {
+            "id"     : 1,
+            "value"  : "Rev"
+        },
+        {
+            "id"     : 2,
+            "value"  : "Sine"
+        },
+        {
+            "id"     : 3,
+            "value"  : "Power"
+        },
+        {
+            "id"     : 4,
+            "value"  : "Chop"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FMSmp/Pbasefuncmodulationpar1",
+        "shortname": "p1",
+        "name"     : "Pbasefuncmodulationpar1",
+        "tooltip"  : "Base function modulation parameter",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FMSmp/Pbasefuncmodulationpar2",
+        "shortname": "p2",
+        "name"     : "Pbasefuncmodulationpar2",
+        "tooltip"  : "Base function modulation parameter",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FMSmp/Pbasefuncmodulationpar3",
+        "shortname": "p3",
+        "name"     : "Pbasefuncmodulationpar3",
+        "tooltip"  : "Base function modulation parameter",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "32"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FMSmp/Pwaveshaping",
+        "shortname": "amount",
+        "name"     : "Pwaveshaping",
+        "tooltip"  : "Degree Of Waveshaping",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FMSmp/Pwaveshapingfunction",
+        "shortname": "distort",
+        "name"     : "Pwaveshapingfunction",
+        "tooltip"  : "Shape of distortion to be applied",
+        "type"     : "i",
+        "default"  : "Undistorted"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "Undistorted"
+        },
+        {
+            "id"     : 1,
+            "value"  : "Arctangent"
+        },
+        {
+            "id"     : 2,
+            "value"  : "Asymmetric"
+        },
+        {
+            "id"     : 3,
+            "value"  : "Pow"
+        },
+        {
+            "id"     : 4,
+            "value"  : "Sine"
+        },
+        {
+            "id"     : 5,
+            "value"  : "Quantisize"
+        },
+        {
+            "id"     : 6,
+            "value"  : "Zigzag"
+        },
+        {
+            "id"     : 7,
+            "value"  : "Limiter"
+        },
+        {
+            "id"     : 8,
+            "value"  : "Upper Limiter"
+        },
+        {
+            "id"     : 9,
+            "value"  : "Lower Limiter"
+        },
+        {
+            "id"     : 10,
+            "value"  : "Inverse Limiter"
+        },
+        {
+            "id"     : 11,
+            "value"  : "Clip"
+        },
+        {
+            "id"     : 12,
+            "value"  : "Asym2"
+        },
+        {
+            "id"     : 13,
+            "value"  : "Pow2"
+        },
+        {
+            "id"     : 14,
+            "value"  : "sigmoid"
+        },
+        {
+            "id"     : 15,
+            "value"  : "Tanh"
+        },
+        {
+            "id"     : 16,
+            "value"  : "Cubic"
+        },
+        {
+            "id"     : 17,
+            "value"  : "Square"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FMSmp/Pfiltertype",
+        "shortname": "filter",
+        "name"     : "Pfiltertype",
+        "tooltip"  : "Harmonic Filter",
+        "type"     : "i",
+        "default"  : "\"No Filter\"S"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "No Filter"
+        },
+        {
+            "id"     : 1,
+            "value"  : "lp"
+        },
+        {
+            "id"     : 2,
+            "value"  : "hp1"
+        },
+        {
+            "id"     : 3,
+            "value"  : "hp1b"
+        },
+        {
+            "id"     : 4,
+            "value"  : "bp1"
+        },
+        {
+            "id"     : 5,
+            "value"  : "bs1"
+        },
+        {
+            "id"     : 6,
+            "value"  : "lp2"
+        },
+        {
+            "id"     : 7,
+            "value"  : "hp2"
+        },
+        {
+            "id"     : 8,
+            "value"  : "bp2"
+        },
+        {
+            "id"     : 9,
+            "value"  : "bs2"
+        },
+        {
+            "id"     : 10,
+            "value"  : "cos"
+        },
+        {
+            "id"     : 11,
+            "value"  : "sin"
+        },
+        {
+            "id"     : 12,
+            "value"  : "low_shelf"
+        },
+        {
+            "id"     : 13,
+            "value"  : "s"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FMSmp/Pfilterpar1",
+        "shortname": "p1",
+        "name"     : "Pfilterpar1",
+        "tooltip"  : "Filter parameter",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FMSmp/Pfilterpar2",
+        "shortname": "p2",
+        "name"     : "Pfilterpar2",
+        "tooltip"  : "Filter parameter",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FMSmp/Pfilterbeforews",
+        "shortname": "pre/post",
+        "name"     : "Pfilterbeforews",
+        "tooltip"  : "Filter before waveshaping spectra;When enabled oscilfilter(freqs); then waveshape(freqs);, otherwise waveshape(freqs); then oscilfilter(freqs);",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FMSmp/Psatype",
+        "shortname": "spec. adj.",
+        "name"     : "Psatype",
+        "tooltip"  : "Spectral Adjustment Type",
+        "type"     : "i",
+        "default"  : "None"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "None"
+        },
+        {
+            "id"     : 1,
+            "value"  : "Pow"
+        },
+        {
+            "id"     : 2,
+            "value"  : "ThrsD"
+        },
+        {
+            "id"     : 3,
+            "value"  : "ThrsU"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FMSmp/Psapar",
+        "shortname": "p1",
+        "name"     : "Psapar",
+        "tooltip"  : "Spectral Adjustment Parameter",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FMSmp/Pharmonicshift",
+        "shortname": "shift",
+        "name"     : "Pharmonicshift",
+        "tooltip"  : "Amount of shift on harmonics",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [-64,64],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FMSmp/Pharmonicshiftfirst",
+        "shortname": "pre/post",
+        "name"     : "Pharmonicshiftfirst",
+        "tooltip"  : "If harmonics are shifted before waveshaping/filtering",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FMSmp/Pmodulation",
+        "shortname": "FM",
+        "name"     : "Pmodulation",
+        "tooltip"  : "Frequency Modulation To Combined Spectra",
+        "type"     : "i",
+        "default"  : "None"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "None"
+        },
+        {
+            "id"     : 1,
+            "value"  : "Rev"
+        },
+        {
+            "id"     : 2,
+            "value"  : "Sine"
+        },
+        {
+            "id"     : 3,
+            "value"  : "Power"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FMSmp/Pmodulationpar1",
+        "shortname": "p1",
+        "name"     : "Pmodulationpar1",
+        "tooltip"  : "modulation parameter",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FMSmp/Pmodulationpar2",
+        "shortname": "p2",
+        "name"     : "Pmodulationpar2",
+        "tooltip"  : "modulation parameter",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FMSmp/Pmodulationpar3",
+        "shortname": "p3",
+        "name"     : "Pmodulationpar3",
+        "tooltip"  : "modulation parameter",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "32"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FMSmp/ADvsPAD",
+        "shortname": "If it is used by PADSynth",
+        "name"     : "ADvsPAD",
+        "tooltip"  : "If it is used by PADSynth (and not ADSynth)",
+        "type"     : "t"
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FMSmp/phase[0,127]",
+        "name"     : "phase#128",
+        "tooltip"  : "Sets harmonic phase",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "[64 ...]"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FMSmp/magnitude[0,127]",
+        "name"     : "magnitude#128",
+        "tooltip"  : "Sets harmonic magnitude",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "[127 64 64 ...]"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FreqLfo/freq",
+        "shortname": "freq",
+        "name"     : "freq",
+        "tooltip"  : "frequency of LFO\nlfo frequency = Pfreq * stretch\ntrue frequency is [0,85.25] Hz",
+        "units"    : "HZ",
+        "scale"    : "logarithmic",
+        "type"     : "f",
+        "range"    : [0.0775679,85.25]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FreqLfo/Pintensity",
+        "shortname": "depth",
+        "name"     : "Pintensity",
+        "tooltip"  : "Intensity of LFO",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FreqLfo/Pstartphase",
+        "shortname": "start",
+        "name"     : "Pstartphase",
+        "tooltip"  : "Starting Phase",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FreqLfo/PLFOtype",
+        "shortname": "type",
+        "name"     : "PLFOtype",
+        "tooltip"  : "Shape of LFO",
+        "type"     : "i",
+        "default"  : "sine"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "sine"
+        },
+        {
+            "id"     : 1,
+            "value"  : "triangle"
+        },
+        {
+            "id"     : 2,
+            "value"  : "square"
+        },
+        {
+            "id"     : 3,
+            "value"  : "up"
+        },
+        {
+            "id"     : 4,
+            "value"  : "down"
+        },
+        {
+            "id"     : 5,
+            "value"  : "exp1"
+        },
+        {
+            "id"     : 6,
+            "value"  : "exp2"
+        },
+        {
+            "id"     : 7,
+            "value"  : "random"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FreqLfo/Prandomness",
+        "shortname": "a.r.",
+        "name"     : "Prandomness",
+        "tooltip"  : "Amplitude Randomness (calculated uniformly at each cycle)",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FreqLfo/Pfreqrand",
+        "shortname": "f.r.",
+        "name"     : "Pfreqrand",
+        "tooltip"  : "Frequency Randomness (calculated uniformly at each cycle)",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FreqLfo/delay",
+        "shortname": "delay",
+        "name"     : "delay",
+        "tooltip"  : "Delay before LFO start\n0..4 second delay",
+        "units"    : "S",
+        "scale"    : "linear",
+        "type"     : "f",
+        "range"    : [0.0,4.0],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FreqLfo/Pcontinous",
+        "shortname": "c",
+        "name"     : "Pcontinous",
+        "tooltip"  : "Enable for global operation",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FreqLfo/Pstretch",
+        "shortname": "str",
+        "name"     : "Pstretch",
+        "tooltip"  : "Note frequency stretch",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/AmpLfo/freq",
+        "shortname": "freq",
+        "name"     : "freq",
+        "tooltip"  : "frequency of LFO\nlfo frequency = Pfreq * stretch\ntrue frequency is [0,85.25] Hz",
+        "units"    : "HZ",
+        "scale"    : "logarithmic",
+        "type"     : "f",
+        "range"    : [0.0775679,85.25]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/AmpLfo/Pintensity",
+        "shortname": "depth",
+        "name"     : "Pintensity",
+        "tooltip"  : "Intensity of LFO",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/AmpLfo/Pstartphase",
+        "shortname": "start",
+        "name"     : "Pstartphase",
+        "tooltip"  : "Starting Phase",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/AmpLfo/PLFOtype",
+        "shortname": "type",
+        "name"     : "PLFOtype",
+        "tooltip"  : "Shape of LFO",
+        "type"     : "i",
+        "default"  : "sine"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "sine"
+        },
+        {
+            "id"     : 1,
+            "value"  : "triangle"
+        },
+        {
+            "id"     : 2,
+            "value"  : "square"
+        },
+        {
+            "id"     : 3,
+            "value"  : "up"
+        },
+        {
+            "id"     : 4,
+            "value"  : "down"
+        },
+        {
+            "id"     : 5,
+            "value"  : "exp1"
+        },
+        {
+            "id"     : 6,
+            "value"  : "exp2"
+        },
+        {
+            "id"     : 7,
+            "value"  : "random"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/AmpLfo/Prandomness",
+        "shortname": "a.r.",
+        "name"     : "Prandomness",
+        "tooltip"  : "Amplitude Randomness (calculated uniformly at each cycle)",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/AmpLfo/Pfreqrand",
+        "shortname": "f.r.",
+        "name"     : "Pfreqrand",
+        "tooltip"  : "Frequency Randomness (calculated uniformly at each cycle)",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/AmpLfo/delay",
+        "shortname": "delay",
+        "name"     : "delay",
+        "tooltip"  : "Delay before LFO start\n0..4 second delay",
+        "units"    : "S",
+        "scale"    : "linear",
+        "type"     : "f",
+        "range"    : [0.0,4.0],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/AmpLfo/Pcontinous",
+        "shortname": "c",
+        "name"     : "Pcontinous",
+        "tooltip"  : "Enable for global operation",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/AmpLfo/Pstretch",
+        "shortname": "str",
+        "name"     : "Pstretch",
+        "tooltip"  : "Note frequency stretch",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FilterLfo/freq",
+        "shortname": "freq",
+        "name"     : "freq",
+        "tooltip"  : "frequency of LFO\nlfo frequency = Pfreq * stretch\ntrue frequency is [0,85.25] Hz",
+        "units"    : "HZ",
+        "scale"    : "logarithmic",
+        "type"     : "f",
+        "range"    : [0.0775679,85.25]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FilterLfo/Pintensity",
+        "shortname": "depth",
+        "name"     : "Pintensity",
+        "tooltip"  : "Intensity of LFO",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FilterLfo/Pstartphase",
+        "shortname": "start",
+        "name"     : "Pstartphase",
+        "tooltip"  : "Starting Phase",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FilterLfo/PLFOtype",
+        "shortname": "type",
+        "name"     : "PLFOtype",
+        "tooltip"  : "Shape of LFO",
+        "type"     : "i",
+        "default"  : "sine"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "sine"
+        },
+        {
+            "id"     : 1,
+            "value"  : "triangle"
+        },
+        {
+            "id"     : 2,
+            "value"  : "square"
+        },
+        {
+            "id"     : 3,
+            "value"  : "up"
+        },
+        {
+            "id"     : 4,
+            "value"  : "down"
+        },
+        {
+            "id"     : 5,
+            "value"  : "exp1"
+        },
+        {
+            "id"     : 6,
+            "value"  : "exp2"
+        },
+        {
+            "id"     : 7,
+            "value"  : "random"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FilterLfo/Prandomness",
+        "shortname": "a.r.",
+        "name"     : "Prandomness",
+        "tooltip"  : "Amplitude Randomness (calculated uniformly at each cycle)",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FilterLfo/Pfreqrand",
+        "shortname": "f.r.",
+        "name"     : "Pfreqrand",
+        "tooltip"  : "Frequency Randomness (calculated uniformly at each cycle)",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FilterLfo/delay",
+        "shortname": "delay",
+        "name"     : "delay",
+        "tooltip"  : "Delay before LFO start\n0..4 second delay",
+        "units"    : "S",
+        "scale"    : "linear",
+        "type"     : "f",
+        "range"    : [0.0,4.0],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FilterLfo/Pcontinous",
+        "shortname": "c",
+        "name"     : "Pcontinous",
+        "tooltip"  : "Enable for global operation",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FilterLfo/Pstretch",
+        "shortname": "str",
+        "name"     : "Pstretch",
+        "tooltip"  : "Note frequency stretch",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FreqEnvelope/Pfreemode",
+        "name"     : "Pfreemode",
+        "tooltip"  : "Complex Envelope Definitions",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FreqEnvelope/Penvsustain",
+        "name"     : "Penvsustain",
+        "tooltip"  : "Location of the sustain point",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "2"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FreqEnvelope/Penvdt[0,39]",
+        "name"     : "Penvdt#40",
+        "tooltip"  : "Envelope Delay Times",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FreqEnvelope/Penvval[0,39]",
+        "name"     : "Penvval#40",
+        "tooltip"  : "Envelope Values",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FreqEnvelope/Penvstretch",
+        "shortname": "stretch",
+        "name"     : "Penvstretch",
+        "tooltip"  : "Stretch with respect to frequency",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FreqEnvelope/Pforcedrelease",
+        "shortname": "frcr",
+        "name"     : "Pforcedrelease",
+        "tooltip"  : "Force Envelope to fully evaluate",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FreqEnvelope/Plinearenvelope",
+        "shortname": "lin/log",
+        "name"     : "Plinearenvelope",
+        "tooltip"  : "Linear or Logarithmic Envelopes",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FreqEnvelope/PA_dt",
+        "shortname": "a.dt",
+        "name"     : "PA_dt",
+        "tooltip"  : "Attack Time",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FreqEnvelope/A_dt",
+        "shortname": "a.dt",
+        "name"     : "A_dt",
+        "tooltip"  : "Attack Time",
+        "scale"    : "logarithmic",
+        "type"     : "f",
+        "range"    : [0.0f,41.0f],
+        "default"  : "0.00"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FreqEnvelope/PA_val",
+        "shortname": "a.val",
+        "name"     : "PA_val",
+        "tooltip"  : "Attack Value",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FreqEnvelope/PD_dt",
+        "shortname": "d.dt",
+        "name"     : "PD_dt",
+        "tooltip"  : "Decay Time",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FreqEnvelope/D_dt",
+        "shortname": "d.dt",
+        "name"     : "D_dt",
+        "tooltip"  : "Decay Time",
+        "scale"    : "logarithmic",
+        "type"     : "f",
+        "range"    : [0.0f,41.0f],
+        "default"  : "0.00925031"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FreqEnvelope/PD_val",
+        "shortname": "d.val",
+        "name"     : "PD_val",
+        "tooltip"  : "Decay Value",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FreqEnvelope/PS_val",
+        "shortname": "s.val",
+        "name"     : "PS_val",
+        "tooltip"  : "Sustain Value",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FreqEnvelope/PR_dt",
+        "shortname": "r.dt",
+        "name"     : "PR_dt",
+        "tooltip"  : "Release Time",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FreqEnvelope/R_dt",
+        "shortname": "r.dt",
+        "name"     : "R_dt",
+        "tooltip"  : "Release Time",
+        "scale"    : "logarithmic",
+        "type"     : "f",
+        "range"    : [0.01f,41.0f],
+        "default"  : "0.498893"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FreqEnvelope/PR_val",
+        "shortname": "r.val",
+        "name"     : "PR_val",
+        "tooltip"  : "Release Value",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/AmpEnvelope/Pfreemode",
+        "name"     : "Pfreemode",
+        "tooltip"  : "Complex Envelope Definitions",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/AmpEnvelope/Penvsustain",
+        "name"     : "Penvsustain",
+        "tooltip"  : "Location of the sustain point",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "2"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/AmpEnvelope/Penvdt[0,39]",
+        "name"     : "Penvdt#40",
+        "tooltip"  : "Envelope Delay Times",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/AmpEnvelope/Penvval[0,39]",
+        "name"     : "Penvval#40",
+        "tooltip"  : "Envelope Values",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/AmpEnvelope/Penvstretch",
+        "shortname": "stretch",
+        "name"     : "Penvstretch",
+        "tooltip"  : "Stretch with respect to frequency",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/AmpEnvelope/Pforcedrelease",
+        "shortname": "frcr",
+        "name"     : "Pforcedrelease",
+        "tooltip"  : "Force Envelope to fully evaluate",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/AmpEnvelope/Plinearenvelope",
+        "shortname": "lin/log",
+        "name"     : "Plinearenvelope",
+        "tooltip"  : "Linear or Logarithmic Envelopes",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/AmpEnvelope/PA_dt",
+        "shortname": "a.dt",
+        "name"     : "PA_dt",
+        "tooltip"  : "Attack Time",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/AmpEnvelope/A_dt",
+        "shortname": "a.dt",
+        "name"     : "A_dt",
+        "tooltip"  : "Attack Time",
+        "scale"    : "logarithmic",
+        "type"     : "f",
+        "range"    : [0.0f,41.0f],
+        "default"  : "0.00"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/AmpEnvelope/PA_val",
+        "shortname": "a.val",
+        "name"     : "PA_val",
+        "tooltip"  : "Attack Value",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/AmpEnvelope/PD_dt",
+        "shortname": "d.dt",
+        "name"     : "PD_dt",
+        "tooltip"  : "Decay Time",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/AmpEnvelope/D_dt",
+        "shortname": "d.dt",
+        "name"     : "D_dt",
+        "tooltip"  : "Decay Time",
+        "scale"    : "logarithmic",
+        "type"     : "f",
+        "range"    : [0.0f,41.0f],
+        "default"  : "0.00925031"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/AmpEnvelope/PD_val",
+        "shortname": "d.val",
+        "name"     : "PD_val",
+        "tooltip"  : "Decay Value",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/AmpEnvelope/PS_val",
+        "shortname": "s.val",
+        "name"     : "PS_val",
+        "tooltip"  : "Sustain Value",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/AmpEnvelope/PR_dt",
+        "shortname": "r.dt",
+        "name"     : "PR_dt",
+        "tooltip"  : "Release Time",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/AmpEnvelope/R_dt",
+        "shortname": "r.dt",
+        "name"     : "R_dt",
+        "tooltip"  : "Release Time",
+        "scale"    : "logarithmic",
+        "type"     : "f",
+        "range"    : [0.01f,41.0f],
+        "default"  : "0.498893"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/AmpEnvelope/PR_val",
+        "shortname": "r.val",
+        "name"     : "PR_val",
+        "tooltip"  : "Release Value",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FilterEnvelope/Pfreemode",
+        "name"     : "Pfreemode",
+        "tooltip"  : "Complex Envelope Definitions",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FilterEnvelope/Penvsustain",
+        "name"     : "Penvsustain",
+        "tooltip"  : "Location of the sustain point",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "2"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FilterEnvelope/Penvdt[0,39]",
+        "name"     : "Penvdt#40",
+        "tooltip"  : "Envelope Delay Times",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FilterEnvelope/Penvval[0,39]",
+        "name"     : "Penvval#40",
+        "tooltip"  : "Envelope Values",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FilterEnvelope/Penvstretch",
+        "shortname": "stretch",
+        "name"     : "Penvstretch",
+        "tooltip"  : "Stretch with respect to frequency",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FilterEnvelope/Pforcedrelease",
+        "shortname": "frcr",
+        "name"     : "Pforcedrelease",
+        "tooltip"  : "Force Envelope to fully evaluate",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FilterEnvelope/Plinearenvelope",
+        "shortname": "lin/log",
+        "name"     : "Plinearenvelope",
+        "tooltip"  : "Linear or Logarithmic Envelopes",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FilterEnvelope/PA_dt",
+        "shortname": "a.dt",
+        "name"     : "PA_dt",
+        "tooltip"  : "Attack Time",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FilterEnvelope/A_dt",
+        "shortname": "a.dt",
+        "name"     : "A_dt",
+        "tooltip"  : "Attack Time",
+        "scale"    : "logarithmic",
+        "type"     : "f",
+        "range"    : [0.0f,41.0f],
+        "default"  : "0.00"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FilterEnvelope/PA_val",
+        "shortname": "a.val",
+        "name"     : "PA_val",
+        "tooltip"  : "Attack Value",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FilterEnvelope/PD_dt",
+        "shortname": "d.dt",
+        "name"     : "PD_dt",
+        "tooltip"  : "Decay Time",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FilterEnvelope/D_dt",
+        "shortname": "d.dt",
+        "name"     : "D_dt",
+        "tooltip"  : "Decay Time",
+        "scale"    : "logarithmic",
+        "type"     : "f",
+        "range"    : [0.0f,41.0f],
+        "default"  : "0.00925031"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FilterEnvelope/PD_val",
+        "shortname": "d.val",
+        "name"     : "PD_val",
+        "tooltip"  : "Decay Value",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FilterEnvelope/PS_val",
+        "shortname": "s.val",
+        "name"     : "PS_val",
+        "tooltip"  : "Sustain Value",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FilterEnvelope/PR_dt",
+        "shortname": "r.dt",
+        "name"     : "PR_dt",
+        "tooltip"  : "Release Time",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FilterEnvelope/R_dt",
+        "shortname": "r.dt",
+        "name"     : "R_dt",
+        "tooltip"  : "Release Time",
+        "scale"    : "logarithmic",
+        "type"     : "f",
+        "range"    : [0.01f,41.0f],
+        "default"  : "0.498893"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FilterEnvelope/PR_val",
+        "shortname": "r.val",
+        "name"     : "PR_val",
+        "tooltip"  : "Release Value",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FMFreqEnvelope/Pfreemode",
+        "name"     : "Pfreemode",
+        "tooltip"  : "Complex Envelope Definitions",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FMFreqEnvelope/Penvsustain",
+        "name"     : "Penvsustain",
+        "tooltip"  : "Location of the sustain point",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "2"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FMFreqEnvelope/Penvdt[0,39]",
+        "name"     : "Penvdt#40",
+        "tooltip"  : "Envelope Delay Times",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FMFreqEnvelope/Penvval[0,39]",
+        "name"     : "Penvval#40",
+        "tooltip"  : "Envelope Values",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FMFreqEnvelope/Penvstretch",
+        "shortname": "stretch",
+        "name"     : "Penvstretch",
+        "tooltip"  : "Stretch with respect to frequency",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FMFreqEnvelope/Pforcedrelease",
+        "shortname": "frcr",
+        "name"     : "Pforcedrelease",
+        "tooltip"  : "Force Envelope to fully evaluate",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FMFreqEnvelope/Plinearenvelope",
+        "shortname": "lin/log",
+        "name"     : "Plinearenvelope",
+        "tooltip"  : "Linear or Logarithmic Envelopes",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FMFreqEnvelope/PA_dt",
+        "shortname": "a.dt",
+        "name"     : "PA_dt",
+        "tooltip"  : "Attack Time",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FMFreqEnvelope/A_dt",
+        "shortname": "a.dt",
+        "name"     : "A_dt",
+        "tooltip"  : "Attack Time",
+        "scale"    : "logarithmic",
+        "type"     : "f",
+        "range"    : [0.0f,41.0f],
+        "default"  : "0.00"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FMFreqEnvelope/PA_val",
+        "shortname": "a.val",
+        "name"     : "PA_val",
+        "tooltip"  : "Attack Value",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FMFreqEnvelope/PD_dt",
+        "shortname": "d.dt",
+        "name"     : "PD_dt",
+        "tooltip"  : "Decay Time",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FMFreqEnvelope/D_dt",
+        "shortname": "d.dt",
+        "name"     : "D_dt",
+        "tooltip"  : "Decay Time",
+        "scale"    : "logarithmic",
+        "type"     : "f",
+        "range"    : [0.0f,41.0f],
+        "default"  : "0.00925031"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FMFreqEnvelope/PD_val",
+        "shortname": "d.val",
+        "name"     : "PD_val",
+        "tooltip"  : "Decay Value",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FMFreqEnvelope/PS_val",
+        "shortname": "s.val",
+        "name"     : "PS_val",
+        "tooltip"  : "Sustain Value",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FMFreqEnvelope/PR_dt",
+        "shortname": "r.dt",
+        "name"     : "PR_dt",
+        "tooltip"  : "Release Time",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FMFreqEnvelope/R_dt",
+        "shortname": "r.dt",
+        "name"     : "R_dt",
+        "tooltip"  : "Release Time",
+        "scale"    : "logarithmic",
+        "type"     : "f",
+        "range"    : [0.01f,41.0f],
+        "default"  : "0.498893"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FMFreqEnvelope/PR_val",
+        "shortname": "r.val",
+        "name"     : "PR_val",
+        "tooltip"  : "Release Value",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FMAmpEnvelope/Pfreemode",
+        "name"     : "Pfreemode",
+        "tooltip"  : "Complex Envelope Definitions",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FMAmpEnvelope/Penvsustain",
+        "name"     : "Penvsustain",
+        "tooltip"  : "Location of the sustain point",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "2"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FMAmpEnvelope/Penvdt[0,39]",
+        "name"     : "Penvdt#40",
+        "tooltip"  : "Envelope Delay Times",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FMAmpEnvelope/Penvval[0,39]",
+        "name"     : "Penvval#40",
+        "tooltip"  : "Envelope Values",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FMAmpEnvelope/Penvstretch",
+        "shortname": "stretch",
+        "name"     : "Penvstretch",
+        "tooltip"  : "Stretch with respect to frequency",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FMAmpEnvelope/Pforcedrelease",
+        "shortname": "frcr",
+        "name"     : "Pforcedrelease",
+        "tooltip"  : "Force Envelope to fully evaluate",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FMAmpEnvelope/Plinearenvelope",
+        "shortname": "lin/log",
+        "name"     : "Plinearenvelope",
+        "tooltip"  : "Linear or Logarithmic Envelopes",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FMAmpEnvelope/PA_dt",
+        "shortname": "a.dt",
+        "name"     : "PA_dt",
+        "tooltip"  : "Attack Time",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FMAmpEnvelope/A_dt",
+        "shortname": "a.dt",
+        "name"     : "A_dt",
+        "tooltip"  : "Attack Time",
+        "scale"    : "logarithmic",
+        "type"     : "f",
+        "range"    : [0.0f,41.0f],
+        "default"  : "0.00"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FMAmpEnvelope/PA_val",
+        "shortname": "a.val",
+        "name"     : "PA_val",
+        "tooltip"  : "Attack Value",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FMAmpEnvelope/PD_dt",
+        "shortname": "d.dt",
+        "name"     : "PD_dt",
+        "tooltip"  : "Decay Time",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FMAmpEnvelope/D_dt",
+        "shortname": "d.dt",
+        "name"     : "D_dt",
+        "tooltip"  : "Decay Time",
+        "scale"    : "logarithmic",
+        "type"     : "f",
+        "range"    : [0.0f,41.0f],
+        "default"  : "0.00925031"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FMAmpEnvelope/PD_val",
+        "shortname": "d.val",
+        "name"     : "PD_val",
+        "tooltip"  : "Decay Value",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FMAmpEnvelope/PS_val",
+        "shortname": "s.val",
+        "name"     : "PS_val",
+        "tooltip"  : "Sustain Value",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FMAmpEnvelope/PR_dt",
+        "shortname": "r.dt",
+        "name"     : "PR_dt",
+        "tooltip"  : "Release Time",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FMAmpEnvelope/R_dt",
+        "shortname": "r.dt",
+        "name"     : "R_dt",
+        "tooltip"  : "Release Time",
+        "scale"    : "logarithmic",
+        "type"     : "f",
+        "range"    : [0.01f,41.0f],
+        "default"  : "0.498893"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FMAmpEnvelope/PR_val",
+        "shortname": "r.val",
+        "name"     : "PR_val",
+        "tooltip"  : "Release Value",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/VoiceFilter/Pcategory",
+        "shortname": "class",
+        "name"     : "Pcategory",
+        "tooltip"  : "Class of filter",
+        "type"     : "i",
+        "default"  : "analog"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "analog"
+        },
+        {
+            "id"     : 1,
+            "value"  : "formant"
+        },
+        {
+            "id"     : 2,
+            "value"  : "st.var."
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/VoiceFilter/Ptype",
+        "shortname": "type",
+        "name"     : "Ptype",
+        "tooltip"  : "Filter Type",
+        "type"     : "i",
+        "default"  : "LP2"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "LP1"
+        },
+        {
+            "id"     : 1,
+            "value"  : "HP1"
+        },
+        {
+            "id"     : 2,
+            "value"  : "LP2"
+        },
+        {
+            "id"     : 3,
+            "value"  : "HP2"
+        },
+        {
+            "id"     : 4,
+            "value"  : "BP"
+        },
+        {
+            "id"     : 5,
+            "value"  : "notch"
+        },
+        {
+            "id"     : 6,
+            "value"  : "peak"
+        },
+        {
+            "id"     : 7,
+            "value"  : "l.shelf"
+        },
+        {
+            "id"     : 8,
+            "value"  : "h.shelf"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/VoiceFilter/Pstages",
+        "shortname": "stages",
+        "name"     : "Pstages",
+        "tooltip"  : "Filter Stages",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,5],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/VoiceFilter/baseq",
+        "shortname": "q",
+        "name"     : "baseq",
+        "tooltip"  : "Quality Factor (resonance/bandwidth)",
+        "units"    : "none",
+        "scale"    : "logarithmic",
+        "type"     : "f",
+        "range"    : [0.1,1000]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/VoiceFilter/basefreq",
+        "shortname": "cutoff",
+        "name"     : "basefreq",
+        "tooltip"  : "Base cutoff frequency",
+        "units"    : "Hz",
+        "scale"    : "logarithmic",
+        "type"     : "f",
+        "range"    : [31.25,32000]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/VoiceFilter/freqtracking",
+        "shortname": "f.track",
+        "name"     : "freqtracking",
+        "tooltip"  : "Frequency Tracking amount",
+        "units"    : "%",
+        "scale"    : "linear",
+        "type"     : "f",
+        "range"    : [-100,100],
+        "default"  : "0.0f"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/VoiceFilter/gain",
+        "shortname": "gain",
+        "name"     : "gain",
+        "tooltip"  : "Output Gain",
+        "units"    : "dB",
+        "scale"    : "linear",
+        "type"     : "f",
+        "range"    : [-30,30],
+        "default"  : "0.0f"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/VoiceFilter/Pnumformants",
+        "shortname": "formants",
+        "name"     : "Pnumformants",
+        "tooltip"  : "Number of formants to be used",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [1,12],
+        "default"  : "3"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/VoiceFilter/Pformantslowness",
+        "shortname": "slew",
+        "name"     : "Pformantslowness",
+        "tooltip"  : "Rate that formants change",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/VoiceFilter/Pvowelclearness",
+        "shortname": "clarity",
+        "name"     : "Pvowelclearness",
+        "tooltip"  : "How much each vowel is smudged with the next in sequence. A high clarity will avoid smudging.",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/VoiceFilter/Pcenterfreq",
+        "shortname": "cutoff",
+        "name"     : "Pcenterfreq",
+        "tooltip"  : "Center Freq (formant)",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/VoiceFilter/Poctavesfreq",
+        "shortname": "octaves",
+        "name"     : "Poctavesfreq",
+        "tooltip"  : "Number of octaves for formant",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/VoiceFilter/Psequencesize",
+        "shortname": "seq.size",
+        "name"     : "Psequencesize",
+        "tooltip"  : "Length of vowel sequence",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,8],
+        "default"  : "3"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/VoiceFilter/Psequencestretch",
+        "shortname": "seq.str",
+        "name"     : "Psequencestretch",
+        "tooltip"  : "How modulators stretch the sequence",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "40"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/VoiceFilter/Psequencereversed",
+        "shortname": "reverse",
+        "name"     : "Psequencereversed",
+        "tooltip"  : "If the modulator input is inverted",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/VoiceFilter/type-svf",
+        "shortname": "type",
+        "name"     : "type-svf",
+        "tooltip"  : "Filter Type",
+        "type"     : "i",
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "low"
+        },
+        {
+            "id"     : 1,
+            "value"  : "high"
+        },
+        {
+            "id"     : 2,
+            "value"  : "band"
+        },
+        {
+            "id"     : 3,
+            "value"  : "notch"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/VoiceFilter/Pvowels[0,5]/Pformants[0,11]/freq",
+        "shortname": "f.freq",
+        "name"     : "freq",
+        "tooltip"  : "Formant frequency",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/VoiceFilter/Pvowels[0,5]/Pformants[0,11]/amp",
+        "shortname": "f.str",
+        "name"     : "amp",
+        "tooltip"  : "Strength of formant",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "127"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/VoiceFilter/Pvowels[0,5]/Pformants[0,11]/q",
+        "shortname": "f.q",
+        "name"     : "q",
+        "tooltip"  : "The formant's quality factor, also known as resonance bandwidth or Q for short",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/Unison_size",
+        "shortname": "size",
+        "name"     : "Unison_size",
+        "tooltip"  : "Number of subvoices",
+        "type"     : "i",
+        "range"    : [1,50],
+        "default"  : "1"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/Unison_phase_randomness",
+        "shortname": "ph.rnd.",
+        "name"     : "Unison_phase_randomness",
+        "tooltip"  : "Phase Randomness",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "127"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/Unison_frequency_spread",
+        "shortname": "detune",
+        "name"     : "Unison_frequency_spread",
+        "tooltip"  : "Subvoice detune",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "60"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/Unison_stereo_spread",
+        "shortname": "spread",
+        "name"     : "Unison_stereo_spread",
+        "tooltip"  : "Subvoice L/R Separation",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/Unison_vibratto",
+        "shortname": "vib.",
+        "name"     : "Unison_vibratto",
+        "tooltip"  : "Subvoice vibratto",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/Unison_vibratto_speed",
+        "shortname": "speed",
+        "name"     : "Unison_vibratto_speed",
+        "tooltip"  : "Subvoice vibratto speed",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/Unison_invert_phase",
+        "shortname": "inv.",
+        "name"     : "Unison_invert_phase",
+        "tooltip"  : "Subvoice Phases",
+        "type"     : "i",
+        "default"  : "none"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "none"
+        },
+        {
+            "id"     : 1,
+            "value"  : "random"
+        },
+        {
+            "id"     : 2,
+            "value"  : "50%"
+        },
+        {
+            "id"     : 3,
+            "value"  : "33%"
+        },
+        {
+            "id"     : 4,
+            "value"  : "25%"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/Type",
+        "shortname": "type",
+        "name"     : "Type",
+        "tooltip"  : "Type of Sound",
+        "type"     : "i",
+        "default"  : "Sound"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "Sound"
+        },
+        {
+            "id"     : 1,
+            "value"  : "White"
+        },
+        {
+            "id"     : 2,
+            "value"  : "Pink"
+        },
+        {
+            "id"     : 3,
+            "value"  : "DC"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/PDelay",
+        "shortname": "delay",
+        "name"     : "PDelay",
+        "tooltip"  : "Voice Startup Delay",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/Presonance",
+        "shortname": "enable",
+        "name"     : "Presonance",
+        "tooltip"  : "Resonance Enable",
+        "type"     : "t",
+        "default"  : "true"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/Pextoscil",
+        "shortname": "ext.",
+        "name"     : "Pextoscil",
+        "tooltip"  : "External Oscillator Selection",
+        "type"     : "i",
+        "range"    : [-1,16],
+        "default"  : "-1"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/PextFMoscil",
+        "shortname": "ext.",
+        "name"     : "PextFMoscil",
+        "tooltip"  : "External FM Oscillator Selection",
+        "type"     : "i",
+        "range"    : [-1,16],
+        "default"  : "-1"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/Poscilphase",
+        "shortname": "phase",
+        "name"     : "Poscilphase",
+        "tooltip"  : "Oscillator Phase",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/PFMoscilphase",
+        "shortname": "phase",
+        "name"     : "PFMoscilphase",
+        "tooltip"  : "FM Oscillator Phase",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/Pfilterbypass",
+        "shortname": "bypass",
+        "name"     : "Pfilterbypass",
+        "tooltip"  : "Filter Bypass",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/Pfixedfreq",
+        "shortname": "fixed",
+        "name"     : "Pfixedfreq",
+        "tooltip"  : "If frequency is fixed",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/PfixedfreqET",
+        "shortname": "e.t.",
+        "name"     : "PfixedfreqET",
+        "tooltip"  : "Equal Temperament Parameter",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/PBendAdjust",
+        "shortname": "bend",
+        "name"     : "PBendAdjust",
+        "tooltip"  : "Pitch bend adjustment",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "88"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/POffsetHz",
+        "shortname": "offset",
+        "name"     : "POffsetHz",
+        "tooltip"  : "Voice constant offset",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/PDetune",
+        "shortname": "fine",
+        "name"     : "PDetune",
+        "tooltip"  : "Fine Detune",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,16383],
+        "default"  : "8192"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/PCoarseDetune",
+        "shortname": "coarse",
+        "name"     : "PCoarseDetune",
+        "tooltip"  : "Coarse Detune",
+        "type"     : "i",
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/PDetuneType",
+        "shortname": "type",
+        "name"     : "PDetuneType",
+        "tooltip"  : "Magnitude of Detune",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "L35cents"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "L35cents"
+        },
+        {
+            "id"     : 1,
+            "value"  : "L10cents"
+        },
+        {
+            "id"     : 2,
+            "value"  : "E100cents"
+        },
+        {
+            "id"     : 3,
+            "value"  : "E1200cents"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/PFreqEnvelopeEnabled",
+        "shortname": "enable",
+        "name"     : "PFreqEnvelopeEnabled",
+        "tooltip"  : "Frequency Envelope Enable",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/PFreqLfoEnabled",
+        "shortname": "enable",
+        "name"     : "PFreqLfoEnabled",
+        "tooltip"  : "Frequency LFO Enable",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/PPanning",
+        "shortname": "pan.",
+        "name"     : "PPanning",
+        "tooltip"  : "Panning",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/volume",
+        "shortname": "volume",
+        "name"     : "volume",
+        "tooltip"  : "Part Volume",
+        "units"    : "dB",
+        "scale"    : "linear",
+        "type"     : "f",
+        "range"    : [-60.0f,0.0f],
+        "default"  : "-12.75"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/PVolumeminus",
+        "shortname": "inv.",
+        "name"     : "PVolumeminus",
+        "tooltip"  : "Signal Inverter",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/PAAEnabled",
+        "shortname": "enable",
+        "name"     : "PAAEnabled",
+        "tooltip"  : "AntiAliasing Enable",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/PAmpVelocityScaleFunction",
+        "shortname": "sense",
+        "name"     : "PAmpVelocityScaleFunction",
+        "tooltip"  : "Velocity Sensing",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "127"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/PAmpEnvelopeEnabled",
+        "shortname": "enable",
+        "name"     : "PAmpEnvelopeEnabled",
+        "tooltip"  : "Amplitude Envelope Enable",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/PAmpLfoEnabled",
+        "shortname": "enable",
+        "name"     : "PAmpLfoEnabled",
+        "tooltip"  : "Amplitude LFO Enable",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/PFilterEnabled",
+        "shortname": "enable",
+        "name"     : "PFilterEnabled",
+        "tooltip"  : "Filter Enable",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/PFilterEnvelopeEnabled",
+        "shortname": "enable",
+        "name"     : "PFilterEnvelopeEnabled",
+        "tooltip"  : "Filter Envelope Enable",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/PFilterLfoEnabled",
+        "shortname": "enable",
+        "name"     : "PFilterLfoEnabled",
+        "tooltip"  : "Filter LFO Enable",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/PFilterVelocityScale",
+        "shortname": "v.scale",
+        "name"     : "PFilterVelocityScale",
+        "tooltip"  : "Filter Velocity Magnitude",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/PFilterVelocityScaleFunction",
+        "shortname": "v.sense",
+        "name"     : "PFilterVelocityScaleFunction",
+        "tooltip"  : "Filter Velocity Function Shape",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/PFMEnabled",
+        "shortname": "mode",
+        "name"     : "PFMEnabled",
+        "tooltip"  : "Modulator mode",
+        "type"     : "i",
+        "default"  : "none"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "none"
+        },
+        {
+            "id"     : 1,
+            "value"  : "mix"
+        },
+        {
+            "id"     : 2,
+            "value"  : "ring"
+        },
+        {
+            "id"     : 3,
+            "value"  : "phase"
+        },
+        {
+            "id"     : 4,
+            "value"  : "frequency"
+        },
+        {
+            "id"     : 5,
+            "value"  : "pulse"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/PFMVoice",
+        "shortname": "voice",
+        "name"     : "PFMVoice",
+        "tooltip"  : "Modulator Oscillator Selection",
+        "type"     : "i",
+        "default"  : "-1"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FMvolume",
+        "shortname": "vol.",
+        "name"     : "FMvolume",
+        "tooltip"  : "Modulator Magnitude",
+        "scale"    : "linear",
+        "type"     : "f",
+        "range"    : [0.0,100.0],
+        "default"  : "70.0"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/PFMVolumeDamp",
+        "shortname": "damp.",
+        "name"     : "PFMVolumeDamp",
+        "tooltip"  : "Modulator HF dampening",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/PFMVelocityScaleFunction",
+        "shortname": "sense",
+        "name"     : "PFMVelocityScaleFunction",
+        "tooltip"  : "Modulator Velocity Function",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/PFMDetune",
+        "shortname": "fine",
+        "name"     : "PFMDetune",
+        "tooltip"  : "Modulator Fine Detune",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,16383],
+        "default"  : "8192"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/PFMCoarseDetune",
+        "shortname": "coarse",
+        "name"     : "PFMCoarseDetune",
+        "tooltip"  : "Modulator Coarse Detune",
+        "type"     : "i",
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/PFMDetuneType",
+        "shortname": "type",
+        "name"     : "PFMDetuneType",
+        "tooltip"  : "Modulator Detune Magnitude",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "L35cents"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "L35cents"
+        },
+        {
+            "id"     : 1,
+            "value"  : "L10cents"
+        },
+        {
+            "id"     : 2,
+            "value"  : "E100cents"
+        },
+        {
+            "id"     : 3,
+            "value"  : "E1200cents"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/PFMFixedFreq",
+        "shortname": "fixed",
+        "name"     : "PFMFixedFreq",
+        "tooltip"  : "Modulator Frequency Fixed",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/PFMFreqEnvelopeEnabled",
+        "shortname": "enable",
+        "name"     : "PFMFreqEnvelopeEnabled",
+        "tooltip"  : "Modulator Frequency Envelope",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/PFMAmpEnvelopeEnabled",
+        "shortname": "enable",
+        "name"     : "PFMAmpEnvelopeEnabled",
+        "tooltip"  : "Modulator Amplitude Envelope",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/octave",
+        "shortname": "octave",
+        "name"     : "octave",
+        "tooltip"  : "Octave note offset",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [-8,7]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/coarsedetune",
+        "shortname": "coarse",
+        "name"     : "coarsedetune",
+        "tooltip"  : "Coarse note detune",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [-64,63],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FMoctave",
+        "shortname": "octave",
+        "name"     : "FMoctave",
+        "tooltip"  : "Octave note offset for modulator",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [-8,7]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/VoicePar[0,7]/FMcoarsedetune",
+        "shortname": "coarse",
+        "name"     : "FMcoarsedetune",
+        "tooltip"  : "Coarse note detune for modulator",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [-64,63]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/Reson/Penabled",
+        "shortname": "enable",
+        "name"     : "Penabled",
+        "tooltip"  : "resonance enable",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/Reson/Pprotectthefundamental",
+        "shortname": "p.fund.",
+        "name"     : "Pprotectthefundamental",
+        "tooltip"  : "Disable resonance filter on first harmonic",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/Reson/Prespoints[0,255]",
+        "name"     : "Prespoints#256",
+        "tooltip"  : "Resonance data points",
+        "type"     : "i",
+        "default"  : "[64 ...]"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/Reson/PmaxdB",
+        "shortname": "max",
+        "name"     : "PmaxdB",
+        "tooltip"  : "how many dB the signal may be amplified",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "20"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/Reson/Pcenterfreq",
+        "shortname": "c.freq",
+        "name"     : "Pcenterfreq",
+        "tooltip"  : "Center frequency",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/Reson/Poctavesfreq",
+        "shortname": "oct",
+        "name"     : "Poctavesfreq",
+        "tooltip"  : "The number of octaves...",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/FreqLfo/freq",
+        "shortname": "freq",
+        "name"     : "freq",
+        "tooltip"  : "frequency of LFO\nlfo frequency = Pfreq * stretch\ntrue frequency is [0,85.25] Hz",
+        "units"    : "HZ",
+        "scale"    : "logarithmic",
+        "type"     : "f",
+        "range"    : [0.0775679,85.25]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/FreqLfo/Pintensity",
+        "shortname": "depth",
+        "name"     : "Pintensity",
+        "tooltip"  : "Intensity of LFO",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/FreqLfo/Pstartphase",
+        "shortname": "start",
+        "name"     : "Pstartphase",
+        "tooltip"  : "Starting Phase",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/FreqLfo/PLFOtype",
+        "shortname": "type",
+        "name"     : "PLFOtype",
+        "tooltip"  : "Shape of LFO",
+        "type"     : "i",
+        "default"  : "sine"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "sine"
+        },
+        {
+            "id"     : 1,
+            "value"  : "triangle"
+        },
+        {
+            "id"     : 2,
+            "value"  : "square"
+        },
+        {
+            "id"     : 3,
+            "value"  : "up"
+        },
+        {
+            "id"     : 4,
+            "value"  : "down"
+        },
+        {
+            "id"     : 5,
+            "value"  : "exp1"
+        },
+        {
+            "id"     : 6,
+            "value"  : "exp2"
+        },
+        {
+            "id"     : 7,
+            "value"  : "random"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/FreqLfo/Prandomness",
+        "shortname": "a.r.",
+        "name"     : "Prandomness",
+        "tooltip"  : "Amplitude Randomness (calculated uniformly at each cycle)",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/FreqLfo/Pfreqrand",
+        "shortname": "f.r.",
+        "name"     : "Pfreqrand",
+        "tooltip"  : "Frequency Randomness (calculated uniformly at each cycle)",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/FreqLfo/delay",
+        "shortname": "delay",
+        "name"     : "delay",
+        "tooltip"  : "Delay before LFO start\n0..4 second delay",
+        "units"    : "S",
+        "scale"    : "linear",
+        "type"     : "f",
+        "range"    : [0.0,4.0],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/FreqLfo/Pcontinous",
+        "shortname": "c",
+        "name"     : "Pcontinous",
+        "tooltip"  : "Enable for global operation",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/FreqLfo/Pstretch",
+        "shortname": "str",
+        "name"     : "Pstretch",
+        "tooltip"  : "Note frequency stretch",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/AmpLfo/freq",
+        "shortname": "freq",
+        "name"     : "freq",
+        "tooltip"  : "frequency of LFO\nlfo frequency = Pfreq * stretch\ntrue frequency is [0,85.25] Hz",
+        "units"    : "HZ",
+        "scale"    : "logarithmic",
+        "type"     : "f",
+        "range"    : [0.0775679,85.25]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/AmpLfo/Pintensity",
+        "shortname": "depth",
+        "name"     : "Pintensity",
+        "tooltip"  : "Intensity of LFO",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/AmpLfo/Pstartphase",
+        "shortname": "start",
+        "name"     : "Pstartphase",
+        "tooltip"  : "Starting Phase",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/AmpLfo/PLFOtype",
+        "shortname": "type",
+        "name"     : "PLFOtype",
+        "tooltip"  : "Shape of LFO",
+        "type"     : "i",
+        "default"  : "sine"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "sine"
+        },
+        {
+            "id"     : 1,
+            "value"  : "triangle"
+        },
+        {
+            "id"     : 2,
+            "value"  : "square"
+        },
+        {
+            "id"     : 3,
+            "value"  : "up"
+        },
+        {
+            "id"     : 4,
+            "value"  : "down"
+        },
+        {
+            "id"     : 5,
+            "value"  : "exp1"
+        },
+        {
+            "id"     : 6,
+            "value"  : "exp2"
+        },
+        {
+            "id"     : 7,
+            "value"  : "random"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/AmpLfo/Prandomness",
+        "shortname": "a.r.",
+        "name"     : "Prandomness",
+        "tooltip"  : "Amplitude Randomness (calculated uniformly at each cycle)",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/AmpLfo/Pfreqrand",
+        "shortname": "f.r.",
+        "name"     : "Pfreqrand",
+        "tooltip"  : "Frequency Randomness (calculated uniformly at each cycle)",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/AmpLfo/delay",
+        "shortname": "delay",
+        "name"     : "delay",
+        "tooltip"  : "Delay before LFO start\n0..4 second delay",
+        "units"    : "S",
+        "scale"    : "linear",
+        "type"     : "f",
+        "range"    : [0.0,4.0],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/AmpLfo/Pcontinous",
+        "shortname": "c",
+        "name"     : "Pcontinous",
+        "tooltip"  : "Enable for global operation",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/AmpLfo/Pstretch",
+        "shortname": "str",
+        "name"     : "Pstretch",
+        "tooltip"  : "Note frequency stretch",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/FilterLfo/freq",
+        "shortname": "freq",
+        "name"     : "freq",
+        "tooltip"  : "frequency of LFO\nlfo frequency = Pfreq * stretch\ntrue frequency is [0,85.25] Hz",
+        "units"    : "HZ",
+        "scale"    : "logarithmic",
+        "type"     : "f",
+        "range"    : [0.0775679,85.25]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/FilterLfo/Pintensity",
+        "shortname": "depth",
+        "name"     : "Pintensity",
+        "tooltip"  : "Intensity of LFO",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/FilterLfo/Pstartphase",
+        "shortname": "start",
+        "name"     : "Pstartphase",
+        "tooltip"  : "Starting Phase",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/FilterLfo/PLFOtype",
+        "shortname": "type",
+        "name"     : "PLFOtype",
+        "tooltip"  : "Shape of LFO",
+        "type"     : "i",
+        "default"  : "sine"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "sine"
+        },
+        {
+            "id"     : 1,
+            "value"  : "triangle"
+        },
+        {
+            "id"     : 2,
+            "value"  : "square"
+        },
+        {
+            "id"     : 3,
+            "value"  : "up"
+        },
+        {
+            "id"     : 4,
+            "value"  : "down"
+        },
+        {
+            "id"     : 5,
+            "value"  : "exp1"
+        },
+        {
+            "id"     : 6,
+            "value"  : "exp2"
+        },
+        {
+            "id"     : 7,
+            "value"  : "random"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/FilterLfo/Prandomness",
+        "shortname": "a.r.",
+        "name"     : "Prandomness",
+        "tooltip"  : "Amplitude Randomness (calculated uniformly at each cycle)",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/FilterLfo/Pfreqrand",
+        "shortname": "f.r.",
+        "name"     : "Pfreqrand",
+        "tooltip"  : "Frequency Randomness (calculated uniformly at each cycle)",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/FilterLfo/delay",
+        "shortname": "delay",
+        "name"     : "delay",
+        "tooltip"  : "Delay before LFO start\n0..4 second delay",
+        "units"    : "S",
+        "scale"    : "linear",
+        "type"     : "f",
+        "range"    : [0.0,4.0],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/FilterLfo/Pcontinous",
+        "shortname": "c",
+        "name"     : "Pcontinous",
+        "tooltip"  : "Enable for global operation",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/FilterLfo/Pstretch",
+        "shortname": "str",
+        "name"     : "Pstretch",
+        "tooltip"  : "Note frequency stretch",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/FreqEnvelope/Pfreemode",
+        "name"     : "Pfreemode",
+        "tooltip"  : "Complex Envelope Definitions",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/FreqEnvelope/Penvsustain",
+        "name"     : "Penvsustain",
+        "tooltip"  : "Location of the sustain point",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "2"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/FreqEnvelope/Penvdt[0,39]",
+        "name"     : "Penvdt#40",
+        "tooltip"  : "Envelope Delay Times",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/FreqEnvelope/Penvval[0,39]",
+        "name"     : "Penvval#40",
+        "tooltip"  : "Envelope Values",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/FreqEnvelope/Penvstretch",
+        "shortname": "stretch",
+        "name"     : "Penvstretch",
+        "tooltip"  : "Stretch with respect to frequency",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/FreqEnvelope/Pforcedrelease",
+        "shortname": "frcr",
+        "name"     : "Pforcedrelease",
+        "tooltip"  : "Force Envelope to fully evaluate",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/FreqEnvelope/Plinearenvelope",
+        "shortname": "lin/log",
+        "name"     : "Plinearenvelope",
+        "tooltip"  : "Linear or Logarithmic Envelopes",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/FreqEnvelope/PA_dt",
+        "shortname": "a.dt",
+        "name"     : "PA_dt",
+        "tooltip"  : "Attack Time",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/FreqEnvelope/A_dt",
+        "shortname": "a.dt",
+        "name"     : "A_dt",
+        "tooltip"  : "Attack Time",
+        "scale"    : "logarithmic",
+        "type"     : "f",
+        "range"    : [0.0f,41.0f],
+        "default"  : "0.00"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/FreqEnvelope/PA_val",
+        "shortname": "a.val",
+        "name"     : "PA_val",
+        "tooltip"  : "Attack Value",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/FreqEnvelope/PD_dt",
+        "shortname": "d.dt",
+        "name"     : "PD_dt",
+        "tooltip"  : "Decay Time",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/FreqEnvelope/D_dt",
+        "shortname": "d.dt",
+        "name"     : "D_dt",
+        "tooltip"  : "Decay Time",
+        "scale"    : "logarithmic",
+        "type"     : "f",
+        "range"    : [0.0f,41.0f],
+        "default"  : "0.00925031"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/FreqEnvelope/PD_val",
+        "shortname": "d.val",
+        "name"     : "PD_val",
+        "tooltip"  : "Decay Value",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/FreqEnvelope/PS_val",
+        "shortname": "s.val",
+        "name"     : "PS_val",
+        "tooltip"  : "Sustain Value",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/FreqEnvelope/PR_dt",
+        "shortname": "r.dt",
+        "name"     : "PR_dt",
+        "tooltip"  : "Release Time",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/FreqEnvelope/R_dt",
+        "shortname": "r.dt",
+        "name"     : "R_dt",
+        "tooltip"  : "Release Time",
+        "scale"    : "logarithmic",
+        "type"     : "f",
+        "range"    : [0.01f,41.0f],
+        "default"  : "0.498893"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/FreqEnvelope/PR_val",
+        "shortname": "r.val",
+        "name"     : "PR_val",
+        "tooltip"  : "Release Value",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/AmpEnvelope/Pfreemode",
+        "name"     : "Pfreemode",
+        "tooltip"  : "Complex Envelope Definitions",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/AmpEnvelope/Penvsustain",
+        "name"     : "Penvsustain",
+        "tooltip"  : "Location of the sustain point",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "2"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/AmpEnvelope/Penvdt[0,39]",
+        "name"     : "Penvdt#40",
+        "tooltip"  : "Envelope Delay Times",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/AmpEnvelope/Penvval[0,39]",
+        "name"     : "Penvval#40",
+        "tooltip"  : "Envelope Values",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/AmpEnvelope/Penvstretch",
+        "shortname": "stretch",
+        "name"     : "Penvstretch",
+        "tooltip"  : "Stretch with respect to frequency",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/AmpEnvelope/Pforcedrelease",
+        "shortname": "frcr",
+        "name"     : "Pforcedrelease",
+        "tooltip"  : "Force Envelope to fully evaluate",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/AmpEnvelope/Plinearenvelope",
+        "shortname": "lin/log",
+        "name"     : "Plinearenvelope",
+        "tooltip"  : "Linear or Logarithmic Envelopes",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/AmpEnvelope/PA_dt",
+        "shortname": "a.dt",
+        "name"     : "PA_dt",
+        "tooltip"  : "Attack Time",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/AmpEnvelope/A_dt",
+        "shortname": "a.dt",
+        "name"     : "A_dt",
+        "tooltip"  : "Attack Time",
+        "scale"    : "logarithmic",
+        "type"     : "f",
+        "range"    : [0.0f,41.0f],
+        "default"  : "0.00"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/AmpEnvelope/PA_val",
+        "shortname": "a.val",
+        "name"     : "PA_val",
+        "tooltip"  : "Attack Value",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/AmpEnvelope/PD_dt",
+        "shortname": "d.dt",
+        "name"     : "PD_dt",
+        "tooltip"  : "Decay Time",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/AmpEnvelope/D_dt",
+        "shortname": "d.dt",
+        "name"     : "D_dt",
+        "tooltip"  : "Decay Time",
+        "scale"    : "logarithmic",
+        "type"     : "f",
+        "range"    : [0.0f,41.0f],
+        "default"  : "0.00925031"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/AmpEnvelope/PD_val",
+        "shortname": "d.val",
+        "name"     : "PD_val",
+        "tooltip"  : "Decay Value",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/AmpEnvelope/PS_val",
+        "shortname": "s.val",
+        "name"     : "PS_val",
+        "tooltip"  : "Sustain Value",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/AmpEnvelope/PR_dt",
+        "shortname": "r.dt",
+        "name"     : "PR_dt",
+        "tooltip"  : "Release Time",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/AmpEnvelope/R_dt",
+        "shortname": "r.dt",
+        "name"     : "R_dt",
+        "tooltip"  : "Release Time",
+        "scale"    : "logarithmic",
+        "type"     : "f",
+        "range"    : [0.01f,41.0f],
+        "default"  : "0.498893"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/AmpEnvelope/PR_val",
+        "shortname": "r.val",
+        "name"     : "PR_val",
+        "tooltip"  : "Release Value",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/FilterEnvelope/Pfreemode",
+        "name"     : "Pfreemode",
+        "tooltip"  : "Complex Envelope Definitions",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/FilterEnvelope/Penvsustain",
+        "name"     : "Penvsustain",
+        "tooltip"  : "Location of the sustain point",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "2"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/FilterEnvelope/Penvdt[0,39]",
+        "name"     : "Penvdt#40",
+        "tooltip"  : "Envelope Delay Times",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/FilterEnvelope/Penvval[0,39]",
+        "name"     : "Penvval#40",
+        "tooltip"  : "Envelope Values",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/FilterEnvelope/Penvstretch",
+        "shortname": "stretch",
+        "name"     : "Penvstretch",
+        "tooltip"  : "Stretch with respect to frequency",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/FilterEnvelope/Pforcedrelease",
+        "shortname": "frcr",
+        "name"     : "Pforcedrelease",
+        "tooltip"  : "Force Envelope to fully evaluate",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/FilterEnvelope/Plinearenvelope",
+        "shortname": "lin/log",
+        "name"     : "Plinearenvelope",
+        "tooltip"  : "Linear or Logarithmic Envelopes",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/FilterEnvelope/PA_dt",
+        "shortname": "a.dt",
+        "name"     : "PA_dt",
+        "tooltip"  : "Attack Time",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/FilterEnvelope/A_dt",
+        "shortname": "a.dt",
+        "name"     : "A_dt",
+        "tooltip"  : "Attack Time",
+        "scale"    : "logarithmic",
+        "type"     : "f",
+        "range"    : [0.0f,41.0f],
+        "default"  : "0.00"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/FilterEnvelope/PA_val",
+        "shortname": "a.val",
+        "name"     : "PA_val",
+        "tooltip"  : "Attack Value",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/FilterEnvelope/PD_dt",
+        "shortname": "d.dt",
+        "name"     : "PD_dt",
+        "tooltip"  : "Decay Time",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/FilterEnvelope/D_dt",
+        "shortname": "d.dt",
+        "name"     : "D_dt",
+        "tooltip"  : "Decay Time",
+        "scale"    : "logarithmic",
+        "type"     : "f",
+        "range"    : [0.0f,41.0f],
+        "default"  : "0.00925031"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/FilterEnvelope/PD_val",
+        "shortname": "d.val",
+        "name"     : "PD_val",
+        "tooltip"  : "Decay Value",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/FilterEnvelope/PS_val",
+        "shortname": "s.val",
+        "name"     : "PS_val",
+        "tooltip"  : "Sustain Value",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/FilterEnvelope/PR_dt",
+        "shortname": "r.dt",
+        "name"     : "PR_dt",
+        "tooltip"  : "Release Time",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/FilterEnvelope/R_dt",
+        "shortname": "r.dt",
+        "name"     : "R_dt",
+        "tooltip"  : "Release Time",
+        "scale"    : "logarithmic",
+        "type"     : "f",
+        "range"    : [0.01f,41.0f],
+        "default"  : "0.498893"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/FilterEnvelope/PR_val",
+        "shortname": "r.val",
+        "name"     : "PR_val",
+        "tooltip"  : "Release Value",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/GlobalFilter/Pcategory",
+        "shortname": "class",
+        "name"     : "Pcategory",
+        "tooltip"  : "Class of filter",
+        "type"     : "i",
+        "default"  : "analog"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "analog"
+        },
+        {
+            "id"     : 1,
+            "value"  : "formant"
+        },
+        {
+            "id"     : 2,
+            "value"  : "st.var."
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/GlobalFilter/Ptype",
+        "shortname": "type",
+        "name"     : "Ptype",
+        "tooltip"  : "Filter Type",
+        "type"     : "i",
+        "default"  : "LP2"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "LP1"
+        },
+        {
+            "id"     : 1,
+            "value"  : "HP1"
+        },
+        {
+            "id"     : 2,
+            "value"  : "LP2"
+        },
+        {
+            "id"     : 3,
+            "value"  : "HP2"
+        },
+        {
+            "id"     : 4,
+            "value"  : "BP"
+        },
+        {
+            "id"     : 5,
+            "value"  : "notch"
+        },
+        {
+            "id"     : 6,
+            "value"  : "peak"
+        },
+        {
+            "id"     : 7,
+            "value"  : "l.shelf"
+        },
+        {
+            "id"     : 8,
+            "value"  : "h.shelf"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/GlobalFilter/Pstages",
+        "shortname": "stages",
+        "name"     : "Pstages",
+        "tooltip"  : "Filter Stages",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,5],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/GlobalFilter/baseq",
+        "shortname": "q",
+        "name"     : "baseq",
+        "tooltip"  : "Quality Factor (resonance/bandwidth)",
+        "units"    : "none",
+        "scale"    : "logarithmic",
+        "type"     : "f",
+        "range"    : [0.1,1000]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/GlobalFilter/basefreq",
+        "shortname": "cutoff",
+        "name"     : "basefreq",
+        "tooltip"  : "Base cutoff frequency",
+        "units"    : "Hz",
+        "scale"    : "logarithmic",
+        "type"     : "f",
+        "range"    : [31.25,32000]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/GlobalFilter/freqtracking",
+        "shortname": "f.track",
+        "name"     : "freqtracking",
+        "tooltip"  : "Frequency Tracking amount",
+        "units"    : "%",
+        "scale"    : "linear",
+        "type"     : "f",
+        "range"    : [-100,100],
+        "default"  : "0.0f"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/GlobalFilter/gain",
+        "shortname": "gain",
+        "name"     : "gain",
+        "tooltip"  : "Output Gain",
+        "units"    : "dB",
+        "scale"    : "linear",
+        "type"     : "f",
+        "range"    : [-30,30],
+        "default"  : "0.0f"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/GlobalFilter/Pnumformants",
+        "shortname": "formants",
+        "name"     : "Pnumformants",
+        "tooltip"  : "Number of formants to be used",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [1,12],
+        "default"  : "3"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/GlobalFilter/Pformantslowness",
+        "shortname": "slew",
+        "name"     : "Pformantslowness",
+        "tooltip"  : "Rate that formants change",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/GlobalFilter/Pvowelclearness",
+        "shortname": "clarity",
+        "name"     : "Pvowelclearness",
+        "tooltip"  : "How much each vowel is smudged with the next in sequence. A high clarity will avoid smudging.",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/GlobalFilter/Pcenterfreq",
+        "shortname": "cutoff",
+        "name"     : "Pcenterfreq",
+        "tooltip"  : "Center Freq (formant)",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/GlobalFilter/Poctavesfreq",
+        "shortname": "octaves",
+        "name"     : "Poctavesfreq",
+        "tooltip"  : "Number of octaves for formant",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/GlobalFilter/Psequencesize",
+        "shortname": "seq.size",
+        "name"     : "Psequencesize",
+        "tooltip"  : "Length of vowel sequence",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,8],
+        "default"  : "3"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/GlobalFilter/Psequencestretch",
+        "shortname": "seq.str",
+        "name"     : "Psequencestretch",
+        "tooltip"  : "How modulators stretch the sequence",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "40"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/GlobalFilter/Psequencereversed",
+        "shortname": "reverse",
+        "name"     : "Psequencereversed",
+        "tooltip"  : "If the modulator input is inverted",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/GlobalFilter/type-svf",
+        "shortname": "type",
+        "name"     : "type-svf",
+        "tooltip"  : "Filter Type",
+        "type"     : "i",
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "low"
+        },
+        {
+            "id"     : 1,
+            "value"  : "high"
+        },
+        {
+            "id"     : 2,
+            "value"  : "band"
+        },
+        {
+            "id"     : 3,
+            "value"  : "notch"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/GlobalFilter/Pvowels[0,5]/Pformants[0,11]/freq",
+        "shortname": "f.freq",
+        "name"     : "freq",
+        "tooltip"  : "Formant frequency",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/GlobalFilter/Pvowels[0,5]/Pformants[0,11]/amp",
+        "shortname": "f.str",
+        "name"     : "amp",
+        "tooltip"  : "Strength of formant",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "127"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/GlobalFilter/Pvowels[0,5]/Pformants[0,11]/q",
+        "shortname": "f.q",
+        "name"     : "q",
+        "tooltip"  : "The formant's quality factor, also known as resonance bandwidth or Q for short",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/PStereo",
+        "shortname": "stereo",
+        "name"     : "PStereo",
+        "tooltip"  : "Mono/Stereo Enable",
+        "type"     : "t",
+        "default"  : "true"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/PDetune",
+        "shortname": "fine",
+        "name"     : "PDetune",
+        "tooltip"  : "Fine Detune",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,16383],
+        "default"  : "8192"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/PCoarseDetune",
+        "shortname": "coarse",
+        "name"     : "PCoarseDetune",
+        "tooltip"  : "Coarse Detune",
+        "type"     : "i",
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/PDetuneType",
+        "shortname": "type",
+        "name"     : "PDetuneType",
+        "tooltip"  : "Detune Scaling Type",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "L10cents"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "L35cents"
+        },
+        {
+            "id"     : 1,
+            "value"  : "L10cents"
+        },
+        {
+            "id"     : 2,
+            "value"  : "E100cents"
+        },
+        {
+            "id"     : 3,
+            "value"  : "E1200cents"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/PBandwidth",
+        "shortname": "bw.",
+        "name"     : "PBandwidth",
+        "tooltip"  : "Relative Fine Detune Gain",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/PPanning",
+        "shortname": "pan",
+        "name"     : "PPanning",
+        "tooltip"  : "Panning of ADsynth (0 random, 1 left, 127 right)",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/Volume",
+        "shortname": "vol",
+        "name"     : "Volume",
+        "tooltip"  : "volume control",
+        "units"    : "dB",
+        "scale"    : "linear",
+        "type"     : "f",
+        "range"    : [-47.9588f,32.0412f],
+        "default"  : "8.29f"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/PAmpVelocityScaleFunction",
+        "shortname": "sense",
+        "name"     : "PAmpVelocityScaleFunction",
+        "tooltip"  : "Volume velocity sense",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/Fadein_adjustment",
+        "name"     : "Fadein_adjustment",
+        "tooltip"  : "Adjustment for anti-pop strategy.",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "20"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/PPunchStrength",
+        "shortname": "strength",
+        "name"     : "PPunchStrength",
+        "tooltip"  : "Punch Strength",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/PPunchTime",
+        "shortname": "time",
+        "name"     : "PPunchTime",
+        "tooltip"  : "Length of Punch",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "60"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/PPunchStretch",
+        "shortname": "stretch",
+        "name"     : "PPunchStretch",
+        "tooltip"  : "How Punch changes with note frequency",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/PPunchVelocitySensing",
+        "shortname": "v.sns",
+        "name"     : "PPunchVelocitySensing",
+        "tooltip"  : "Punch Velocity control",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "72"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/PFilterVelocityScale",
+        "shortname": "scale",
+        "name"     : "PFilterVelocityScale",
+        "tooltip"  : "Filter Velocity Magnitude",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/PFilterVelocityScaleFunction",
+        "shortname": "sense",
+        "name"     : "PFilterVelocityScaleFunction",
+        "tooltip"  : "Filter Velocity Function Shape",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/Hrandgrouping",
+        "name"     : "Hrandgrouping",
+        "tooltip"  : "How randomness is applied to multiple voices using the same oscil",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/octave",
+        "shortname": "octave",
+        "name"     : "octave",
+        "tooltip"  : "Octave note offset",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [-8,7]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/adpars/GlobalPar/coarsedetune",
+        "shortname": "coarse",
+        "name"     : "coarsedetune",
+        "tooltip"  : "Coarse note detune",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [-64,63]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/Pstereo",
+        "shortname": "stereo",
+        "name"     : "Pstereo",
+        "tooltip"  : "Stereo Enable",
+        "type"     : "t",
+        "default"  : "true"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/Volume",
+        "shortname": "volume",
+        "name"     : "Volume",
+        "tooltip"  : "Volume",
+        "units"    : "dB",
+        "scale"    : "linear",
+        "type"     : "f",
+        "range"    : [-60.0f,20.0f],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/PPanning",
+        "shortname": "panning",
+        "name"     : "PPanning",
+        "tooltip"  : "Left Right Panning",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/AmpVelocityScaleFunction",
+        "shortname": "sense",
+        "name"     : "AmpVelocityScaleFunction",
+        "tooltip"  : "Amplitude Velocity Sensing function",
+        "scale"    : "linear",
+        "type"     : "f",
+        "range"    : [0.0,100.0],
+        "default"  : "70.86"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/PAmpVelocityScaleFunction",
+        "shortname": "sense",
+        "name"     : "PAmpVelocityScaleFunction",
+        "tooltip"  : "Amplitude Velocity Sensing function",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "90"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/PDetune",
+        "shortname": "detune",
+        "name"     : "PDetune",
+        "tooltip"  : "Detune in detune type units",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,16383],
+        "default"  : "8192"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/PCoarseDetune",
+        "shortname": "cdetune",
+        "name"     : "PCoarseDetune",
+        "tooltip"  : "Coarse Detune",
+        "type"     : "i",
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/PDetuneType",
+        "shortname": "det. scl.",
+        "name"     : "PDetuneType",
+        "tooltip"  : "Detune Scale",
+        "type"     : "i",
+        "default"  : "\"L10 cents\"S"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "L35 cents"
+        },
+        {
+            "id"     : 1,
+            "value"  : "L10 cents"
+        },
+        {
+            "id"     : 2,
+            "value"  : "E100 cents"
+        },
+        {
+            "id"     : 3,
+            "value"  : "E1200 cents"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/PFreqEnvelopeEnabled",
+        "shortname": "enable",
+        "name"     : "PFreqEnvelopeEnabled",
+        "tooltip"  : "Enable for Frequency Envelope",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/PBandWidthEnvelopeEnabled",
+        "shortname": "enable",
+        "name"     : "PBandWidthEnvelopeEnabled",
+        "tooltip"  : "Enable for Bandwidth Envelope",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/PGlobalFilterEnabled",
+        "shortname": "enable",
+        "name"     : "PGlobalFilterEnabled",
+        "tooltip"  : "Enable for Global Filter",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/PGlobalFilterVelocityScale",
+        "shortname": "scale",
+        "name"     : "PGlobalFilterVelocityScale",
+        "tooltip"  : "Filter Velocity Magnitude",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/PGlobalFilterVelocityScaleFunction",
+        "shortname": "sense",
+        "name"     : "PGlobalFilterVelocityScaleFunction",
+        "tooltip"  : "Filter Velocity Function Shape",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/Pfixedfreq",
+        "shortname": "fixed freq",
+        "name"     : "Pfixedfreq",
+        "tooltip"  : "Base frequency fixed frequency enable",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/PfixedfreqET",
+        "shortname": "fixed ET",
+        "name"     : "PfixedfreqET",
+        "tooltip"  : "Equal temeperate control for fixed frequency operation",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/PBendAdjust",
+        "shortname": "bend",
+        "name"     : "PBendAdjust",
+        "tooltip"  : "Pitch bend adjustment",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "88"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/POffsetHz",
+        "shortname": "+ Hz",
+        "name"     : "POffsetHz",
+        "tooltip"  : "Voice constant offset",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/POvertoneSpread.type",
+        "shortname": "spread type",
+        "name"     : "POvertoneSpread.type",
+        "tooltip"  : ":default",
+        "type"     : "i",
+        "range"    : [0,7],
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "Harmonic"
+        },
+        {
+            "id"     : 1,
+            "value"  : "ShiftU"
+        },
+        {
+            "id"     : 2,
+            "value"  : "ShiftL"
+        },
+        {
+            "id"     : 3,
+            "value"  : "PowerU"
+        },
+        {
+            "id"     : 4,
+            "value"  : "PowerL"
+        },
+        {
+            "id"     : 5,
+            "value"  : "Sine"
+        },
+        {
+            "id"     : 6,
+            "value"  : "Power"
+        },
+        {
+            "id"     : 7,
+            "value"  : "Shift"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/POvertoneSpread.par1",
+        "shortname": "p1",
+        "name"     : "POvertoneSpread.par1",
+        "tooltip"  : "Overtone Parameter",
+        "type"     : "i",
+        "range"    : [0,255],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/POvertoneSpread.par2",
+        "shortname": "p2",
+        "name"     : "POvertoneSpread.par2",
+        "tooltip"  : "Overtone Parameter",
+        "type"     : "i",
+        "range"    : [0,255],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/POvertoneSpread.par3",
+        "shortname": "forceH",
+        "name"     : "POvertoneSpread.par3",
+        "tooltip"  : "Force Overtones To Harmonics",
+        "type"     : "i",
+        "range"    : [0,255],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/Pnumstages",
+        "shortname": "stages",
+        "name"     : "Pnumstages",
+        "tooltip"  : "Number of filter stages",
+        "type"     : "i",
+        "range"    : [1,5],
+        "default"  : "2"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/Pbandwidth",
+        "shortname": "bandwidth",
+        "name"     : "Pbandwidth",
+        "tooltip"  : "Bandwidth of filters",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "40"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/Phmagtype",
+        "shortname": "mag. type",
+        "name"     : "Phmagtype",
+        "tooltip"  : "Magnitude scale",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "linear"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "linear"
+        },
+        {
+            "id"     : 1,
+            "value"  : "-40dB"
+        },
+        {
+            "id"     : 2,
+            "value"  : "-60dB"
+        },
+        {
+            "id"     : 3,
+            "value"  : "-80dB"
+        },
+        {
+            "id"     : 4,
+            "value"  : "-100dB"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/Phmag[0,63]",
+        "name"     : "Phmag#64",
+        "tooltip"  : "Harmonic magnitudes",
+        "type"     : "i",
+        "default"  : "[127 0 0 ...]"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/Phrelbw[0,63]",
+        "name"     : "Phrelbw#64",
+        "tooltip"  : "Relative bandwidth",
+        "type"     : "i",
+        "default"  : "[64 ...]"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/Pbwscale",
+        "shortname": "stretch",
+        "name"     : "Pbwscale",
+        "tooltip"  : "Bandwidth scaling with frequency",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/AmpEnvelope/Pfreemode",
+        "name"     : "Pfreemode",
+        "tooltip"  : "Complex Envelope Definitions",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/AmpEnvelope/Penvsustain",
+        "name"     : "Penvsustain",
+        "tooltip"  : "Location of the sustain point",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "2"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/AmpEnvelope/Penvdt[0,39]",
+        "name"     : "Penvdt#40",
+        "tooltip"  : "Envelope Delay Times",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/AmpEnvelope/Penvval[0,39]",
+        "name"     : "Penvval#40",
+        "tooltip"  : "Envelope Values",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/AmpEnvelope/Penvstretch",
+        "shortname": "stretch",
+        "name"     : "Penvstretch",
+        "tooltip"  : "Stretch with respect to frequency",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/AmpEnvelope/Pforcedrelease",
+        "shortname": "frcr",
+        "name"     : "Pforcedrelease",
+        "tooltip"  : "Force Envelope to fully evaluate",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/AmpEnvelope/Plinearenvelope",
+        "shortname": "lin/log",
+        "name"     : "Plinearenvelope",
+        "tooltip"  : "Linear or Logarithmic Envelopes",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/AmpEnvelope/PA_dt",
+        "shortname": "a.dt",
+        "name"     : "PA_dt",
+        "tooltip"  : "Attack Time",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/AmpEnvelope/A_dt",
+        "shortname": "a.dt",
+        "name"     : "A_dt",
+        "tooltip"  : "Attack Time",
+        "scale"    : "logarithmic",
+        "type"     : "f",
+        "range"    : [0.0f,41.0f],
+        "default"  : "0.00"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/AmpEnvelope/PA_val",
+        "shortname": "a.val",
+        "name"     : "PA_val",
+        "tooltip"  : "Attack Value",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/AmpEnvelope/PD_dt",
+        "shortname": "d.dt",
+        "name"     : "PD_dt",
+        "tooltip"  : "Decay Time",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/AmpEnvelope/D_dt",
+        "shortname": "d.dt",
+        "name"     : "D_dt",
+        "tooltip"  : "Decay Time",
+        "scale"    : "logarithmic",
+        "type"     : "f",
+        "range"    : [0.0f,41.0f],
+        "default"  : "0.00925031"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/AmpEnvelope/PD_val",
+        "shortname": "d.val",
+        "name"     : "PD_val",
+        "tooltip"  : "Decay Value",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/AmpEnvelope/PS_val",
+        "shortname": "s.val",
+        "name"     : "PS_val",
+        "tooltip"  : "Sustain Value",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/AmpEnvelope/PR_dt",
+        "shortname": "r.dt",
+        "name"     : "PR_dt",
+        "tooltip"  : "Release Time",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/AmpEnvelope/R_dt",
+        "shortname": "r.dt",
+        "name"     : "R_dt",
+        "tooltip"  : "Release Time",
+        "scale"    : "logarithmic",
+        "type"     : "f",
+        "range"    : [0.01f,41.0f],
+        "default"  : "0.498893"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/AmpEnvelope/PR_val",
+        "shortname": "r.val",
+        "name"     : "PR_val",
+        "tooltip"  : "Release Value",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/FreqEnvelope/Pfreemode",
+        "name"     : "Pfreemode",
+        "tooltip"  : "Complex Envelope Definitions",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/FreqEnvelope/Penvsustain",
+        "name"     : "Penvsustain",
+        "tooltip"  : "Location of the sustain point",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "2"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/FreqEnvelope/Penvdt[0,39]",
+        "name"     : "Penvdt#40",
+        "tooltip"  : "Envelope Delay Times",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/FreqEnvelope/Penvval[0,39]",
+        "name"     : "Penvval#40",
+        "tooltip"  : "Envelope Values",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/FreqEnvelope/Penvstretch",
+        "shortname": "stretch",
+        "name"     : "Penvstretch",
+        "tooltip"  : "Stretch with respect to frequency",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/FreqEnvelope/Pforcedrelease",
+        "shortname": "frcr",
+        "name"     : "Pforcedrelease",
+        "tooltip"  : "Force Envelope to fully evaluate",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/FreqEnvelope/Plinearenvelope",
+        "shortname": "lin/log",
+        "name"     : "Plinearenvelope",
+        "tooltip"  : "Linear or Logarithmic Envelopes",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/FreqEnvelope/PA_dt",
+        "shortname": "a.dt",
+        "name"     : "PA_dt",
+        "tooltip"  : "Attack Time",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/FreqEnvelope/A_dt",
+        "shortname": "a.dt",
+        "name"     : "A_dt",
+        "tooltip"  : "Attack Time",
+        "scale"    : "logarithmic",
+        "type"     : "f",
+        "range"    : [0.0f,41.0f],
+        "default"  : "0.00"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/FreqEnvelope/PA_val",
+        "shortname": "a.val",
+        "name"     : "PA_val",
+        "tooltip"  : "Attack Value",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/FreqEnvelope/PD_dt",
+        "shortname": "d.dt",
+        "name"     : "PD_dt",
+        "tooltip"  : "Decay Time",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/FreqEnvelope/D_dt",
+        "shortname": "d.dt",
+        "name"     : "D_dt",
+        "tooltip"  : "Decay Time",
+        "scale"    : "logarithmic",
+        "type"     : "f",
+        "range"    : [0.0f,41.0f],
+        "default"  : "0.00925031"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/FreqEnvelope/PD_val",
+        "shortname": "d.val",
+        "name"     : "PD_val",
+        "tooltip"  : "Decay Value",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/FreqEnvelope/PS_val",
+        "shortname": "s.val",
+        "name"     : "PS_val",
+        "tooltip"  : "Sustain Value",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/FreqEnvelope/PR_dt",
+        "shortname": "r.dt",
+        "name"     : "PR_dt",
+        "tooltip"  : "Release Time",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/FreqEnvelope/R_dt",
+        "shortname": "r.dt",
+        "name"     : "R_dt",
+        "tooltip"  : "Release Time",
+        "scale"    : "logarithmic",
+        "type"     : "f",
+        "range"    : [0.01f,41.0f],
+        "default"  : "0.498893"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/FreqEnvelope/PR_val",
+        "shortname": "r.val",
+        "name"     : "PR_val",
+        "tooltip"  : "Release Value",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/BandWidthEnvelope/Pfreemode",
+        "name"     : "Pfreemode",
+        "tooltip"  : "Complex Envelope Definitions",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/BandWidthEnvelope/Penvsustain",
+        "name"     : "Penvsustain",
+        "tooltip"  : "Location of the sustain point",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "2"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/BandWidthEnvelope/Penvdt[0,39]",
+        "name"     : "Penvdt#40",
+        "tooltip"  : "Envelope Delay Times",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/BandWidthEnvelope/Penvval[0,39]",
+        "name"     : "Penvval#40",
+        "tooltip"  : "Envelope Values",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/BandWidthEnvelope/Penvstretch",
+        "shortname": "stretch",
+        "name"     : "Penvstretch",
+        "tooltip"  : "Stretch with respect to frequency",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/BandWidthEnvelope/Pforcedrelease",
+        "shortname": "frcr",
+        "name"     : "Pforcedrelease",
+        "tooltip"  : "Force Envelope to fully evaluate",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/BandWidthEnvelope/Plinearenvelope",
+        "shortname": "lin/log",
+        "name"     : "Plinearenvelope",
+        "tooltip"  : "Linear or Logarithmic Envelopes",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/BandWidthEnvelope/PA_dt",
+        "shortname": "a.dt",
+        "name"     : "PA_dt",
+        "tooltip"  : "Attack Time",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/BandWidthEnvelope/A_dt",
+        "shortname": "a.dt",
+        "name"     : "A_dt",
+        "tooltip"  : "Attack Time",
+        "scale"    : "logarithmic",
+        "type"     : "f",
+        "range"    : [0.0f,41.0f],
+        "default"  : "0.00"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/BandWidthEnvelope/PA_val",
+        "shortname": "a.val",
+        "name"     : "PA_val",
+        "tooltip"  : "Attack Value",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/BandWidthEnvelope/PD_dt",
+        "shortname": "d.dt",
+        "name"     : "PD_dt",
+        "tooltip"  : "Decay Time",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/BandWidthEnvelope/D_dt",
+        "shortname": "d.dt",
+        "name"     : "D_dt",
+        "tooltip"  : "Decay Time",
+        "scale"    : "logarithmic",
+        "type"     : "f",
+        "range"    : [0.0f,41.0f],
+        "default"  : "0.00925031"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/BandWidthEnvelope/PD_val",
+        "shortname": "d.val",
+        "name"     : "PD_val",
+        "tooltip"  : "Decay Value",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/BandWidthEnvelope/PS_val",
+        "shortname": "s.val",
+        "name"     : "PS_val",
+        "tooltip"  : "Sustain Value",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/BandWidthEnvelope/PR_dt",
+        "shortname": "r.dt",
+        "name"     : "PR_dt",
+        "tooltip"  : "Release Time",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/BandWidthEnvelope/R_dt",
+        "shortname": "r.dt",
+        "name"     : "R_dt",
+        "tooltip"  : "Release Time",
+        "scale"    : "logarithmic",
+        "type"     : "f",
+        "range"    : [0.01f,41.0f],
+        "default"  : "0.498893"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/BandWidthEnvelope/PR_val",
+        "shortname": "r.val",
+        "name"     : "PR_val",
+        "tooltip"  : "Release Value",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/GlobalFilterEnvelope/Pfreemode",
+        "name"     : "Pfreemode",
+        "tooltip"  : "Complex Envelope Definitions",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/GlobalFilterEnvelope/Penvsustain",
+        "name"     : "Penvsustain",
+        "tooltip"  : "Location of the sustain point",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "2"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/GlobalFilterEnvelope/Penvdt[0,39]",
+        "name"     : "Penvdt#40",
+        "tooltip"  : "Envelope Delay Times",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/GlobalFilterEnvelope/Penvval[0,39]",
+        "name"     : "Penvval#40",
+        "tooltip"  : "Envelope Values",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/GlobalFilterEnvelope/Penvstretch",
+        "shortname": "stretch",
+        "name"     : "Penvstretch",
+        "tooltip"  : "Stretch with respect to frequency",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/GlobalFilterEnvelope/Pforcedrelease",
+        "shortname": "frcr",
+        "name"     : "Pforcedrelease",
+        "tooltip"  : "Force Envelope to fully evaluate",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/GlobalFilterEnvelope/Plinearenvelope",
+        "shortname": "lin/log",
+        "name"     : "Plinearenvelope",
+        "tooltip"  : "Linear or Logarithmic Envelopes",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/GlobalFilterEnvelope/PA_dt",
+        "shortname": "a.dt",
+        "name"     : "PA_dt",
+        "tooltip"  : "Attack Time",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/GlobalFilterEnvelope/A_dt",
+        "shortname": "a.dt",
+        "name"     : "A_dt",
+        "tooltip"  : "Attack Time",
+        "scale"    : "logarithmic",
+        "type"     : "f",
+        "range"    : [0.0f,41.0f],
+        "default"  : "0.00"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/GlobalFilterEnvelope/PA_val",
+        "shortname": "a.val",
+        "name"     : "PA_val",
+        "tooltip"  : "Attack Value",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/GlobalFilterEnvelope/PD_dt",
+        "shortname": "d.dt",
+        "name"     : "PD_dt",
+        "tooltip"  : "Decay Time",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/GlobalFilterEnvelope/D_dt",
+        "shortname": "d.dt",
+        "name"     : "D_dt",
+        "tooltip"  : "Decay Time",
+        "scale"    : "logarithmic",
+        "type"     : "f",
+        "range"    : [0.0f,41.0f],
+        "default"  : "0.00925031"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/GlobalFilterEnvelope/PD_val",
+        "shortname": "d.val",
+        "name"     : "PD_val",
+        "tooltip"  : "Decay Value",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/GlobalFilterEnvelope/PS_val",
+        "shortname": "s.val",
+        "name"     : "PS_val",
+        "tooltip"  : "Sustain Value",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/GlobalFilterEnvelope/PR_dt",
+        "shortname": "r.dt",
+        "name"     : "PR_dt",
+        "tooltip"  : "Release Time",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/GlobalFilterEnvelope/R_dt",
+        "shortname": "r.dt",
+        "name"     : "R_dt",
+        "tooltip"  : "Release Time",
+        "scale"    : "logarithmic",
+        "type"     : "f",
+        "range"    : [0.01f,41.0f],
+        "default"  : "0.498893"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/GlobalFilterEnvelope/PR_val",
+        "shortname": "r.val",
+        "name"     : "PR_val",
+        "tooltip"  : "Release Value",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/GlobalFilter/Pcategory",
+        "shortname": "class",
+        "name"     : "Pcategory",
+        "tooltip"  : "Class of filter",
+        "type"     : "i",
+        "default"  : "analog"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "analog"
+        },
+        {
+            "id"     : 1,
+            "value"  : "formant"
+        },
+        {
+            "id"     : 2,
+            "value"  : "st.var."
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/GlobalFilter/Ptype",
+        "shortname": "type",
+        "name"     : "Ptype",
+        "tooltip"  : "Filter Type",
+        "type"     : "i",
+        "default"  : "LP2"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "LP1"
+        },
+        {
+            "id"     : 1,
+            "value"  : "HP1"
+        },
+        {
+            "id"     : 2,
+            "value"  : "LP2"
+        },
+        {
+            "id"     : 3,
+            "value"  : "HP2"
+        },
+        {
+            "id"     : 4,
+            "value"  : "BP"
+        },
+        {
+            "id"     : 5,
+            "value"  : "notch"
+        },
+        {
+            "id"     : 6,
+            "value"  : "peak"
+        },
+        {
+            "id"     : 7,
+            "value"  : "l.shelf"
+        },
+        {
+            "id"     : 8,
+            "value"  : "h.shelf"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/GlobalFilter/Pstages",
+        "shortname": "stages",
+        "name"     : "Pstages",
+        "tooltip"  : "Filter Stages",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,5],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/GlobalFilter/baseq",
+        "shortname": "q",
+        "name"     : "baseq",
+        "tooltip"  : "Quality Factor (resonance/bandwidth)",
+        "units"    : "none",
+        "scale"    : "logarithmic",
+        "type"     : "f",
+        "range"    : [0.1,1000]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/GlobalFilter/basefreq",
+        "shortname": "cutoff",
+        "name"     : "basefreq",
+        "tooltip"  : "Base cutoff frequency",
+        "units"    : "Hz",
+        "scale"    : "logarithmic",
+        "type"     : "f",
+        "range"    : [31.25,32000]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/GlobalFilter/freqtracking",
+        "shortname": "f.track",
+        "name"     : "freqtracking",
+        "tooltip"  : "Frequency Tracking amount",
+        "units"    : "%",
+        "scale"    : "linear",
+        "type"     : "f",
+        "range"    : [-100,100],
+        "default"  : "0.0f"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/GlobalFilter/gain",
+        "shortname": "gain",
+        "name"     : "gain",
+        "tooltip"  : "Output Gain",
+        "units"    : "dB",
+        "scale"    : "linear",
+        "type"     : "f",
+        "range"    : [-30,30],
+        "default"  : "0.0f"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/GlobalFilter/Pnumformants",
+        "shortname": "formants",
+        "name"     : "Pnumformants",
+        "tooltip"  : "Number of formants to be used",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [1,12],
+        "default"  : "3"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/GlobalFilter/Pformantslowness",
+        "shortname": "slew",
+        "name"     : "Pformantslowness",
+        "tooltip"  : "Rate that formants change",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/GlobalFilter/Pvowelclearness",
+        "shortname": "clarity",
+        "name"     : "Pvowelclearness",
+        "tooltip"  : "How much each vowel is smudged with the next in sequence. A high clarity will avoid smudging.",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/GlobalFilter/Pcenterfreq",
+        "shortname": "cutoff",
+        "name"     : "Pcenterfreq",
+        "tooltip"  : "Center Freq (formant)",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/GlobalFilter/Poctavesfreq",
+        "shortname": "octaves",
+        "name"     : "Poctavesfreq",
+        "tooltip"  : "Number of octaves for formant",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/GlobalFilter/Psequencesize",
+        "shortname": "seq.size",
+        "name"     : "Psequencesize",
+        "tooltip"  : "Length of vowel sequence",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,8],
+        "default"  : "3"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/GlobalFilter/Psequencestretch",
+        "shortname": "seq.str",
+        "name"     : "Psequencestretch",
+        "tooltip"  : "How modulators stretch the sequence",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "40"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/GlobalFilter/Psequencereversed",
+        "shortname": "reverse",
+        "name"     : "Psequencereversed",
+        "tooltip"  : "If the modulator input is inverted",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/GlobalFilter/type-svf",
+        "shortname": "type",
+        "name"     : "type-svf",
+        "tooltip"  : "Filter Type",
+        "type"     : "i",
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "low"
+        },
+        {
+            "id"     : 1,
+            "value"  : "high"
+        },
+        {
+            "id"     : 2,
+            "value"  : "band"
+        },
+        {
+            "id"     : 3,
+            "value"  : "notch"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/GlobalFilter/Pvowels[0,5]/Pformants[0,11]/freq",
+        "shortname": "f.freq",
+        "name"     : "freq",
+        "tooltip"  : "Formant frequency",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/GlobalFilter/Pvowels[0,5]/Pformants[0,11]/amp",
+        "shortname": "f.str",
+        "name"     : "amp",
+        "tooltip"  : "Strength of formant",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "127"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/GlobalFilter/Pvowels[0,5]/Pformants[0,11]/q",
+        "shortname": "f.q",
+        "name"     : "q",
+        "tooltip"  : "The formant's quality factor, also known as resonance bandwidth or Q for short",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/Pstart",
+        "shortname": "initial",
+        "name"     : "Pstart",
+        "tooltip"  : "How harmonics are initialized",
+        "type"     : "i",
+        "default"  : "random"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "zero"
+        },
+        {
+            "id"     : 1,
+            "value"  : "random"
+        },
+        {
+            "id"     : 2,
+            "value"  : "ones"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/octave",
+        "shortname": "octave",
+        "name"     : "octave",
+        "tooltip"  : "Note octave shift",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [-8,7]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/subpars/coarsedetune",
+        "shortname": "coarse",
+        "name"     : "coarsedetune",
+        "tooltip"  : "Note coarse detune",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [-64,63]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/Penabled",
+        "name"     : "Penabled",
+        "tooltip"  : "Kit item enable",
+        "type"     : "t"
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/Pmuted",
+        "name"     : "Pmuted",
+        "tooltip"  : "Kit item mute",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/Pminkey",
+        "name"     : "Pminkey",
+        "tooltip"  : "Kit item min key",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/Pmaxkey",
+        "name"     : "Pmaxkey",
+        "tooltip"  : ":default",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/Padenabled",
+        "name"     : "Padenabled",
+        "tooltip"  : "ADsynth enable",
+        "type"     : "t"
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/Psubenabled",
+        "name"     : "Psubenabled",
+        "tooltip"  : "SUBsynth enable",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/Ppadenabled",
+        "name"     : "Ppadenabled",
+        "tooltip"  : "PADsynth enable",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/Psendtoparteffect",
+        "name"     : "Psendtoparteffect",
+        "tooltip"  : "Effect Levels",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "FX1"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "FX1"
+        },
+        {
+            "id"     : 1,
+            "value"  : "FX2"
+        },
+        {
+            "id"     : 2,
+            "value"  : "FX3"
+        },
+        {
+            "id"     : 3,
+            "value"  : "Off"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/kit[0,15]/Pname",
+        "name"     : "Pname",
+        "tooltip"  : "Kit User Specified Label",
+        "type"     : "s",
+        "default"  : "\"\""
+
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/filterpars/Pcategory",
+        "shortname": "class",
+        "name"     : "Pcategory",
+        "tooltip"  : "Class of filter",
+        "type"     : "i",
+        "default"  : "analog"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "analog"
+        },
+        {
+            "id"     : 1,
+            "value"  : "formant"
+        },
+        {
+            "id"     : 2,
+            "value"  : "st.var."
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/filterpars/Ptype",
+        "shortname": "type",
+        "name"     : "Ptype",
+        "tooltip"  : "Filter Type",
+        "type"     : "i",
+        "default"  : "LP2"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "LP1"
+        },
+        {
+            "id"     : 1,
+            "value"  : "HP1"
+        },
+        {
+            "id"     : 2,
+            "value"  : "LP2"
+        },
+        {
+            "id"     : 3,
+            "value"  : "HP2"
+        },
+        {
+            "id"     : 4,
+            "value"  : "BP"
+        },
+        {
+            "id"     : 5,
+            "value"  : "notch"
+        },
+        {
+            "id"     : 6,
+            "value"  : "peak"
+        },
+        {
+            "id"     : 7,
+            "value"  : "l.shelf"
+        },
+        {
+            "id"     : 8,
+            "value"  : "h.shelf"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/filterpars/Pstages",
+        "shortname": "stages",
+        "name"     : "Pstages",
+        "tooltip"  : "Filter Stages",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,5],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/filterpars/baseq",
+        "shortname": "q",
+        "name"     : "baseq",
+        "tooltip"  : "Quality Factor (resonance/bandwidth)",
+        "units"    : "none",
+        "scale"    : "logarithmic",
+        "type"     : "f",
+        "range"    : [0.1,1000]
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/filterpars/basefreq",
+        "shortname": "cutoff",
+        "name"     : "basefreq",
+        "tooltip"  : "Base cutoff frequency",
+        "units"    : "Hz",
+        "scale"    : "logarithmic",
+        "type"     : "f",
+        "range"    : [31.25,32000]
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/filterpars/freqtracking",
+        "shortname": "f.track",
+        "name"     : "freqtracking",
+        "tooltip"  : "Frequency Tracking amount",
+        "units"    : "%",
+        "scale"    : "linear",
+        "type"     : "f",
+        "range"    : [-100,100],
+        "default"  : "0.0f"
+
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/filterpars/gain",
+        "shortname": "gain",
+        "name"     : "gain",
+        "tooltip"  : "Output Gain",
+        "units"    : "dB",
+        "scale"    : "linear",
+        "type"     : "f",
+        "range"    : [-30,30],
+        "default"  : "0.0f"
+
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/filterpars/Pnumformants",
+        "shortname": "formants",
+        "name"     : "Pnumformants",
+        "tooltip"  : "Number of formants to be used",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [1,12],
+        "default"  : "3"
+
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/filterpars/Pformantslowness",
+        "shortname": "slew",
+        "name"     : "Pformantslowness",
+        "tooltip"  : "Rate that formants change",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/filterpars/Pvowelclearness",
+        "shortname": "clarity",
+        "name"     : "Pvowelclearness",
+        "tooltip"  : "How much each vowel is smudged with the next in sequence. A high clarity will avoid smudging.",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/filterpars/Pcenterfreq",
+        "shortname": "cutoff",
+        "name"     : "Pcenterfreq",
+        "tooltip"  : "Center Freq (formant)",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/filterpars/Poctavesfreq",
+        "shortname": "octaves",
+        "name"     : "Poctavesfreq",
+        "tooltip"  : "Number of octaves for formant",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/filterpars/Psequencesize",
+        "shortname": "seq.size",
+        "name"     : "Psequencesize",
+        "tooltip"  : "Length of vowel sequence",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,8],
+        "default"  : "3"
+
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/filterpars/Psequencestretch",
+        "shortname": "seq.str",
+        "name"     : "Psequencestretch",
+        "tooltip"  : "How modulators stretch the sequence",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "40"
+
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/filterpars/Psequencereversed",
+        "shortname": "reverse",
+        "name"     : "Psequencereversed",
+        "tooltip"  : "If the modulator input is inverted",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/filterpars/type-svf",
+        "shortname": "type",
+        "name"     : "type-svf",
+        "tooltip"  : "Filter Type",
+        "type"     : "i",
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "low"
+        },
+        {
+            "id"     : 1,
+            "value"  : "high"
+        },
+        {
+            "id"     : 2,
+            "value"  : "band"
+        },
+        {
+            "id"     : 3,
+            "value"  : "notch"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/filterpars/Pvowels[0,5]/Pformants[0,11]/freq",
+        "shortname": "f.freq",
+        "name"     : "freq",
+        "tooltip"  : "Formant frequency",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/filterpars/Pvowels[0,5]/Pformants[0,11]/amp",
+        "shortname": "f.str",
+        "name"     : "amp",
+        "tooltip"  : "Strength of formant",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "127"
+
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/filterpars/Pvowels[0,5]/Pformants[0,11]/q",
+        "shortname": "f.q",
+        "name"     : "q",
+        "tooltip"  : "The formant's quality factor, also known as resonance bandwidth or Q for short",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Pvolume",
+        "shortname": "amt",
+        "name"     : "Pvolume",
+        "tooltip"  : "amount of effect",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Ppanning",
+        "shortname": "pan",
+        "name"     : "Ppanning",
+        "tooltip"  : "panning",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/parameter[0,127]",
+        "name"     : "parameter#128",
+        "tooltip"  : "Parameter Accessor",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/preset",
+        "name"     : "preset",
+        "tooltip"  : "Effect Preset Selector",
+        "type"     : "i",
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/efftype",
+        "name"     : "efftype",
+        "tooltip"  : "Get Effect Type",
+        "type"     : "i",
+        "default"  : "Disabled"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "Disabled"
+        },
+        {
+            "id"     : 1,
+            "value"  : "Reverb"
+        },
+        {
+            "id"     : 2,
+            "value"  : "Echo"
+        },
+        {
+            "id"     : 3,
+            "value"  : "Chorus"
+        },
+        {
+            "id"     : 4,
+            "value"  : "Phaser"
+        },
+        {
+            "id"     : 5,
+            "value"  : "Alienwah"
+        },
+        {
+            "id"     : 6,
+            "value"  : "Distortion"
+        },
+        {
+            "id"     : 7,
+            "value"  : "EQ"
+        },
+        {
+            "id"     : 8,
+            "value"  : "DynFilter"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Alienwah/preset",
+        "name"     : "preset",
+        "tooltip"  : "Instrument Presets",
+        "type"     : "i",
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "wah 1"
+        },
+        {
+            "id"     : 1,
+            "value"  : "wah 2"
+        },
+        {
+            "id"     : 2,
+            "value"  : "wah 3"
+        },
+        {
+            "id"     : 3,
+            "value"  : "wah 4"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Alienwah/Pvolume",
+        "shortname": "amt",
+        "name"     : "Pvolume",
+        "tooltip"  : "amount of effect",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "127"
+
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Alienwah/Ppanning",
+        "shortname": "pan",
+        "name"     : "Ppanning",
+        "tooltip"  : "panning",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Alienwah/Pfreq",
+        "shortname": "freq",
+        "name"     : "Pfreq",
+        "tooltip"  : "Effect Frequency",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Alienwah/Pfreqrnd",
+        "shortname": "rand",
+        "name"     : "Pfreqrnd",
+        "tooltip"  : "Frequency Randomness",
+        "type"     : "i",
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Alienwah/PLFOtype",
+        "shortname": "shape",
+        "name"     : "PLFOtype",
+        "tooltip"  : "LFO Shape",
+        "type"     : "i",
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "sine"
+        },
+        {
+            "id"     : 1,
+            "value"  : "triangle"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Alienwah/PStereo",
+        "shortname": "stereo",
+        "name"     : "PStereo",
+        "tooltip"  : "Stereo Mode",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Alienwah/Pdepth",
+        "shortname": "depth",
+        "name"     : "Pdepth",
+        "tooltip"  : "LFO Depth",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Alienwah/Pfeedback",
+        "shortname": "fb",
+        "name"     : "Pfeedback",
+        "tooltip"  : "Feedback",
+        "type"     : "i",
+        "default"  : "105"
+
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Alienwah/Pdelay",
+        "shortname": "delay",
+        "name"     : "Pdelay",
+        "tooltip"  : "Delay",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [1,100]
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Alienwah/Plrcross",
+        "shortname": "l/r",
+        "name"     : "Plrcross",
+        "tooltip"  : "Left/Right Crossover",
+        "type"     : "i",
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Alienwah/Pphase",
+        "shortname": "phase",
+        "name"     : "Pphase",
+        "tooltip"  : "Phase",
+        "type"     : "i",
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Chorus/preset",
+        "name"     : "preset",
+        "tooltip"  : "Instrument Presets",
+        "type"     : "i",
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "Chorus1"
+        },
+        {
+            "id"     : 1,
+            "value"  : "Chorus2"
+        },
+        {
+            "id"     : 2,
+            "value"  : "Chorus3"
+        },
+        {
+            "id"     : 3,
+            "value"  : "Celeste1"
+        },
+        {
+            "id"     : 4,
+            "value"  : "Celeste2"
+        },
+        {
+            "id"     : 5,
+            "value"  : "Flange1"
+        },
+        {
+            "id"     : 6,
+            "value"  : "Flange2"
+        },
+        {
+            "id"     : 7,
+            "value"  : "Flange3"
+        },
+        {
+            "id"     : 8,
+            "value"  : "Flange4"
+        },
+        {
+            "id"     : 9,
+            "value"  : "Flange5"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Chorus/Pvolume",
+        "shortname": "amt",
+        "name"     : "Pvolume",
+        "tooltip"  : "amount of effect",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Chorus/Ppanning",
+        "shortname": "pan",
+        "name"     : "Ppanning",
+        "tooltip"  : "panning",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Chorus/Pfreq",
+        "shortname": "freq",
+        "name"     : "Pfreq",
+        "tooltip"  : "Effect Frequency",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Chorus/Pfreqrnd",
+        "shortname": "rand",
+        "name"     : "Pfreqrnd",
+        "tooltip"  : "Frequency Randomness",
+        "type"     : "i",
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Chorus/PLFOtype",
+        "shortname": "shape",
+        "name"     : "PLFOtype",
+        "tooltip"  : "LFO Shape",
+        "type"     : "i",
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "sine"
+        },
+        {
+            "id"     : 1,
+            "value"  : "tri"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Chorus/PStereo",
+        "shortname": "stereo",
+        "name"     : "PStereo",
+        "tooltip"  : "Stereo Mode",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Chorus/Pdepth",
+        "shortname": "depth",
+        "name"     : "Pdepth",
+        "tooltip"  : "LFO Depth",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Chorus/Pdelay",
+        "shortname": "delay",
+        "name"     : "Pdelay",
+        "tooltip"  : "Delay",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Chorus/Pfeedback",
+        "shortname": "fb",
+        "name"     : "Pfeedback",
+        "tooltip"  : "Feedback",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Chorus/Plrcross",
+        "shortname": "l/r",
+        "name"     : "Plrcross",
+        "tooltip"  : "Left/Right Crossover",
+        "type"     : "i",
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Chorus/Pflangemode",
+        "shortname": "flange",
+        "name"     : "Pflangemode",
+        "tooltip"  : "Flange Mode",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Chorus/Poutsub",
+        "shortname": "sub",
+        "name"     : "Poutsub",
+        "tooltip"  : "Output Subtraction",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Distorsion/preset",
+        "name"     : "preset",
+        "tooltip"  : "Instrument Presets",
+        "type"     : "i",
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "Overdrive 1"
+        },
+        {
+            "id"     : 1,
+            "value"  : "Overdrive 2"
+        },
+        {
+            "id"     : 2,
+            "value"  : "A. Exciter 1"
+        },
+        {
+            "id"     : 3,
+            "value"  : "A. Exciter 2"
+        },
+        {
+            "id"     : 4,
+            "value"  : "Guitar Amp"
+        },
+        {
+            "id"     : 5,
+            "value"  : "Quantisize"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Distorsion/Pvolume",
+        "shortname": "amt",
+        "name"     : "Pvolume",
+        "tooltip"  : "amount of effect",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "127"
+
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Distorsion/Ppanning",
+        "shortname": "pan",
+        "name"     : "Ppanning",
+        "tooltip"  : "panning",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Distorsion/Plrcross",
+        "shortname": "l/r",
+        "name"     : "Plrcross",
+        "tooltip"  : "Left/Right Crossover",
+        "type"     : "i",
+        "default"  : "35"
+
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Distorsion/Pdrive",
+        "shortname": "drive",
+        "name"     : "Pdrive",
+        "tooltip"  : "Input amplification",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Distorsion/Plevel",
+        "shortname": "output",
+        "name"     : "Plevel",
+        "tooltip"  : "Output amplification",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Distorsion/Ptype",
+        "shortname": "type",
+        "name"     : "Ptype",
+        "tooltip"  : "Distortion Shape",
+        "type"     : "i",
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "Arctangent"
+        },
+        {
+            "id"     : 1,
+            "value"  : "Asymmetric"
+        },
+        {
+            "id"     : 2,
+            "value"  : "Pow"
+        },
+        {
+            "id"     : 3,
+            "value"  : "Sine"
+        },
+        {
+            "id"     : 4,
+            "value"  : "Quantisize"
+        },
+        {
+            "id"     : 5,
+            "value"  : "Zigzag"
+        },
+        {
+            "id"     : 6,
+            "value"  : "Limiter"
+        },
+        {
+            "id"     : 7,
+            "value"  : "Upper Limiter"
+        },
+        {
+            "id"     : 8,
+            "value"  : "Lower Limiter"
+        },
+        {
+            "id"     : 9,
+            "value"  : "Inverse Limiter"
+        },
+        {
+            "id"     : 10,
+            "value"  : "Clip"
+        },
+        {
+            "id"     : 11,
+            "value"  : "Asym2"
+        },
+        {
+            "id"     : 12,
+            "value"  : "Pow2"
+        },
+        {
+            "id"     : 13,
+            "value"  : "Sigmoid"
+        },
+        {
+            "id"     : 14,
+            "value"  : "Tanh"
+        },
+        {
+            "id"     : 15,
+            "value"  : "Cubic"
+        },
+        {
+            "id"     : 16,
+            "value"  : "Square"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Distorsion/Pnegate",
+        "shortname": "neg",
+        "name"     : "Pnegate",
+        "tooltip"  : "Negate Signal",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Distorsion/Plpf",
+        "shortname": "lpf",
+        "name"     : "Plpf",
+        "tooltip"  : "Low Pass Cutoff",
+        "type"     : "i",
+        "default"  : "127"
+
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Distorsion/Phpf",
+        "shortname": "hpf",
+        "name"     : "Phpf",
+        "tooltip"  : "High Pass Cutoff",
+        "type"     : "i",
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Distorsion/Pstereo",
+        "shortname": "stereo",
+        "name"     : "Pstereo",
+        "tooltip"  : "Stereo",
+        "type"     : "t"
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Distorsion/Pprefiltering",
+        "shortname": "p.filt",
+        "name"     : "Pprefiltering",
+        "tooltip"  : "Filtering before/after non-linearity",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Distorsion/Pfuncpar",
+        "shortname": "shape",
+        "name"     : "Pfuncpar",
+        "tooltip"  : "Shape of the wave shaping function",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "32"
+
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Distorsion/Poffset",
+        "shortname": "offset",
+        "name"     : "Poffset",
+        "tooltip"  : "Input DC Offset",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/DynamicFilter/Pvolume",
+        "shortname": "amt",
+        "name"     : "Pvolume",
+        "tooltip"  : "amount of effect",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "110"
+
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/DynamicFilter/Ppanning",
+        "shortname": "pan",
+        "name"     : "Ppanning",
+        "tooltip"  : "panning",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/DynamicFilter/Pfreq",
+        "shortname": "freq",
+        "name"     : "Pfreq",
+        "tooltip"  : "Effect Frequency",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/DynamicFilter/Pfreqrnd",
+        "shortname": "rand",
+        "name"     : "Pfreqrnd",
+        "tooltip"  : "Frequency Randomness",
+        "type"     : "i",
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/DynamicFilter/PLFOtype",
+        "shortname": "shape",
+        "name"     : "PLFOtype",
+        "tooltip"  : "LFO Shape",
+        "type"     : "i",
+        "default"  : "sin"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "sin"
+        },
+        {
+            "id"     : 1,
+            "value"  : "tri"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/DynamicFilter/PStereo",
+        "shortname": "stereo",
+        "name"     : "PStereo",
+        "tooltip"  : "Stereo Mode",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/DynamicFilter/Pdepth",
+        "shortname": "depth",
+        "name"     : "Pdepth",
+        "tooltip"  : "LFO Depth",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/DynamicFilter/Pampsns",
+        "shortname": "sense",
+        "name"     : "Pampsns",
+        "tooltip"  : "how the filter varies according to the input amplitude",
+        "type"     : "i",
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/DynamicFilter/Pampsnsinv",
+        "shortname": "sns.inv",
+        "name"     : "Pampsnsinv",
+        "tooltip"  : "Sense Inversion",
+        "type"     : "i",
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/DynamicFilter/Pampsmooth",
+        "shortname": "smooth",
+        "name"     : "Pampsmooth",
+        "tooltip"  : "how smooth the input amplitude changes the filter",
+        "type"     : "i",
+        "default"  : "60"
+
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Echo/preset",
+        "name"     : "preset",
+        "tooltip"  : "Instrument Presets",
+        "type"     : "i",
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "Echo 1"
+        },
+        {
+            "id"     : 1,
+            "value"  : "Echo 2"
+        },
+        {
+            "id"     : 2,
+            "value"  : "Echo 3"
+        },
+        {
+            "id"     : 3,
+            "value"  : "Simple Echo"
+        },
+        {
+            "id"     : 4,
+            "value"  : "Canyon"
+        },
+        {
+            "id"     : 5,
+            "value"  : "Panning Echo 1"
+        },
+        {
+            "id"     : 6,
+            "value"  : "Panning Echo 2"
+        },
+        {
+            "id"     : 7,
+            "value"  : "Panning Echo 3"
+        },
+        {
+            "id"     : 8,
+            "value"  : "Feedback Echo"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Echo/Pvolume",
+        "shortname": "amt",
+        "name"     : "Pvolume",
+        "tooltip"  : "amount of effect",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "67"
+
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Echo/Ppanning",
+        "shortname": "pan",
+        "name"     : "Ppanning",
+        "tooltip"  : "panning",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Echo/Pdelay",
+        "shortname": "delay",
+        "name"     : "Pdelay",
+        "tooltip"  : "Length of Echo",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Echo/Plrdelay",
+        "shortname": "lr delay",
+        "name"     : "Plrdelay",
+        "tooltip"  : "Difference In Left/Right Delay",
+        "type"     : "i",
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Echo/Plrcross",
+        "shortname": "cross",
+        "name"     : "Plrcross",
+        "tooltip"  : "Left/Right Crossover",
+        "type"     : "i",
+        "default"  : "30"
+
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Echo/Pfb",
+        "shortname": "feedback",
+        "name"     : "Pfb",
+        "tooltip"  : "Echo Feedback",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Echo/Phidamp",
+        "shortname": "damp",
+        "name"     : "Phidamp",
+        "tooltip"  : "Dampen High Frequencies",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/EQ/filter[0,7]/Ptype",
+        "shortname": "type",
+        "name"     : "Ptype",
+        "tooltip"  : "Filter Type",
+        "type"     : "i",
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "Off"
+        },
+        {
+            "id"     : 1,
+            "value"  : "LP1"
+        },
+        {
+            "id"     : 2,
+            "value"  : "HP1"
+        },
+        {
+            "id"     : 3,
+            "value"  : "LP2"
+        },
+        {
+            "id"     : 4,
+            "value"  : "HP2"
+        },
+        {
+            "id"     : 5,
+            "value"  : "BP"
+        },
+        {
+            "id"     : 6,
+            "value"  : "notch"
+        },
+        {
+            "id"     : 7,
+            "value"  : "peak"
+        },
+        {
+            "id"     : 8,
+            "value"  : "l.shelf"
+        },
+        {
+            "id"     : 9,
+            "value"  : "h.shelf"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/EQ/filter[0,7]/Pfreq",
+        "shortname": "freq",
+        "name"     : "Pfreq",
+        "tooltip"  : "",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/EQ/filter[0,7]/Pgain",
+        "shortname": "gain",
+        "name"     : "Pgain",
+        "tooltip"  : "",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/EQ/filter[0,7]/Pq",
+        "shortname": "q",
+        "name"     : "Pq",
+        "tooltip"  : "Resonance/Bandwidth",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/EQ/filter[0,7]/Pstages",
+        "shortname": "stages",
+        "name"     : "Pstages",
+        "tooltip"  : "Additional filter stages",
+        "type"     : "i",
+        "range"    : [0,4]
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Phaser/preset",
+        "name"     : "preset",
+        "tooltip"  : "Instrument Presets",
+        "type"     : "i",
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "Phaser 1"
+        },
+        {
+            "id"     : 1,
+            "value"  : "Phaser 2"
+        },
+        {
+            "id"     : 2,
+            "value"  : "Phaser 3"
+        },
+        {
+            "id"     : 3,
+            "value"  : "Phaser 4"
+        },
+        {
+            "id"     : 4,
+            "value"  : "Phaser 5"
+        },
+        {
+            "id"     : 5,
+            "value"  : "Phaser 6"
+        },
+        {
+            "id"     : 6,
+            "value"  : "APhaser 1"
+        },
+        {
+            "id"     : 7,
+            "value"  : "APhaser 2"
+        },
+        {
+            "id"     : 8,
+            "value"  : "APhaser 3"
+        },
+        {
+            "id"     : 9,
+            "value"  : "APhaser 4"
+        },
+        {
+            "id"     : 10,
+            "value"  : "APhaser 5"
+        },
+        {
+            "id"     : 11,
+            "value"  : "APhaser 6"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Phaser/Pvolume",
+        "shortname": "amt",
+        "name"     : "Pvolume",
+        "tooltip"  : "amount of effect",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Phaser/Ppanning",
+        "shortname": "pan",
+        "name"     : "Ppanning",
+        "tooltip"  : "panning",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Phaser/lfo.Pfreq",
+        "shortname": "freq",
+        "name"     : "lfo.Pfreq",
+        "tooltip"  : "LFO frequency",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Phaser/lfo.Prandomness",
+        "shortname": "rnd.",
+        "name"     : "lfo.Prandomness",
+        "tooltip"  : "LFO randomness",
+        "type"     : "i",
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Phaser/lfo.PLFOtype",
+        "shortname": "type",
+        "name"     : "lfo.PLFOtype",
+        "tooltip"  : "lfo shape",
+        "type"     : "i",
+        "default"  : "sine"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "sine"
+        },
+        {
+            "id"     : 1,
+            "value"  : "tri"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Phaser/lfo.Pstereo",
+        "shortname": "stereo",
+        "name"     : "lfo.Pstereo",
+        "tooltip"  : "Left/right channel phase shift",
+        "type"     : "i",
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Phaser/Pdepth",
+        "shortname": "depth",
+        "name"     : "Pdepth",
+        "tooltip"  : "LFP depth",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Phaser/Pfb",
+        "shortname": "fb",
+        "name"     : "Pfb",
+        "tooltip"  : "Feedback",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Phaser/Pstages",
+        "shortname": "stages",
+        "name"     : "Pstages",
+        "tooltip"  : "",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [1,12]
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Phaser/Plrcross",
+        "shortname": "cross",
+        "name"     : "Plrcross",
+        "tooltip"  : "Channel routing",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Phaser/Poffset",
+        "shortname": "off",
+        "name"     : "Poffset",
+        "tooltip"  : "Offset",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Phaser/Poutsub",
+        "shortname": "sub",
+        "name"     : "Poutsub",
+        "tooltip"  : "Invert output",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Phaser/Pphase",
+        "shortname": "phase",
+        "name"     : "Pphase",
+        "tooltip"  : "",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Phaser/Pwidth",
+        "shortname": "width",
+        "name"     : "Pwidth",
+        "tooltip"  : "",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Phaser/Phyper",
+        "shortname": "hyp.",
+        "name"     : "Phyper",
+        "tooltip"  : "Square the LFO",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Phaser/Pdistortion",
+        "shortname": "distort",
+        "name"     : "Pdistortion",
+        "tooltip"  : "Distortion",
+        "type"     : "i",
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Phaser/Panalog",
+        "shortname": "analog",
+        "name"     : "Panalog",
+        "tooltip"  : "Use analog phaser",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Reverb/preset",
+        "name"     : "preset",
+        "tooltip"  : "Instrument Presets",
+        "type"     : "i",
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "Cathedral1"
+        },
+        {
+            "id"     : 1,
+            "value"  : "Cathedral2"
+        },
+        {
+            "id"     : 2,
+            "value"  : "Cathedral3"
+        },
+        {
+            "id"     : 3,
+            "value"  : "Hall1"
+        },
+        {
+            "id"     : 4,
+            "value"  : "Hall2"
+        },
+        {
+            "id"     : 5,
+            "value"  : "Room1"
+        },
+        {
+            "id"     : 6,
+            "value"  : "Room2"
+        },
+        {
+            "id"     : 7,
+            "value"  : "Basement"
+        },
+        {
+            "id"     : 8,
+            "value"  : "Tunnel"
+        },
+        {
+            "id"     : 9,
+            "value"  : "Echoed1"
+        },
+        {
+            "id"     : 10,
+            "value"  : "Echoed2"
+        },
+        {
+            "id"     : 11,
+            "value"  : "VeryLong1"
+        },
+        {
+            "id"     : 12,
+            "value"  : "VeryLong2"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Reverb/Pvolume",
+        "shortname": "amt",
+        "name"     : "Pvolume",
+        "tooltip"  : "amount of effect",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "90"
+
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Reverb/Ppanning",
+        "shortname": "pan",
+        "name"     : "Ppanning",
+        "tooltip"  : "panning",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Reverb/Ptime",
+        "shortname": "time",
+        "name"     : "Ptime",
+        "tooltip"  : "Length of Reverb",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Reverb/Pidelay",
+        "shortname": "i.time",
+        "name"     : "Pidelay",
+        "tooltip"  : "Delay for first impulse",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Reverb/Pidelayfb",
+        "shortname": "i.fb",
+        "name"     : "Pidelayfb",
+        "tooltip"  : "Feedback for first impulse",
+        "type"     : "i",
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Reverb/Plpf",
+        "shortname": "lpf",
+        "name"     : "Plpf",
+        "tooltip"  : "Low pass filter",
+        "type"     : "i",
+        "default"  : "127"
+
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Reverb/Phpf",
+        "shortname": "hpf",
+        "name"     : "Phpf",
+        "tooltip"  : "High pass filter",
+        "type"     : "i",
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Reverb/Plohidamp",
+        "shortname": "damp",
+        "name"     : "Plohidamp",
+        "tooltip"  : ":default 0",
+        "type"     : "i",
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Reverb/Ptype",
+        "shortname": "type",
+        "name"     : "Ptype",
+        "tooltip"  : "Type",
+        "type"     : "i",
+        "default"  : "Random"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "Random"
+        },
+        {
+            "id"     : 1,
+            "value"  : "Freeverb"
+        },
+        {
+            "id"     : 2,
+            "value"  : "Bandwidth"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Reverb/Proomsize",
+        "shortname": "size",
+        "name"     : "Proomsize",
+        "tooltip"  : "Room Size",
+        "type"     : "i",
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/partefx[0,2]/Reverb/Pbandwidth",
+        "shortname": "bw",
+        "name"     : "Pbandwidth",
+        "tooltip"  : "Bandwidth",
+        "type"     : "i",
+        "default"  : "20"
+
+    },
+    {
+        "path"     : "/part[0,15]/ctl/panning.depth",
+        "shortname": "pan.d",
+        "name"     : "panning.depth",
+        "tooltip"  : "Depth of Panning MIDI Control",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/ctl/filtercutoff.depth",
+        "shortname": "fc.d",
+        "name"     : "filtercutoff.depth",
+        "tooltip"  : "Depth of Filter Cutoff MIDI Control",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/ctl/filterq.depth",
+        "shortname": "fq.d",
+        "name"     : "filterq.depth",
+        "tooltip"  : "Depth of Filter Q MIDI Control",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/ctl/bandwidth.depth",
+        "shortname": "bw.d",
+        "name"     : "bandwidth.depth",
+        "tooltip"  : "Depth of Bandwidth MIDI Control",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/ctl/bandwidth.exponential",
+        "shortname": "bw.exp",
+        "name"     : "bandwidth.exponential",
+        "tooltip"  : "Bandwidth Exponential Mode",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/ctl/modwheel.depth",
+        "shortname": "mdw.d",
+        "name"     : "modwheel.depth",
+        "tooltip"  : "Depth of Modwheel MIDI Control",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "80"
+
+    },
+    {
+        "path"     : "/part[0,15]/ctl/modwheel.exponential",
+        "shortname": "mdw.exp",
+        "name"     : "modwheel.exponential",
+        "tooltip"  : "Modwheel Exponential Mode",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/ctl/pitchwheel.is_split",
+        "name"     : "pitchwheel.is_split",
+        "tooltip"  : "If PitchWheel has unified bendrange or not",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/ctl/pitchwheel.bendrange",
+        "shortname": "pch.d",
+        "name"     : "pitchwheel.bendrange",
+        "tooltip"  : "Range of MIDI Pitch Wheel",
+        "units"    : "% of semitone",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [-6400,6400],
+        "default"  : "200"
+
+    },
+    {
+        "path"     : "/part[0,15]/ctl/pitchwheel.bendrange_down",
+        "name"     : "pitchwheel.bendrange_down",
+        "tooltip"  : "Lower Range of MIDI Pitch Wheel",
+        "type"     : "i",
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/ctl/expression.receive",
+        "shortname": "exp.rcv",
+        "name"     : "expression.receive",
+        "tooltip"  : "Expression MIDI Receive",
+        "type"     : "t",
+        "default"  : "true"
+
+    },
+    {
+        "path"     : "/part[0,15]/ctl/fmamp.receive",
+        "shortname": "fma.rcv",
+        "name"     : "fmamp.receive",
+        "tooltip"  : "FM amplitude MIDI Receive",
+        "type"     : "t",
+        "default"  : "true"
+
+    },
+    {
+        "path"     : "/part[0,15]/ctl/volume.receive",
+        "shortname": "vol.rcv",
+        "name"     : "volume.receive",
+        "tooltip"  : "Volume MIDI Receive",
+        "type"     : "t",
+        "default"  : "true"
+
+    },
+    {
+        "path"     : "/part[0,15]/ctl/sustain.receive",
+        "shortname": "sus.rcv",
+        "name"     : "sustain.receive",
+        "tooltip"  : "Sustain MIDI Receive",
+        "type"     : "t",
+        "default"  : "true"
+
+    },
+    {
+        "path"     : "/part[0,15]/ctl/portamento.receive",
+        "shortname": "prt.rcv",
+        "name"     : "portamento.receive",
+        "tooltip"  : "Portamento MIDI Receive",
+        "type"     : "t",
+        "default"  : "true"
+
+    },
+    {
+        "path"     : "/part[0,15]/ctl/portamento.portamento",
+        "name"     : "portamento.portamento",
+        "tooltip"  : "Portamento Enable",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/ctl/portamento.time",
+        "shortname": "time",
+        "name"     : "portamento.time",
+        "tooltip"  : "Portamento Length",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/ctl/portamento.proportional",
+        "shortname": "propt.",
+        "name"     : "portamento.proportional",
+        "tooltip"  : "Whether the portamento time is proportionalto the size of the interval between two notes.",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/ctl/portamento.propRate",
+        "shortname": "scale",
+        "name"     : "portamento.propRate",
+        "tooltip"  : "Portamento proportional scale",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "80"
+
+    },
+    {
+        "path"     : "/part[0,15]/ctl/portamento.propDepth",
+        "shortname": "depth",
+        "name"     : "portamento.propDepth",
+        "tooltip"  : "Portamento proportional depth",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "90"
+
+    },
+    {
+        "path"     : "/part[0,15]/ctl/portamento.pitchthresh",
+        "shortname": "thresh",
+        "name"     : "portamento.pitchthresh",
+        "tooltip"  : "Threshold for portamento",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "3"
+
+    },
+    {
+        "path"     : "/part[0,15]/ctl/portamento.pitchthreshtype",
+        "shortname": "tr.type",
+        "name"     : "portamento.pitchthreshtype",
+        "tooltip"  : "Type of threshold",
+        "type"     : "t",
+        "default"  : "true"
+
+    },
+    {
+        "path"     : "/part[0,15]/ctl/portamento.updowntimestretch",
+        "shortname": "up/dwn",
+        "name"     : "portamento.updowntimestretch",
+        "tooltip"  : "Relative length of glide up vs glide down",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/ctl/resonancecenter.depth",
+        "shortname": "rfc.d",
+        "name"     : "resonancecenter.depth",
+        "tooltip"  : "Resonance Center MIDI Depth",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/ctl/resonancebandwidth.depth",
+        "shortname": "rbw.d",
+        "name"     : "resonancebandwidth.depth",
+        "tooltip"  : "Resonance Bandwidth MIDI Depth",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/ctl/NRPN.receive",
+        "name"     : "NRPN.receive",
+        "tooltip"  : "NRPN MIDI Enable",
+        "type"     : "t",
+        "default"  : "true"
+
+    },
+    {
+        "path"     : "/part[0,15]/Penabled",
+        "shortname": "enable",
+        "name"     : "Penabled",
+        "tooltip"  : "Part enable",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/Volume",
+        "shortname": "Vol",
+        "name"     : "Volume",
+        "tooltip"  : "Part Volume",
+        "units"    : "dB",
+        "scale"    : "linear",
+        "type"     : "f",
+        "range"    : [-40.0,13.3333],
+        "default"  : "0.0"
+
+    },
+    {
+        "path"     : "/part[0,15]/Pvolume",
+        "shortname": "Vol",
+        "name"     : "Pvolume",
+        "tooltip"  : "Part Volume",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "96"
+
+    },
+    {
+        "path"     : "/part[0,15]/Ppanning",
+        "shortname": "pan",
+        "name"     : "Ppanning",
+        "tooltip"  : "Set Panning",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/Pkeylimit",
+        "shortname": "limit",
+        "name"     : "Pkeylimit",
+        "tooltip"  : "Key limit per part",
+        "type"     : "i",
+        "range"    : [0,60],
+        "default"  : "15"
+
+    },
+    {
+        "path"     : "/part[0,15]/Pminkey",
+        "shortname": "min",
+        "name"     : "Pminkey",
+        "tooltip"  : "Min Used Key",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/Pmaxkey",
+        "shortname": "max",
+        "name"     : "Pmaxkey",
+        "tooltip"  : "Max Used Key",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "127"
+
+    },
+    {
+        "path"     : "/part[0,15]/Pkeyshift",
+        "shortname": "shift",
+        "name"     : "Pkeyshift",
+        "tooltip"  : "Part keyshift",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/Prcvchn",
+        "name"     : "Prcvchn",
+        "tooltip"  : "Active MIDI channel",
+        "type"     : "i",
+        "range"    : [0,127],
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "ch1"
+        },
+        {
+            "id"     : 1,
+            "value"  : "ch2"
+        },
+        {
+            "id"     : 2,
+            "value"  : "ch3"
+        },
+        {
+            "id"     : 3,
+            "value"  : "ch4"
+        },
+        {
+            "id"     : 4,
+            "value"  : "ch5"
+        },
+        {
+            "id"     : 5,
+            "value"  : "ch6"
+        },
+        {
+            "id"     : 6,
+            "value"  : "ch7"
+        },
+        {
+            "id"     : 7,
+            "value"  : "ch8"
+        },
+        {
+            "id"     : 8,
+            "value"  : "ch9"
+        },
+        {
+            "id"     : 9,
+            "value"  : "ch10"
+        },
+        {
+            "id"     : 10,
+            "value"  : "ch11"
+        },
+        {
+            "id"     : 11,
+            "value"  : "ch12"
+        },
+        {
+            "id"     : 12,
+            "value"  : "ch13"
+        },
+        {
+            "id"     : 13,
+            "value"  : "ch14"
+        },
+        {
+            "id"     : 14,
+            "value"  : "ch15"
+        },
+        {
+            "id"     : 15,
+            "value"  : "ch16"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/Pvelsns",
+        "shortname": "sense",
+        "name"     : "Pvelsns",
+        "tooltip"  : "Velocity sensing",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/Pveloffs",
+        "shortname": "offset",
+        "name"     : "Pveloffs",
+        "tooltip"  : "Velocity offset",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/part[0,15]/Pnoteon",
+        "name"     : "Pnoteon",
+        "tooltip"  : "If the channel accepts note on events",
+        "type"     : "t",
+        "default"  : "true"
+
+    },
+    {
+        "path"     : "/part[0,15]/Pkitmode",
+        "name"     : "Pkitmode",
+        "tooltip"  : "Kit mode/enable\nOff        - Only the first kit is ever utilized\nMulti-kit  - Every applicable kit is run for a note\nSingle-kit - The first applicable kit is run for a given note",
+        "type"     : "i",
+        "default"  : "Off"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "Off"
+        },
+        {
+            "id"     : 1,
+            "value"  : "Multi-Kit"
+        },
+        {
+            "id"     : 2,
+            "value"  : "Single-Kit"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/Pdrummode",
+        "name"     : "Pdrummode",
+        "tooltip"  : "Drum mode enable\nWhen drum mode is enabled all keys are mapped to 12tET and legato is disabled",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/Ppolymode",
+        "name"     : "Ppolymode",
+        "tooltip"  : "Polyphony mode",
+        "type"     : "t",
+        "default"  : "true"
+
+    },
+    {
+        "path"     : "/part[0,15]/Plegatomode",
+        "name"     : "Plegatomode",
+        "tooltip"  : "Legato mode",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/part[0,15]/info.Ptype",
+        "name"     : "info.Ptype",
+        "tooltip"  : "Class of Instrument",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/part[0,15]/info.Pauthor",
+        "name"     : "info.Pauthor",
+        "tooltip"  : "Instrument author",
+        "type"     : "s",
+        "default"  : "\"\""
+
+    },
+    {
+        "path"     : "/part[0,15]/info.Pcomments",
+        "name"     : "info.Pcomments",
+        "tooltip"  : "Instrument comments",
+        "type"     : "s",
+        "default"  : "\"\""
+
+    },
+    {
+        "path"     : "/part[0,15]/Pname",
+        "name"     : "Pname",
+        "tooltip"  : "User specified label",
+        "type"     : "s",
+        "default"  : "\"\""
+
+    },
+    {
+        "path"     : "/part[0,15]/Pefxroute[0,2]",
+        "name"     : "Pefxroute#3",
+        "tooltip"  : "Effect Routing",
+        "type"     : "i",
+        "default"  : "[\"Next Effect\"S...]"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "Next Effect"
+        },
+        {
+            "id"     : 1,
+            "value"  : "Part Out"
+        },
+        {
+            "id"     : 2,
+            "value"  : "Dry Out"
+        }
+        ]
+    },
+    {
+        "path"     : "/part[0,15]/Pefxbypass[0,2]",
+        "name"     : "Pefxbypass#3",
+        "tooltip"  : "If an effect is bypassed",
+        "type"     : "t",
+        "default"  : "[false...]"
+
+    },
+    {
+        "path"     : "/part[0,15]/polyType",
+        "name"     : "polyType",
+        "tooltip"  : "Synthesis polyphony type\nPolyphonic - Each note is played independently\nMonophonic - A single note is played at a time with envelopes resetting between notes\nLegato     - A single note is played at a time without envelopes resetting between notes\n",
+        "type"     : "i",
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "Polyphonic"
+        },
+        {
+            "id"     : 1,
+            "value"  : "Monophonic"
+        },
+        {
+            "id"     : 2,
+            "value"  : "Legato"
+        }
+        ]
+    },
+    {
+        "path"     : "/sysefx[0,3]/filterpars/Pcategory",
+        "shortname": "class",
+        "name"     : "Pcategory",
+        "tooltip"  : "Class of filter",
+        "type"     : "i",
+        "default"  : "analog"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "analog"
+        },
+        {
+            "id"     : 1,
+            "value"  : "formant"
+        },
+        {
+            "id"     : 2,
+            "value"  : "st.var."
+        }
+        ]
+    },
+    {
+        "path"     : "/sysefx[0,3]/filterpars/Ptype",
+        "shortname": "type",
+        "name"     : "Ptype",
+        "tooltip"  : "Filter Type",
+        "type"     : "i",
+        "default"  : "LP2"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "LP1"
+        },
+        {
+            "id"     : 1,
+            "value"  : "HP1"
+        },
+        {
+            "id"     : 2,
+            "value"  : "LP2"
+        },
+        {
+            "id"     : 3,
+            "value"  : "HP2"
+        },
+        {
+            "id"     : 4,
+            "value"  : "BP"
+        },
+        {
+            "id"     : 5,
+            "value"  : "notch"
+        },
+        {
+            "id"     : 6,
+            "value"  : "peak"
+        },
+        {
+            "id"     : 7,
+            "value"  : "l.shelf"
+        },
+        {
+            "id"     : 8,
+            "value"  : "h.shelf"
+        }
+        ]
+    },
+    {
+        "path"     : "/sysefx[0,3]/filterpars/Pstages",
+        "shortname": "stages",
+        "name"     : "Pstages",
+        "tooltip"  : "Filter Stages",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,5],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/sysefx[0,3]/filterpars/baseq",
+        "shortname": "q",
+        "name"     : "baseq",
+        "tooltip"  : "Quality Factor (resonance/bandwidth)",
+        "units"    : "none",
+        "scale"    : "logarithmic",
+        "type"     : "f",
+        "range"    : [0.1,1000]
+    },
+    {
+        "path"     : "/sysefx[0,3]/filterpars/basefreq",
+        "shortname": "cutoff",
+        "name"     : "basefreq",
+        "tooltip"  : "Base cutoff frequency",
+        "units"    : "Hz",
+        "scale"    : "logarithmic",
+        "type"     : "f",
+        "range"    : [31.25,32000]
+    },
+    {
+        "path"     : "/sysefx[0,3]/filterpars/freqtracking",
+        "shortname": "f.track",
+        "name"     : "freqtracking",
+        "tooltip"  : "Frequency Tracking amount",
+        "units"    : "%",
+        "scale"    : "linear",
+        "type"     : "f",
+        "range"    : [-100,100],
+        "default"  : "0.0f"
+
+    },
+    {
+        "path"     : "/sysefx[0,3]/filterpars/gain",
+        "shortname": "gain",
+        "name"     : "gain",
+        "tooltip"  : "Output Gain",
+        "units"    : "dB",
+        "scale"    : "linear",
+        "type"     : "f",
+        "range"    : [-30,30],
+        "default"  : "0.0f"
+
+    },
+    {
+        "path"     : "/sysefx[0,3]/filterpars/Pnumformants",
+        "shortname": "formants",
+        "name"     : "Pnumformants",
+        "tooltip"  : "Number of formants to be used",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [1,12],
+        "default"  : "3"
+
+    },
+    {
+        "path"     : "/sysefx[0,3]/filterpars/Pformantslowness",
+        "shortname": "slew",
+        "name"     : "Pformantslowness",
+        "tooltip"  : "Rate that formants change",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/sysefx[0,3]/filterpars/Pvowelclearness",
+        "shortname": "clarity",
+        "name"     : "Pvowelclearness",
+        "tooltip"  : "How much each vowel is smudged with the next in sequence. A high clarity will avoid smudging.",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/sysefx[0,3]/filterpars/Pcenterfreq",
+        "shortname": "cutoff",
+        "name"     : "Pcenterfreq",
+        "tooltip"  : "Center Freq (formant)",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/sysefx[0,3]/filterpars/Poctavesfreq",
+        "shortname": "octaves",
+        "name"     : "Poctavesfreq",
+        "tooltip"  : "Number of octaves for formant",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/sysefx[0,3]/filterpars/Psequencesize",
+        "shortname": "seq.size",
+        "name"     : "Psequencesize",
+        "tooltip"  : "Length of vowel sequence",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,8],
+        "default"  : "3"
+
+    },
+    {
+        "path"     : "/sysefx[0,3]/filterpars/Psequencestretch",
+        "shortname": "seq.str",
+        "name"     : "Psequencestretch",
+        "tooltip"  : "How modulators stretch the sequence",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "40"
+
+    },
+    {
+        "path"     : "/sysefx[0,3]/filterpars/Psequencereversed",
+        "shortname": "reverse",
+        "name"     : "Psequencereversed",
+        "tooltip"  : "If the modulator input is inverted",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/sysefx[0,3]/filterpars/type-svf",
+        "shortname": "type",
+        "name"     : "type-svf",
+        "tooltip"  : "Filter Type",
+        "type"     : "i",
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "low"
+        },
+        {
+            "id"     : 1,
+            "value"  : "high"
+        },
+        {
+            "id"     : 2,
+            "value"  : "band"
+        },
+        {
+            "id"     : 3,
+            "value"  : "notch"
+        }
+        ]
+    },
+    {
+        "path"     : "/sysefx[0,3]/filterpars/Pvowels[0,5]/Pformants[0,11]/freq",
+        "shortname": "f.freq",
+        "name"     : "freq",
+        "tooltip"  : "Formant frequency",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/sysefx[0,3]/filterpars/Pvowels[0,5]/Pformants[0,11]/amp",
+        "shortname": "f.str",
+        "name"     : "amp",
+        "tooltip"  : "Strength of formant",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "127"
+
+    },
+    {
+        "path"     : "/sysefx[0,3]/filterpars/Pvowels[0,5]/Pformants[0,11]/q",
+        "shortname": "f.q",
+        "name"     : "q",
+        "tooltip"  : "The formant's quality factor, also known as resonance bandwidth or Q for short",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/sysefx[0,3]/Pvolume",
+        "shortname": "amt",
+        "name"     : "Pvolume",
+        "tooltip"  : "amount of effect",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/sysefx[0,3]/Ppanning",
+        "shortname": "pan",
+        "name"     : "Ppanning",
+        "tooltip"  : "panning",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/sysefx[0,3]/parameter[0,127]",
+        "name"     : "parameter#128",
+        "tooltip"  : "Parameter Accessor",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/sysefx[0,3]/preset",
+        "name"     : "preset",
+        "tooltip"  : "Effect Preset Selector",
+        "type"     : "i",
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/sysefx[0,3]/efftype",
+        "name"     : "efftype",
+        "tooltip"  : "Get Effect Type",
+        "type"     : "i",
+        "default"  : "Disabled"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "Disabled"
+        },
+        {
+            "id"     : 1,
+            "value"  : "Reverb"
+        },
+        {
+            "id"     : 2,
+            "value"  : "Echo"
+        },
+        {
+            "id"     : 3,
+            "value"  : "Chorus"
+        },
+        {
+            "id"     : 4,
+            "value"  : "Phaser"
+        },
+        {
+            "id"     : 5,
+            "value"  : "Alienwah"
+        },
+        {
+            "id"     : 6,
+            "value"  : "Distortion"
+        },
+        {
+            "id"     : 7,
+            "value"  : "EQ"
+        },
+        {
+            "id"     : 8,
+            "value"  : "DynFilter"
+        }
+        ]
+    },
+    {
+        "path"     : "/sysefx[0,3]/Alienwah/preset",
+        "name"     : "preset",
+        "tooltip"  : "Instrument Presets",
+        "type"     : "i",
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "wah 1"
+        },
+        {
+            "id"     : 1,
+            "value"  : "wah 2"
+        },
+        {
+            "id"     : 2,
+            "value"  : "wah 3"
+        },
+        {
+            "id"     : 3,
+            "value"  : "wah 4"
+        }
+        ]
+    },
+    {
+        "path"     : "/sysefx[0,3]/Alienwah/Pvolume",
+        "shortname": "amt",
+        "name"     : "Pvolume",
+        "tooltip"  : "amount of effect",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "127"
+
+    },
+    {
+        "path"     : "/sysefx[0,3]/Alienwah/Ppanning",
+        "shortname": "pan",
+        "name"     : "Ppanning",
+        "tooltip"  : "panning",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/sysefx[0,3]/Alienwah/Pfreq",
+        "shortname": "freq",
+        "name"     : "Pfreq",
+        "tooltip"  : "Effect Frequency",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/sysefx[0,3]/Alienwah/Pfreqrnd",
+        "shortname": "rand",
+        "name"     : "Pfreqrnd",
+        "tooltip"  : "Frequency Randomness",
+        "type"     : "i",
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/sysefx[0,3]/Alienwah/PLFOtype",
+        "shortname": "shape",
+        "name"     : "PLFOtype",
+        "tooltip"  : "LFO Shape",
+        "type"     : "i",
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "sine"
+        },
+        {
+            "id"     : 1,
+            "value"  : "triangle"
+        }
+        ]
+    },
+    {
+        "path"     : "/sysefx[0,3]/Alienwah/PStereo",
+        "shortname": "stereo",
+        "name"     : "PStereo",
+        "tooltip"  : "Stereo Mode",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/sysefx[0,3]/Alienwah/Pdepth",
+        "shortname": "depth",
+        "name"     : "Pdepth",
+        "tooltip"  : "LFO Depth",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/sysefx[0,3]/Alienwah/Pfeedback",
+        "shortname": "fb",
+        "name"     : "Pfeedback",
+        "tooltip"  : "Feedback",
+        "type"     : "i",
+        "default"  : "105"
+
+    },
+    {
+        "path"     : "/sysefx[0,3]/Alienwah/Pdelay",
+        "shortname": "delay",
+        "name"     : "Pdelay",
+        "tooltip"  : "Delay",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [1,100]
+    },
+    {
+        "path"     : "/sysefx[0,3]/Alienwah/Plrcross",
+        "shortname": "l/r",
+        "name"     : "Plrcross",
+        "tooltip"  : "Left/Right Crossover",
+        "type"     : "i",
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/sysefx[0,3]/Alienwah/Pphase",
+        "shortname": "phase",
+        "name"     : "Pphase",
+        "tooltip"  : "Phase",
+        "type"     : "i",
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/sysefx[0,3]/Chorus/preset",
+        "name"     : "preset",
+        "tooltip"  : "Instrument Presets",
+        "type"     : "i",
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "Chorus1"
+        },
+        {
+            "id"     : 1,
+            "value"  : "Chorus2"
+        },
+        {
+            "id"     : 2,
+            "value"  : "Chorus3"
+        },
+        {
+            "id"     : 3,
+            "value"  : "Celeste1"
+        },
+        {
+            "id"     : 4,
+            "value"  : "Celeste2"
+        },
+        {
+            "id"     : 5,
+            "value"  : "Flange1"
+        },
+        {
+            "id"     : 6,
+            "value"  : "Flange2"
+        },
+        {
+            "id"     : 7,
+            "value"  : "Flange3"
+        },
+        {
+            "id"     : 8,
+            "value"  : "Flange4"
+        },
+        {
+            "id"     : 9,
+            "value"  : "Flange5"
+        }
+        ]
+    },
+    {
+        "path"     : "/sysefx[0,3]/Chorus/Pvolume",
+        "shortname": "amt",
+        "name"     : "Pvolume",
+        "tooltip"  : "amount of effect",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/sysefx[0,3]/Chorus/Ppanning",
+        "shortname": "pan",
+        "name"     : "Ppanning",
+        "tooltip"  : "panning",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/sysefx[0,3]/Chorus/Pfreq",
+        "shortname": "freq",
+        "name"     : "Pfreq",
+        "tooltip"  : "Effect Frequency",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/sysefx[0,3]/Chorus/Pfreqrnd",
+        "shortname": "rand",
+        "name"     : "Pfreqrnd",
+        "tooltip"  : "Frequency Randomness",
+        "type"     : "i",
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/sysefx[0,3]/Chorus/PLFOtype",
+        "shortname": "shape",
+        "name"     : "PLFOtype",
+        "tooltip"  : "LFO Shape",
+        "type"     : "i",
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "sine"
+        },
+        {
+            "id"     : 1,
+            "value"  : "tri"
+        }
+        ]
+    },
+    {
+        "path"     : "/sysefx[0,3]/Chorus/PStereo",
+        "shortname": "stereo",
+        "name"     : "PStereo",
+        "tooltip"  : "Stereo Mode",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/sysefx[0,3]/Chorus/Pdepth",
+        "shortname": "depth",
+        "name"     : "Pdepth",
+        "tooltip"  : "LFO Depth",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/sysefx[0,3]/Chorus/Pdelay",
+        "shortname": "delay",
+        "name"     : "Pdelay",
+        "tooltip"  : "Delay",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/sysefx[0,3]/Chorus/Pfeedback",
+        "shortname": "fb",
+        "name"     : "Pfeedback",
+        "tooltip"  : "Feedback",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/sysefx[0,3]/Chorus/Plrcross",
+        "shortname": "l/r",
+        "name"     : "Plrcross",
+        "tooltip"  : "Left/Right Crossover",
+        "type"     : "i",
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/sysefx[0,3]/Chorus/Pflangemode",
+        "shortname": "flange",
+        "name"     : "Pflangemode",
+        "tooltip"  : "Flange Mode",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/sysefx[0,3]/Chorus/Poutsub",
+        "shortname": "sub",
+        "name"     : "Poutsub",
+        "tooltip"  : "Output Subtraction",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/sysefx[0,3]/Distorsion/preset",
+        "name"     : "preset",
+        "tooltip"  : "Instrument Presets",
+        "type"     : "i",
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "Overdrive 1"
+        },
+        {
+            "id"     : 1,
+            "value"  : "Overdrive 2"
+        },
+        {
+            "id"     : 2,
+            "value"  : "A. Exciter 1"
+        },
+        {
+            "id"     : 3,
+            "value"  : "A. Exciter 2"
+        },
+        {
+            "id"     : 4,
+            "value"  : "Guitar Amp"
+        },
+        {
+            "id"     : 5,
+            "value"  : "Quantisize"
+        }
+        ]
+    },
+    {
+        "path"     : "/sysefx[0,3]/Distorsion/Pvolume",
+        "shortname": "amt",
+        "name"     : "Pvolume",
+        "tooltip"  : "amount of effect",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "127"
+
+    },
+    {
+        "path"     : "/sysefx[0,3]/Distorsion/Ppanning",
+        "shortname": "pan",
+        "name"     : "Ppanning",
+        "tooltip"  : "panning",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/sysefx[0,3]/Distorsion/Plrcross",
+        "shortname": "l/r",
+        "name"     : "Plrcross",
+        "tooltip"  : "Left/Right Crossover",
+        "type"     : "i",
+        "default"  : "35"
+
+    },
+    {
+        "path"     : "/sysefx[0,3]/Distorsion/Pdrive",
+        "shortname": "drive",
+        "name"     : "Pdrive",
+        "tooltip"  : "Input amplification",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/sysefx[0,3]/Distorsion/Plevel",
+        "shortname": "output",
+        "name"     : "Plevel",
+        "tooltip"  : "Output amplification",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/sysefx[0,3]/Distorsion/Ptype",
+        "shortname": "type",
+        "name"     : "Ptype",
+        "tooltip"  : "Distortion Shape",
+        "type"     : "i",
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "Arctangent"
+        },
+        {
+            "id"     : 1,
+            "value"  : "Asymmetric"
+        },
+        {
+            "id"     : 2,
+            "value"  : "Pow"
+        },
+        {
+            "id"     : 3,
+            "value"  : "Sine"
+        },
+        {
+            "id"     : 4,
+            "value"  : "Quantisize"
+        },
+        {
+            "id"     : 5,
+            "value"  : "Zigzag"
+        },
+        {
+            "id"     : 6,
+            "value"  : "Limiter"
+        },
+        {
+            "id"     : 7,
+            "value"  : "Upper Limiter"
+        },
+        {
+            "id"     : 8,
+            "value"  : "Lower Limiter"
+        },
+        {
+            "id"     : 9,
+            "value"  : "Inverse Limiter"
+        },
+        {
+            "id"     : 10,
+            "value"  : "Clip"
+        },
+        {
+            "id"     : 11,
+            "value"  : "Asym2"
+        },
+        {
+            "id"     : 12,
+            "value"  : "Pow2"
+        },
+        {
+            "id"     : 13,
+            "value"  : "Sigmoid"
+        },
+        {
+            "id"     : 14,
+            "value"  : "Tanh"
+        },
+        {
+            "id"     : 15,
+            "value"  : "Cubic"
+        },
+        {
+            "id"     : 16,
+            "value"  : "Square"
+        }
+        ]
+    },
+    {
+        "path"     : "/sysefx[0,3]/Distorsion/Pnegate",
+        "shortname": "neg",
+        "name"     : "Pnegate",
+        "tooltip"  : "Negate Signal",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/sysefx[0,3]/Distorsion/Plpf",
+        "shortname": "lpf",
+        "name"     : "Plpf",
+        "tooltip"  : "Low Pass Cutoff",
+        "type"     : "i",
+        "default"  : "127"
+
+    },
+    {
+        "path"     : "/sysefx[0,3]/Distorsion/Phpf",
+        "shortname": "hpf",
+        "name"     : "Phpf",
+        "tooltip"  : "High Pass Cutoff",
+        "type"     : "i",
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/sysefx[0,3]/Distorsion/Pstereo",
+        "shortname": "stereo",
+        "name"     : "Pstereo",
+        "tooltip"  : "Stereo",
+        "type"     : "t"
+    },
+    {
+        "path"     : "/sysefx[0,3]/Distorsion/Pprefiltering",
+        "shortname": "p.filt",
+        "name"     : "Pprefiltering",
+        "tooltip"  : "Filtering before/after non-linearity",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/sysefx[0,3]/Distorsion/Pfuncpar",
+        "shortname": "shape",
+        "name"     : "Pfuncpar",
+        "tooltip"  : "Shape of the wave shaping function",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "32"
+
+    },
+    {
+        "path"     : "/sysefx[0,3]/Distorsion/Poffset",
+        "shortname": "offset",
+        "name"     : "Poffset",
+        "tooltip"  : "Input DC Offset",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/sysefx[0,3]/DynamicFilter/Pvolume",
+        "shortname": "amt",
+        "name"     : "Pvolume",
+        "tooltip"  : "amount of effect",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "110"
+
+    },
+    {
+        "path"     : "/sysefx[0,3]/DynamicFilter/Ppanning",
+        "shortname": "pan",
+        "name"     : "Ppanning",
+        "tooltip"  : "panning",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/sysefx[0,3]/DynamicFilter/Pfreq",
+        "shortname": "freq",
+        "name"     : "Pfreq",
+        "tooltip"  : "Effect Frequency",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/sysefx[0,3]/DynamicFilter/Pfreqrnd",
+        "shortname": "rand",
+        "name"     : "Pfreqrnd",
+        "tooltip"  : "Frequency Randomness",
+        "type"     : "i",
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/sysefx[0,3]/DynamicFilter/PLFOtype",
+        "shortname": "shape",
+        "name"     : "PLFOtype",
+        "tooltip"  : "LFO Shape",
+        "type"     : "i",
+        "default"  : "sin"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "sin"
+        },
+        {
+            "id"     : 1,
+            "value"  : "tri"
+        }
+        ]
+    },
+    {
+        "path"     : "/sysefx[0,3]/DynamicFilter/PStereo",
+        "shortname": "stereo",
+        "name"     : "PStereo",
+        "tooltip"  : "Stereo Mode",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/sysefx[0,3]/DynamicFilter/Pdepth",
+        "shortname": "depth",
+        "name"     : "Pdepth",
+        "tooltip"  : "LFO Depth",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/sysefx[0,3]/DynamicFilter/Pampsns",
+        "shortname": "sense",
+        "name"     : "Pampsns",
+        "tooltip"  : "how the filter varies according to the input amplitude",
+        "type"     : "i",
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/sysefx[0,3]/DynamicFilter/Pampsnsinv",
+        "shortname": "sns.inv",
+        "name"     : "Pampsnsinv",
+        "tooltip"  : "Sense Inversion",
+        "type"     : "i",
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/sysefx[0,3]/DynamicFilter/Pampsmooth",
+        "shortname": "smooth",
+        "name"     : "Pampsmooth",
+        "tooltip"  : "how smooth the input amplitude changes the filter",
+        "type"     : "i",
+        "default"  : "60"
+
+    },
+    {
+        "path"     : "/sysefx[0,3]/Echo/preset",
+        "name"     : "preset",
+        "tooltip"  : "Instrument Presets",
+        "type"     : "i",
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "Echo 1"
+        },
+        {
+            "id"     : 1,
+            "value"  : "Echo 2"
+        },
+        {
+            "id"     : 2,
+            "value"  : "Echo 3"
+        },
+        {
+            "id"     : 3,
+            "value"  : "Simple Echo"
+        },
+        {
+            "id"     : 4,
+            "value"  : "Canyon"
+        },
+        {
+            "id"     : 5,
+            "value"  : "Panning Echo 1"
+        },
+        {
+            "id"     : 6,
+            "value"  : "Panning Echo 2"
+        },
+        {
+            "id"     : 7,
+            "value"  : "Panning Echo 3"
+        },
+        {
+            "id"     : 8,
+            "value"  : "Feedback Echo"
+        }
+        ]
+    },
+    {
+        "path"     : "/sysefx[0,3]/Echo/Pvolume",
+        "shortname": "amt",
+        "name"     : "Pvolume",
+        "tooltip"  : "amount of effect",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "67"
+
+    },
+    {
+        "path"     : "/sysefx[0,3]/Echo/Ppanning",
+        "shortname": "pan",
+        "name"     : "Ppanning",
+        "tooltip"  : "panning",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/sysefx[0,3]/Echo/Pdelay",
+        "shortname": "delay",
+        "name"     : "Pdelay",
+        "tooltip"  : "Length of Echo",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/sysefx[0,3]/Echo/Plrdelay",
+        "shortname": "lr delay",
+        "name"     : "Plrdelay",
+        "tooltip"  : "Difference In Left/Right Delay",
+        "type"     : "i",
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/sysefx[0,3]/Echo/Plrcross",
+        "shortname": "cross",
+        "name"     : "Plrcross",
+        "tooltip"  : "Left/Right Crossover",
+        "type"     : "i",
+        "default"  : "30"
+
+    },
+    {
+        "path"     : "/sysefx[0,3]/Echo/Pfb",
+        "shortname": "feedback",
+        "name"     : "Pfb",
+        "tooltip"  : "Echo Feedback",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/sysefx[0,3]/Echo/Phidamp",
+        "shortname": "damp",
+        "name"     : "Phidamp",
+        "tooltip"  : "Dampen High Frequencies",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/sysefx[0,3]/EQ/filter[0,7]/Ptype",
+        "shortname": "type",
+        "name"     : "Ptype",
+        "tooltip"  : "Filter Type",
+        "type"     : "i",
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "Off"
+        },
+        {
+            "id"     : 1,
+            "value"  : "LP1"
+        },
+        {
+            "id"     : 2,
+            "value"  : "HP1"
+        },
+        {
+            "id"     : 3,
+            "value"  : "LP2"
+        },
+        {
+            "id"     : 4,
+            "value"  : "HP2"
+        },
+        {
+            "id"     : 5,
+            "value"  : "BP"
+        },
+        {
+            "id"     : 6,
+            "value"  : "notch"
+        },
+        {
+            "id"     : 7,
+            "value"  : "peak"
+        },
+        {
+            "id"     : 8,
+            "value"  : "l.shelf"
+        },
+        {
+            "id"     : 9,
+            "value"  : "h.shelf"
+        }
+        ]
+    },
+    {
+        "path"     : "/sysefx[0,3]/EQ/filter[0,7]/Pfreq",
+        "shortname": "freq",
+        "name"     : "Pfreq",
+        "tooltip"  : "",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/sysefx[0,3]/EQ/filter[0,7]/Pgain",
+        "shortname": "gain",
+        "name"     : "Pgain",
+        "tooltip"  : "",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/sysefx[0,3]/EQ/filter[0,7]/Pq",
+        "shortname": "q",
+        "name"     : "Pq",
+        "tooltip"  : "Resonance/Bandwidth",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/sysefx[0,3]/EQ/filter[0,7]/Pstages",
+        "shortname": "stages",
+        "name"     : "Pstages",
+        "tooltip"  : "Additional filter stages",
+        "type"     : "i",
+        "range"    : [0,4]
+    },
+    {
+        "path"     : "/sysefx[0,3]/Phaser/preset",
+        "name"     : "preset",
+        "tooltip"  : "Instrument Presets",
+        "type"     : "i",
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "Phaser 1"
+        },
+        {
+            "id"     : 1,
+            "value"  : "Phaser 2"
+        },
+        {
+            "id"     : 2,
+            "value"  : "Phaser 3"
+        },
+        {
+            "id"     : 3,
+            "value"  : "Phaser 4"
+        },
+        {
+            "id"     : 4,
+            "value"  : "Phaser 5"
+        },
+        {
+            "id"     : 5,
+            "value"  : "Phaser 6"
+        },
+        {
+            "id"     : 6,
+            "value"  : "APhaser 1"
+        },
+        {
+            "id"     : 7,
+            "value"  : "APhaser 2"
+        },
+        {
+            "id"     : 8,
+            "value"  : "APhaser 3"
+        },
+        {
+            "id"     : 9,
+            "value"  : "APhaser 4"
+        },
+        {
+            "id"     : 10,
+            "value"  : "APhaser 5"
+        },
+        {
+            "id"     : 11,
+            "value"  : "APhaser 6"
+        }
+        ]
+    },
+    {
+        "path"     : "/sysefx[0,3]/Phaser/Pvolume",
+        "shortname": "amt",
+        "name"     : "Pvolume",
+        "tooltip"  : "amount of effect",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/sysefx[0,3]/Phaser/Ppanning",
+        "shortname": "pan",
+        "name"     : "Ppanning",
+        "tooltip"  : "panning",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/sysefx[0,3]/Phaser/lfo.Pfreq",
+        "shortname": "freq",
+        "name"     : "lfo.Pfreq",
+        "tooltip"  : "LFO frequency",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/sysefx[0,3]/Phaser/lfo.Prandomness",
+        "shortname": "rnd.",
+        "name"     : "lfo.Prandomness",
+        "tooltip"  : "LFO randomness",
+        "type"     : "i",
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/sysefx[0,3]/Phaser/lfo.PLFOtype",
+        "shortname": "type",
+        "name"     : "lfo.PLFOtype",
+        "tooltip"  : "lfo shape",
+        "type"     : "i",
+        "default"  : "sine"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "sine"
+        },
+        {
+            "id"     : 1,
+            "value"  : "tri"
+        }
+        ]
+    },
+    {
+        "path"     : "/sysefx[0,3]/Phaser/lfo.Pstereo",
+        "shortname": "stereo",
+        "name"     : "lfo.Pstereo",
+        "tooltip"  : "Left/right channel phase shift",
+        "type"     : "i",
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/sysefx[0,3]/Phaser/Pdepth",
+        "shortname": "depth",
+        "name"     : "Pdepth",
+        "tooltip"  : "LFP depth",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/sysefx[0,3]/Phaser/Pfb",
+        "shortname": "fb",
+        "name"     : "Pfb",
+        "tooltip"  : "Feedback",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/sysefx[0,3]/Phaser/Pstages",
+        "shortname": "stages",
+        "name"     : "Pstages",
+        "tooltip"  : "",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [1,12]
+    },
+    {
+        "path"     : "/sysefx[0,3]/Phaser/Plrcross",
+        "shortname": "cross",
+        "name"     : "Plrcross",
+        "tooltip"  : "Channel routing",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/sysefx[0,3]/Phaser/Poffset",
+        "shortname": "off",
+        "name"     : "Poffset",
+        "tooltip"  : "Offset",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/sysefx[0,3]/Phaser/Poutsub",
+        "shortname": "sub",
+        "name"     : "Poutsub",
+        "tooltip"  : "Invert output",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/sysefx[0,3]/Phaser/Pphase",
+        "shortname": "phase",
+        "name"     : "Pphase",
+        "tooltip"  : "",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/sysefx[0,3]/Phaser/Pwidth",
+        "shortname": "width",
+        "name"     : "Pwidth",
+        "tooltip"  : "",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/sysefx[0,3]/Phaser/Phyper",
+        "shortname": "hyp.",
+        "name"     : "Phyper",
+        "tooltip"  : "Square the LFO",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/sysefx[0,3]/Phaser/Pdistortion",
+        "shortname": "distort",
+        "name"     : "Pdistortion",
+        "tooltip"  : "Distortion",
+        "type"     : "i",
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/sysefx[0,3]/Phaser/Panalog",
+        "shortname": "analog",
+        "name"     : "Panalog",
+        "tooltip"  : "Use analog phaser",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/sysefx[0,3]/Reverb/preset",
+        "name"     : "preset",
+        "tooltip"  : "Instrument Presets",
+        "type"     : "i",
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "Cathedral1"
+        },
+        {
+            "id"     : 1,
+            "value"  : "Cathedral2"
+        },
+        {
+            "id"     : 2,
+            "value"  : "Cathedral3"
+        },
+        {
+            "id"     : 3,
+            "value"  : "Hall1"
+        },
+        {
+            "id"     : 4,
+            "value"  : "Hall2"
+        },
+        {
+            "id"     : 5,
+            "value"  : "Room1"
+        },
+        {
+            "id"     : 6,
+            "value"  : "Room2"
+        },
+        {
+            "id"     : 7,
+            "value"  : "Basement"
+        },
+        {
+            "id"     : 8,
+            "value"  : "Tunnel"
+        },
+        {
+            "id"     : 9,
+            "value"  : "Echoed1"
+        },
+        {
+            "id"     : 10,
+            "value"  : "Echoed2"
+        },
+        {
+            "id"     : 11,
+            "value"  : "VeryLong1"
+        },
+        {
+            "id"     : 12,
+            "value"  : "VeryLong2"
+        }
+        ]
+    },
+    {
+        "path"     : "/sysefx[0,3]/Reverb/Pvolume",
+        "shortname": "amt",
+        "name"     : "Pvolume",
+        "tooltip"  : "amount of effect",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "90"
+
+    },
+    {
+        "path"     : "/sysefx[0,3]/Reverb/Ppanning",
+        "shortname": "pan",
+        "name"     : "Ppanning",
+        "tooltip"  : "panning",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/sysefx[0,3]/Reverb/Ptime",
+        "shortname": "time",
+        "name"     : "Ptime",
+        "tooltip"  : "Length of Reverb",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/sysefx[0,3]/Reverb/Pidelay",
+        "shortname": "i.time",
+        "name"     : "Pidelay",
+        "tooltip"  : "Delay for first impulse",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/sysefx[0,3]/Reverb/Pidelayfb",
+        "shortname": "i.fb",
+        "name"     : "Pidelayfb",
+        "tooltip"  : "Feedback for first impulse",
+        "type"     : "i",
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/sysefx[0,3]/Reverb/Plpf",
+        "shortname": "lpf",
+        "name"     : "Plpf",
+        "tooltip"  : "Low pass filter",
+        "type"     : "i",
+        "default"  : "127"
+
+    },
+    {
+        "path"     : "/sysefx[0,3]/Reverb/Phpf",
+        "shortname": "hpf",
+        "name"     : "Phpf",
+        "tooltip"  : "High pass filter",
+        "type"     : "i",
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/sysefx[0,3]/Reverb/Plohidamp",
+        "shortname": "damp",
+        "name"     : "Plohidamp",
+        "tooltip"  : ":default 0",
+        "type"     : "i",
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/sysefx[0,3]/Reverb/Ptype",
+        "shortname": "type",
+        "name"     : "Ptype",
+        "tooltip"  : "Type",
+        "type"     : "i",
+        "default"  : "Random"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "Random"
+        },
+        {
+            "id"     : 1,
+            "value"  : "Freeverb"
+        },
+        {
+            "id"     : 2,
+            "value"  : "Bandwidth"
+        }
+        ]
+    },
+    {
+        "path"     : "/sysefx[0,3]/Reverb/Proomsize",
+        "shortname": "size",
+        "name"     : "Proomsize",
+        "tooltip"  : "Room Size",
+        "type"     : "i",
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/sysefx[0,3]/Reverb/Pbandwidth",
+        "shortname": "bw",
+        "name"     : "Pbandwidth",
+        "tooltip"  : "Bandwidth",
+        "type"     : "i",
+        "default"  : "20"
+
+    },
+    {
+        "path"     : "/insefx[0,7]/filterpars/Pcategory",
+        "shortname": "class",
+        "name"     : "Pcategory",
+        "tooltip"  : "Class of filter",
+        "type"     : "i",
+        "default"  : "analog"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "analog"
+        },
+        {
+            "id"     : 1,
+            "value"  : "formant"
+        },
+        {
+            "id"     : 2,
+            "value"  : "st.var."
+        }
+        ]
+    },
+    {
+        "path"     : "/insefx[0,7]/filterpars/Ptype",
+        "shortname": "type",
+        "name"     : "Ptype",
+        "tooltip"  : "Filter Type",
+        "type"     : "i",
+        "default"  : "LP2"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "LP1"
+        },
+        {
+            "id"     : 1,
+            "value"  : "HP1"
+        },
+        {
+            "id"     : 2,
+            "value"  : "LP2"
+        },
+        {
+            "id"     : 3,
+            "value"  : "HP2"
+        },
+        {
+            "id"     : 4,
+            "value"  : "BP"
+        },
+        {
+            "id"     : 5,
+            "value"  : "notch"
+        },
+        {
+            "id"     : 6,
+            "value"  : "peak"
+        },
+        {
+            "id"     : 7,
+            "value"  : "l.shelf"
+        },
+        {
+            "id"     : 8,
+            "value"  : "h.shelf"
+        }
+        ]
+    },
+    {
+        "path"     : "/insefx[0,7]/filterpars/Pstages",
+        "shortname": "stages",
+        "name"     : "Pstages",
+        "tooltip"  : "Filter Stages",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,5],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/insefx[0,7]/filterpars/baseq",
+        "shortname": "q",
+        "name"     : "baseq",
+        "tooltip"  : "Quality Factor (resonance/bandwidth)",
+        "units"    : "none",
+        "scale"    : "logarithmic",
+        "type"     : "f",
+        "range"    : [0.1,1000]
+    },
+    {
+        "path"     : "/insefx[0,7]/filterpars/basefreq",
+        "shortname": "cutoff",
+        "name"     : "basefreq",
+        "tooltip"  : "Base cutoff frequency",
+        "units"    : "Hz",
+        "scale"    : "logarithmic",
+        "type"     : "f",
+        "range"    : [31.25,32000]
+    },
+    {
+        "path"     : "/insefx[0,7]/filterpars/freqtracking",
+        "shortname": "f.track",
+        "name"     : "freqtracking",
+        "tooltip"  : "Frequency Tracking amount",
+        "units"    : "%",
+        "scale"    : "linear",
+        "type"     : "f",
+        "range"    : [-100,100],
+        "default"  : "0.0f"
+
+    },
+    {
+        "path"     : "/insefx[0,7]/filterpars/gain",
+        "shortname": "gain",
+        "name"     : "gain",
+        "tooltip"  : "Output Gain",
+        "units"    : "dB",
+        "scale"    : "linear",
+        "type"     : "f",
+        "range"    : [-30,30],
+        "default"  : "0.0f"
+
+    },
+    {
+        "path"     : "/insefx[0,7]/filterpars/Pnumformants",
+        "shortname": "formants",
+        "name"     : "Pnumformants",
+        "tooltip"  : "Number of formants to be used",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [1,12],
+        "default"  : "3"
+
+    },
+    {
+        "path"     : "/insefx[0,7]/filterpars/Pformantslowness",
+        "shortname": "slew",
+        "name"     : "Pformantslowness",
+        "tooltip"  : "Rate that formants change",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/insefx[0,7]/filterpars/Pvowelclearness",
+        "shortname": "clarity",
+        "name"     : "Pvowelclearness",
+        "tooltip"  : "How much each vowel is smudged with the next in sequence. A high clarity will avoid smudging.",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/insefx[0,7]/filterpars/Pcenterfreq",
+        "shortname": "cutoff",
+        "name"     : "Pcenterfreq",
+        "tooltip"  : "Center Freq (formant)",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/insefx[0,7]/filterpars/Poctavesfreq",
+        "shortname": "octaves",
+        "name"     : "Poctavesfreq",
+        "tooltip"  : "Number of octaves for formant",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/insefx[0,7]/filterpars/Psequencesize",
+        "shortname": "seq.size",
+        "name"     : "Psequencesize",
+        "tooltip"  : "Length of vowel sequence",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,8],
+        "default"  : "3"
+
+    },
+    {
+        "path"     : "/insefx[0,7]/filterpars/Psequencestretch",
+        "shortname": "seq.str",
+        "name"     : "Psequencestretch",
+        "tooltip"  : "How modulators stretch the sequence",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "40"
+
+    },
+    {
+        "path"     : "/insefx[0,7]/filterpars/Psequencereversed",
+        "shortname": "reverse",
+        "name"     : "Psequencereversed",
+        "tooltip"  : "If the modulator input is inverted",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/insefx[0,7]/filterpars/type-svf",
+        "shortname": "type",
+        "name"     : "type-svf",
+        "tooltip"  : "Filter Type",
+        "type"     : "i",
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "low"
+        },
+        {
+            "id"     : 1,
+            "value"  : "high"
+        },
+        {
+            "id"     : 2,
+            "value"  : "band"
+        },
+        {
+            "id"     : 3,
+            "value"  : "notch"
+        }
+        ]
+    },
+    {
+        "path"     : "/insefx[0,7]/filterpars/Pvowels[0,5]/Pformants[0,11]/freq",
+        "shortname": "f.freq",
+        "name"     : "freq",
+        "tooltip"  : "Formant frequency",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/insefx[0,7]/filterpars/Pvowels[0,5]/Pformants[0,11]/amp",
+        "shortname": "f.str",
+        "name"     : "amp",
+        "tooltip"  : "Strength of formant",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "127"
+
+    },
+    {
+        "path"     : "/insefx[0,7]/filterpars/Pvowels[0,5]/Pformants[0,11]/q",
+        "shortname": "f.q",
+        "name"     : "q",
+        "tooltip"  : "The formant's quality factor, also known as resonance bandwidth or Q for short",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/insefx[0,7]/Pvolume",
+        "shortname": "amt",
+        "name"     : "Pvolume",
+        "tooltip"  : "amount of effect",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/insefx[0,7]/Ppanning",
+        "shortname": "pan",
+        "name"     : "Ppanning",
+        "tooltip"  : "panning",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/insefx[0,7]/parameter[0,127]",
+        "name"     : "parameter#128",
+        "tooltip"  : "Parameter Accessor",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/insefx[0,7]/preset",
+        "name"     : "preset",
+        "tooltip"  : "Effect Preset Selector",
+        "type"     : "i",
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/insefx[0,7]/efftype",
+        "name"     : "efftype",
+        "tooltip"  : "Get Effect Type",
+        "type"     : "i",
+        "default"  : "Disabled"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "Disabled"
+        },
+        {
+            "id"     : 1,
+            "value"  : "Reverb"
+        },
+        {
+            "id"     : 2,
+            "value"  : "Echo"
+        },
+        {
+            "id"     : 3,
+            "value"  : "Chorus"
+        },
+        {
+            "id"     : 4,
+            "value"  : "Phaser"
+        },
+        {
+            "id"     : 5,
+            "value"  : "Alienwah"
+        },
+        {
+            "id"     : 6,
+            "value"  : "Distortion"
+        },
+        {
+            "id"     : 7,
+            "value"  : "EQ"
+        },
+        {
+            "id"     : 8,
+            "value"  : "DynFilter"
+        }
+        ]
+    },
+    {
+        "path"     : "/insefx[0,7]/Alienwah/preset",
+        "name"     : "preset",
+        "tooltip"  : "Instrument Presets",
+        "type"     : "i",
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "wah 1"
+        },
+        {
+            "id"     : 1,
+            "value"  : "wah 2"
+        },
+        {
+            "id"     : 2,
+            "value"  : "wah 3"
+        },
+        {
+            "id"     : 3,
+            "value"  : "wah 4"
+        }
+        ]
+    },
+    {
+        "path"     : "/insefx[0,7]/Alienwah/Pvolume",
+        "shortname": "amt",
+        "name"     : "Pvolume",
+        "tooltip"  : "amount of effect",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "127"
+
+    },
+    {
+        "path"     : "/insefx[0,7]/Alienwah/Ppanning",
+        "shortname": "pan",
+        "name"     : "Ppanning",
+        "tooltip"  : "panning",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/insefx[0,7]/Alienwah/Pfreq",
+        "shortname": "freq",
+        "name"     : "Pfreq",
+        "tooltip"  : "Effect Frequency",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/insefx[0,7]/Alienwah/Pfreqrnd",
+        "shortname": "rand",
+        "name"     : "Pfreqrnd",
+        "tooltip"  : "Frequency Randomness",
+        "type"     : "i",
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/insefx[0,7]/Alienwah/PLFOtype",
+        "shortname": "shape",
+        "name"     : "PLFOtype",
+        "tooltip"  : "LFO Shape",
+        "type"     : "i",
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "sine"
+        },
+        {
+            "id"     : 1,
+            "value"  : "triangle"
+        }
+        ]
+    },
+    {
+        "path"     : "/insefx[0,7]/Alienwah/PStereo",
+        "shortname": "stereo",
+        "name"     : "PStereo",
+        "tooltip"  : "Stereo Mode",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/insefx[0,7]/Alienwah/Pdepth",
+        "shortname": "depth",
+        "name"     : "Pdepth",
+        "tooltip"  : "LFO Depth",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/insefx[0,7]/Alienwah/Pfeedback",
+        "shortname": "fb",
+        "name"     : "Pfeedback",
+        "tooltip"  : "Feedback",
+        "type"     : "i",
+        "default"  : "105"
+
+    },
+    {
+        "path"     : "/insefx[0,7]/Alienwah/Pdelay",
+        "shortname": "delay",
+        "name"     : "Pdelay",
+        "tooltip"  : "Delay",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [1,100]
+    },
+    {
+        "path"     : "/insefx[0,7]/Alienwah/Plrcross",
+        "shortname": "l/r",
+        "name"     : "Plrcross",
+        "tooltip"  : "Left/Right Crossover",
+        "type"     : "i",
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/insefx[0,7]/Alienwah/Pphase",
+        "shortname": "phase",
+        "name"     : "Pphase",
+        "tooltip"  : "Phase",
+        "type"     : "i",
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/insefx[0,7]/Chorus/preset",
+        "name"     : "preset",
+        "tooltip"  : "Instrument Presets",
+        "type"     : "i",
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "Chorus1"
+        },
+        {
+            "id"     : 1,
+            "value"  : "Chorus2"
+        },
+        {
+            "id"     : 2,
+            "value"  : "Chorus3"
+        },
+        {
+            "id"     : 3,
+            "value"  : "Celeste1"
+        },
+        {
+            "id"     : 4,
+            "value"  : "Celeste2"
+        },
+        {
+            "id"     : 5,
+            "value"  : "Flange1"
+        },
+        {
+            "id"     : 6,
+            "value"  : "Flange2"
+        },
+        {
+            "id"     : 7,
+            "value"  : "Flange3"
+        },
+        {
+            "id"     : 8,
+            "value"  : "Flange4"
+        },
+        {
+            "id"     : 9,
+            "value"  : "Flange5"
+        }
+        ]
+    },
+    {
+        "path"     : "/insefx[0,7]/Chorus/Pvolume",
+        "shortname": "amt",
+        "name"     : "Pvolume",
+        "tooltip"  : "amount of effect",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/insefx[0,7]/Chorus/Ppanning",
+        "shortname": "pan",
+        "name"     : "Ppanning",
+        "tooltip"  : "panning",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/insefx[0,7]/Chorus/Pfreq",
+        "shortname": "freq",
+        "name"     : "Pfreq",
+        "tooltip"  : "Effect Frequency",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/insefx[0,7]/Chorus/Pfreqrnd",
+        "shortname": "rand",
+        "name"     : "Pfreqrnd",
+        "tooltip"  : "Frequency Randomness",
+        "type"     : "i",
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/insefx[0,7]/Chorus/PLFOtype",
+        "shortname": "shape",
+        "name"     : "PLFOtype",
+        "tooltip"  : "LFO Shape",
+        "type"     : "i",
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "sine"
+        },
+        {
+            "id"     : 1,
+            "value"  : "tri"
+        }
+        ]
+    },
+    {
+        "path"     : "/insefx[0,7]/Chorus/PStereo",
+        "shortname": "stereo",
+        "name"     : "PStereo",
+        "tooltip"  : "Stereo Mode",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/insefx[0,7]/Chorus/Pdepth",
+        "shortname": "depth",
+        "name"     : "Pdepth",
+        "tooltip"  : "LFO Depth",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/insefx[0,7]/Chorus/Pdelay",
+        "shortname": "delay",
+        "name"     : "Pdelay",
+        "tooltip"  : "Delay",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/insefx[0,7]/Chorus/Pfeedback",
+        "shortname": "fb",
+        "name"     : "Pfeedback",
+        "tooltip"  : "Feedback",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/insefx[0,7]/Chorus/Plrcross",
+        "shortname": "l/r",
+        "name"     : "Plrcross",
+        "tooltip"  : "Left/Right Crossover",
+        "type"     : "i",
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/insefx[0,7]/Chorus/Pflangemode",
+        "shortname": "flange",
+        "name"     : "Pflangemode",
+        "tooltip"  : "Flange Mode",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/insefx[0,7]/Chorus/Poutsub",
+        "shortname": "sub",
+        "name"     : "Poutsub",
+        "tooltip"  : "Output Subtraction",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/insefx[0,7]/Distorsion/preset",
+        "name"     : "preset",
+        "tooltip"  : "Instrument Presets",
+        "type"     : "i",
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "Overdrive 1"
+        },
+        {
+            "id"     : 1,
+            "value"  : "Overdrive 2"
+        },
+        {
+            "id"     : 2,
+            "value"  : "A. Exciter 1"
+        },
+        {
+            "id"     : 3,
+            "value"  : "A. Exciter 2"
+        },
+        {
+            "id"     : 4,
+            "value"  : "Guitar Amp"
+        },
+        {
+            "id"     : 5,
+            "value"  : "Quantisize"
+        }
+        ]
+    },
+    {
+        "path"     : "/insefx[0,7]/Distorsion/Pvolume",
+        "shortname": "amt",
+        "name"     : "Pvolume",
+        "tooltip"  : "amount of effect",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "127"
+
+    },
+    {
+        "path"     : "/insefx[0,7]/Distorsion/Ppanning",
+        "shortname": "pan",
+        "name"     : "Ppanning",
+        "tooltip"  : "panning",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/insefx[0,7]/Distorsion/Plrcross",
+        "shortname": "l/r",
+        "name"     : "Plrcross",
+        "tooltip"  : "Left/Right Crossover",
+        "type"     : "i",
+        "default"  : "35"
+
+    },
+    {
+        "path"     : "/insefx[0,7]/Distorsion/Pdrive",
+        "shortname": "drive",
+        "name"     : "Pdrive",
+        "tooltip"  : "Input amplification",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/insefx[0,7]/Distorsion/Plevel",
+        "shortname": "output",
+        "name"     : "Plevel",
+        "tooltip"  : "Output amplification",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/insefx[0,7]/Distorsion/Ptype",
+        "shortname": "type",
+        "name"     : "Ptype",
+        "tooltip"  : "Distortion Shape",
+        "type"     : "i",
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "Arctangent"
+        },
+        {
+            "id"     : 1,
+            "value"  : "Asymmetric"
+        },
+        {
+            "id"     : 2,
+            "value"  : "Pow"
+        },
+        {
+            "id"     : 3,
+            "value"  : "Sine"
+        },
+        {
+            "id"     : 4,
+            "value"  : "Quantisize"
+        },
+        {
+            "id"     : 5,
+            "value"  : "Zigzag"
+        },
+        {
+            "id"     : 6,
+            "value"  : "Limiter"
+        },
+        {
+            "id"     : 7,
+            "value"  : "Upper Limiter"
+        },
+        {
+            "id"     : 8,
+            "value"  : "Lower Limiter"
+        },
+        {
+            "id"     : 9,
+            "value"  : "Inverse Limiter"
+        },
+        {
+            "id"     : 10,
+            "value"  : "Clip"
+        },
+        {
+            "id"     : 11,
+            "value"  : "Asym2"
+        },
+        {
+            "id"     : 12,
+            "value"  : "Pow2"
+        },
+        {
+            "id"     : 13,
+            "value"  : "Sigmoid"
+        },
+        {
+            "id"     : 14,
+            "value"  : "Tanh"
+        },
+        {
+            "id"     : 15,
+            "value"  : "Cubic"
+        },
+        {
+            "id"     : 16,
+            "value"  : "Square"
+        }
+        ]
+    },
+    {
+        "path"     : "/insefx[0,7]/Distorsion/Pnegate",
+        "shortname": "neg",
+        "name"     : "Pnegate",
+        "tooltip"  : "Negate Signal",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/insefx[0,7]/Distorsion/Plpf",
+        "shortname": "lpf",
+        "name"     : "Plpf",
+        "tooltip"  : "Low Pass Cutoff",
+        "type"     : "i",
+        "default"  : "127"
+
+    },
+    {
+        "path"     : "/insefx[0,7]/Distorsion/Phpf",
+        "shortname": "hpf",
+        "name"     : "Phpf",
+        "tooltip"  : "High Pass Cutoff",
+        "type"     : "i",
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/insefx[0,7]/Distorsion/Pstereo",
+        "shortname": "stereo",
+        "name"     : "Pstereo",
+        "tooltip"  : "Stereo",
+        "type"     : "t"
+    },
+    {
+        "path"     : "/insefx[0,7]/Distorsion/Pprefiltering",
+        "shortname": "p.filt",
+        "name"     : "Pprefiltering",
+        "tooltip"  : "Filtering before/after non-linearity",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/insefx[0,7]/Distorsion/Pfuncpar",
+        "shortname": "shape",
+        "name"     : "Pfuncpar",
+        "tooltip"  : "Shape of the wave shaping function",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "32"
+
+    },
+    {
+        "path"     : "/insefx[0,7]/Distorsion/Poffset",
+        "shortname": "offset",
+        "name"     : "Poffset",
+        "tooltip"  : "Input DC Offset",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/insefx[0,7]/DynamicFilter/Pvolume",
+        "shortname": "amt",
+        "name"     : "Pvolume",
+        "tooltip"  : "amount of effect",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "110"
+
+    },
+    {
+        "path"     : "/insefx[0,7]/DynamicFilter/Ppanning",
+        "shortname": "pan",
+        "name"     : "Ppanning",
+        "tooltip"  : "panning",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/insefx[0,7]/DynamicFilter/Pfreq",
+        "shortname": "freq",
+        "name"     : "Pfreq",
+        "tooltip"  : "Effect Frequency",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/insefx[0,7]/DynamicFilter/Pfreqrnd",
+        "shortname": "rand",
+        "name"     : "Pfreqrnd",
+        "tooltip"  : "Frequency Randomness",
+        "type"     : "i",
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/insefx[0,7]/DynamicFilter/PLFOtype",
+        "shortname": "shape",
+        "name"     : "PLFOtype",
+        "tooltip"  : "LFO Shape",
+        "type"     : "i",
+        "default"  : "sin"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "sin"
+        },
+        {
+            "id"     : 1,
+            "value"  : "tri"
+        }
+        ]
+    },
+    {
+        "path"     : "/insefx[0,7]/DynamicFilter/PStereo",
+        "shortname": "stereo",
+        "name"     : "PStereo",
+        "tooltip"  : "Stereo Mode",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/insefx[0,7]/DynamicFilter/Pdepth",
+        "shortname": "depth",
+        "name"     : "Pdepth",
+        "tooltip"  : "LFO Depth",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/insefx[0,7]/DynamicFilter/Pampsns",
+        "shortname": "sense",
+        "name"     : "Pampsns",
+        "tooltip"  : "how the filter varies according to the input amplitude",
+        "type"     : "i",
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/insefx[0,7]/DynamicFilter/Pampsnsinv",
+        "shortname": "sns.inv",
+        "name"     : "Pampsnsinv",
+        "tooltip"  : "Sense Inversion",
+        "type"     : "i",
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/insefx[0,7]/DynamicFilter/Pampsmooth",
+        "shortname": "smooth",
+        "name"     : "Pampsmooth",
+        "tooltip"  : "how smooth the input amplitude changes the filter",
+        "type"     : "i",
+        "default"  : "60"
+
+    },
+    {
+        "path"     : "/insefx[0,7]/Echo/preset",
+        "name"     : "preset",
+        "tooltip"  : "Instrument Presets",
+        "type"     : "i",
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "Echo 1"
+        },
+        {
+            "id"     : 1,
+            "value"  : "Echo 2"
+        },
+        {
+            "id"     : 2,
+            "value"  : "Echo 3"
+        },
+        {
+            "id"     : 3,
+            "value"  : "Simple Echo"
+        },
+        {
+            "id"     : 4,
+            "value"  : "Canyon"
+        },
+        {
+            "id"     : 5,
+            "value"  : "Panning Echo 1"
+        },
+        {
+            "id"     : 6,
+            "value"  : "Panning Echo 2"
+        },
+        {
+            "id"     : 7,
+            "value"  : "Panning Echo 3"
+        },
+        {
+            "id"     : 8,
+            "value"  : "Feedback Echo"
+        }
+        ]
+    },
+    {
+        "path"     : "/insefx[0,7]/Echo/Pvolume",
+        "shortname": "amt",
+        "name"     : "Pvolume",
+        "tooltip"  : "amount of effect",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "67"
+
+    },
+    {
+        "path"     : "/insefx[0,7]/Echo/Ppanning",
+        "shortname": "pan",
+        "name"     : "Ppanning",
+        "tooltip"  : "panning",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/insefx[0,7]/Echo/Pdelay",
+        "shortname": "delay",
+        "name"     : "Pdelay",
+        "tooltip"  : "Length of Echo",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/insefx[0,7]/Echo/Plrdelay",
+        "shortname": "lr delay",
+        "name"     : "Plrdelay",
+        "tooltip"  : "Difference In Left/Right Delay",
+        "type"     : "i",
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/insefx[0,7]/Echo/Plrcross",
+        "shortname": "cross",
+        "name"     : "Plrcross",
+        "tooltip"  : "Left/Right Crossover",
+        "type"     : "i",
+        "default"  : "30"
+
+    },
+    {
+        "path"     : "/insefx[0,7]/Echo/Pfb",
+        "shortname": "feedback",
+        "name"     : "Pfb",
+        "tooltip"  : "Echo Feedback",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/insefx[0,7]/Echo/Phidamp",
+        "shortname": "damp",
+        "name"     : "Phidamp",
+        "tooltip"  : "Dampen High Frequencies",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/insefx[0,7]/EQ/filter[0,7]/Ptype",
+        "shortname": "type",
+        "name"     : "Ptype",
+        "tooltip"  : "Filter Type",
+        "type"     : "i",
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "Off"
+        },
+        {
+            "id"     : 1,
+            "value"  : "LP1"
+        },
+        {
+            "id"     : 2,
+            "value"  : "HP1"
+        },
+        {
+            "id"     : 3,
+            "value"  : "LP2"
+        },
+        {
+            "id"     : 4,
+            "value"  : "HP2"
+        },
+        {
+            "id"     : 5,
+            "value"  : "BP"
+        },
+        {
+            "id"     : 6,
+            "value"  : "notch"
+        },
+        {
+            "id"     : 7,
+            "value"  : "peak"
+        },
+        {
+            "id"     : 8,
+            "value"  : "l.shelf"
+        },
+        {
+            "id"     : 9,
+            "value"  : "h.shelf"
+        }
+        ]
+    },
+    {
+        "path"     : "/insefx[0,7]/EQ/filter[0,7]/Pfreq",
+        "shortname": "freq",
+        "name"     : "Pfreq",
+        "tooltip"  : "",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/insefx[0,7]/EQ/filter[0,7]/Pgain",
+        "shortname": "gain",
+        "name"     : "Pgain",
+        "tooltip"  : "",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/insefx[0,7]/EQ/filter[0,7]/Pq",
+        "shortname": "q",
+        "name"     : "Pq",
+        "tooltip"  : "Resonance/Bandwidth",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/insefx[0,7]/EQ/filter[0,7]/Pstages",
+        "shortname": "stages",
+        "name"     : "Pstages",
+        "tooltip"  : "Additional filter stages",
+        "type"     : "i",
+        "range"    : [0,4]
+    },
+    {
+        "path"     : "/insefx[0,7]/Phaser/preset",
+        "name"     : "preset",
+        "tooltip"  : "Instrument Presets",
+        "type"     : "i",
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "Phaser 1"
+        },
+        {
+            "id"     : 1,
+            "value"  : "Phaser 2"
+        },
+        {
+            "id"     : 2,
+            "value"  : "Phaser 3"
+        },
+        {
+            "id"     : 3,
+            "value"  : "Phaser 4"
+        },
+        {
+            "id"     : 4,
+            "value"  : "Phaser 5"
+        },
+        {
+            "id"     : 5,
+            "value"  : "Phaser 6"
+        },
+        {
+            "id"     : 6,
+            "value"  : "APhaser 1"
+        },
+        {
+            "id"     : 7,
+            "value"  : "APhaser 2"
+        },
+        {
+            "id"     : 8,
+            "value"  : "APhaser 3"
+        },
+        {
+            "id"     : 9,
+            "value"  : "APhaser 4"
+        },
+        {
+            "id"     : 10,
+            "value"  : "APhaser 5"
+        },
+        {
+            "id"     : 11,
+            "value"  : "APhaser 6"
+        }
+        ]
+    },
+    {
+        "path"     : "/insefx[0,7]/Phaser/Pvolume",
+        "shortname": "amt",
+        "name"     : "Pvolume",
+        "tooltip"  : "amount of effect",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/insefx[0,7]/Phaser/Ppanning",
+        "shortname": "pan",
+        "name"     : "Ppanning",
+        "tooltip"  : "panning",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/insefx[0,7]/Phaser/lfo.Pfreq",
+        "shortname": "freq",
+        "name"     : "lfo.Pfreq",
+        "tooltip"  : "LFO frequency",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/insefx[0,7]/Phaser/lfo.Prandomness",
+        "shortname": "rnd.",
+        "name"     : "lfo.Prandomness",
+        "tooltip"  : "LFO randomness",
+        "type"     : "i",
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/insefx[0,7]/Phaser/lfo.PLFOtype",
+        "shortname": "type",
+        "name"     : "lfo.PLFOtype",
+        "tooltip"  : "lfo shape",
+        "type"     : "i",
+        "default"  : "sine"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "sine"
+        },
+        {
+            "id"     : 1,
+            "value"  : "tri"
+        }
+        ]
+    },
+    {
+        "path"     : "/insefx[0,7]/Phaser/lfo.Pstereo",
+        "shortname": "stereo",
+        "name"     : "lfo.Pstereo",
+        "tooltip"  : "Left/right channel phase shift",
+        "type"     : "i",
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/insefx[0,7]/Phaser/Pdepth",
+        "shortname": "depth",
+        "name"     : "Pdepth",
+        "tooltip"  : "LFP depth",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/insefx[0,7]/Phaser/Pfb",
+        "shortname": "fb",
+        "name"     : "Pfb",
+        "tooltip"  : "Feedback",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/insefx[0,7]/Phaser/Pstages",
+        "shortname": "stages",
+        "name"     : "Pstages",
+        "tooltip"  : "",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [1,12]
+    },
+    {
+        "path"     : "/insefx[0,7]/Phaser/Plrcross",
+        "shortname": "cross",
+        "name"     : "Plrcross",
+        "tooltip"  : "Channel routing",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/insefx[0,7]/Phaser/Poffset",
+        "shortname": "off",
+        "name"     : "Poffset",
+        "tooltip"  : "Offset",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/insefx[0,7]/Phaser/Poutsub",
+        "shortname": "sub",
+        "name"     : "Poutsub",
+        "tooltip"  : "Invert output",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/insefx[0,7]/Phaser/Pphase",
+        "shortname": "phase",
+        "name"     : "Pphase",
+        "tooltip"  : "",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/insefx[0,7]/Phaser/Pwidth",
+        "shortname": "width",
+        "name"     : "Pwidth",
+        "tooltip"  : "",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/insefx[0,7]/Phaser/Phyper",
+        "shortname": "hyp.",
+        "name"     : "Phyper",
+        "tooltip"  : "Square the LFO",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/insefx[0,7]/Phaser/Pdistortion",
+        "shortname": "distort",
+        "name"     : "Pdistortion",
+        "tooltip"  : "Distortion",
+        "type"     : "i",
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/insefx[0,7]/Phaser/Panalog",
+        "shortname": "analog",
+        "name"     : "Panalog",
+        "tooltip"  : "Use analog phaser",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/insefx[0,7]/Reverb/preset",
+        "name"     : "preset",
+        "tooltip"  : "Instrument Presets",
+        "type"     : "i",
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "Cathedral1"
+        },
+        {
+            "id"     : 1,
+            "value"  : "Cathedral2"
+        },
+        {
+            "id"     : 2,
+            "value"  : "Cathedral3"
+        },
+        {
+            "id"     : 3,
+            "value"  : "Hall1"
+        },
+        {
+            "id"     : 4,
+            "value"  : "Hall2"
+        },
+        {
+            "id"     : 5,
+            "value"  : "Room1"
+        },
+        {
+            "id"     : 6,
+            "value"  : "Room2"
+        },
+        {
+            "id"     : 7,
+            "value"  : "Basement"
+        },
+        {
+            "id"     : 8,
+            "value"  : "Tunnel"
+        },
+        {
+            "id"     : 9,
+            "value"  : "Echoed1"
+        },
+        {
+            "id"     : 10,
+            "value"  : "Echoed2"
+        },
+        {
+            "id"     : 11,
+            "value"  : "VeryLong1"
+        },
+        {
+            "id"     : 12,
+            "value"  : "VeryLong2"
+        }
+        ]
+    },
+    {
+        "path"     : "/insefx[0,7]/Reverb/Pvolume",
+        "shortname": "amt",
+        "name"     : "Pvolume",
+        "tooltip"  : "amount of effect",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "90"
+
+    },
+    {
+        "path"     : "/insefx[0,7]/Reverb/Ppanning",
+        "shortname": "pan",
+        "name"     : "Ppanning",
+        "tooltip"  : "panning",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/insefx[0,7]/Reverb/Ptime",
+        "shortname": "time",
+        "name"     : "Ptime",
+        "tooltip"  : "Length of Reverb",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/insefx[0,7]/Reverb/Pidelay",
+        "shortname": "i.time",
+        "name"     : "Pidelay",
+        "tooltip"  : "Delay for first impulse",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/insefx[0,7]/Reverb/Pidelayfb",
+        "shortname": "i.fb",
+        "name"     : "Pidelayfb",
+        "tooltip"  : "Feedback for first impulse",
+        "type"     : "i",
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/insefx[0,7]/Reverb/Plpf",
+        "shortname": "lpf",
+        "name"     : "Plpf",
+        "tooltip"  : "Low pass filter",
+        "type"     : "i",
+        "default"  : "127"
+
+    },
+    {
+        "path"     : "/insefx[0,7]/Reverb/Phpf",
+        "shortname": "hpf",
+        "name"     : "Phpf",
+        "tooltip"  : "High pass filter",
+        "type"     : "i",
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/insefx[0,7]/Reverb/Plohidamp",
+        "shortname": "damp",
+        "name"     : "Plohidamp",
+        "tooltip"  : ":default 0",
+        "type"     : "i",
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/insefx[0,7]/Reverb/Ptype",
+        "shortname": "type",
+        "name"     : "Ptype",
+        "tooltip"  : "Type",
+        "type"     : "i",
+        "default"  : "Random"
+,
+        "options"  : [
+        {
+            "id"     : 0,
+            "value"  : "Random"
+        },
+        {
+            "id"     : 1,
+            "value"  : "Freeverb"
+        },
+        {
+            "id"     : 2,
+            "value"  : "Bandwidth"
+        }
+        ]
+    },
+    {
+        "path"     : "/insefx[0,7]/Reverb/Proomsize",
+        "shortname": "size",
+        "name"     : "Proomsize",
+        "tooltip"  : "Room Size",
+        "type"     : "i",
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/insefx[0,7]/Reverb/Pbandwidth",
+        "shortname": "bw",
+        "name"     : "Pbandwidth",
+        "tooltip"  : "Bandwidth",
+        "type"     : "i",
+        "default"  : "20"
+
+    },
+    {
+        "path"     : "/microtonal/Pinvertupdown",
+        "shortname": "inv.",
+        "name"     : "Pinvertupdown",
+        "tooltip"  : "key mapping inverse",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/microtonal/Pinvertupdowncenter",
+        "shortname": "center",
+        "name"     : "Pinvertupdowncenter",
+        "tooltip"  : "center of the inversion",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "60"
+
+    },
+    {
+        "path"     : "/microtonal/Penabled",
+        "shortname": "enable",
+        "name"     : "Penabled",
+        "tooltip"  : "Enable for microtonal mode",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/microtonal/PAnote",
+        "shortname": "1/1 midi note",
+        "name"     : "PAnote",
+        "tooltip"  : "The note for 'A'",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "69"
+
+    },
+    {
+        "path"     : "/microtonal/PAfreq",
+        "shortname": "ref freq",
+        "name"     : "PAfreq",
+        "tooltip"  : "Frequency of the 'A' note",
+        "scale"    : "logarithmic",
+        "type"     : "f",
+        "range"    : [1.0,20000.0],
+        "default"  : "440.0f"
+
+    },
+    {
+        "path"     : "/microtonal/Pscaleshift",
+        "shortname": "shift",
+        "name"     : "Pscaleshift",
+        "tooltip"  : "UNDOCUMENTED",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/microtonal/Pfirstkey",
+        "shortname": "first key",
+        "name"     : "Pfirstkey",
+        "tooltip"  : "First key to retune",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/microtonal/Plastkey",
+        "shortname": "last key",
+        "name"     : "Plastkey",
+        "tooltip"  : "Last key to retune",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "127"
+
+    },
+    {
+        "path"     : "/microtonal/Pmiddlenote",
+        "shortname": "middle",
+        "name"     : "Pmiddlenote",
+        "tooltip"  : "Scale degree 0 note",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "60"
+
+    },
+    {
+        "path"     : "/microtonal/Pmapsize",
+        "name"     : "Pmapsize",
+        "tooltip"  : "Size of key map",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "12"
+
+    },
+    {
+        "path"     : "/microtonal/Pmappingenabled",
+        "name"     : "Pmappingenabled",
+        "tooltip"  : "Mapping Enable",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/microtonal/Pmapping[0,127]",
+        "name"     : "Pmapping#128",
+        "tooltip"  : "Mapping of keys",
+        "type"     : "i",
+        "default"  : "[0 1 ...]"
+
+    },
+    {
+        "path"     : "/microtonal/Pglobalfinedetune",
+        "shortname": "fine",
+        "name"     : "Pglobalfinedetune",
+        "tooltip"  : "Fine detune for all notes",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/microtonal/Pname",
+        "shortname": "name",
+        "name"     : "Pname",
+        "tooltip"  : "Microtonal Name",
+        "type"     : "s",
+        "default"  : "\"12tET\""
+
+    },
+    {
+        "path"     : "/microtonal/Pcomment",
+        "shortname": "comment",
+        "name"     : "Pcomment",
+        "tooltip"  : "Microtonal comments",
+        "type"     : "s",
+        "default"  : "\"Equal Temperament 12 notes per octave\""
+
+    },
+    {
+        "path"     : "/ctl/panning.depth",
+        "shortname": "pan.d",
+        "name"     : "panning.depth",
+        "tooltip"  : "Depth of Panning MIDI Control",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/ctl/filtercutoff.depth",
+        "shortname": "fc.d",
+        "name"     : "filtercutoff.depth",
+        "tooltip"  : "Depth of Filter Cutoff MIDI Control",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/ctl/filterq.depth",
+        "shortname": "fq.d",
+        "name"     : "filterq.depth",
+        "tooltip"  : "Depth of Filter Q MIDI Control",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/ctl/bandwidth.depth",
+        "shortname": "bw.d",
+        "name"     : "bandwidth.depth",
+        "tooltip"  : "Depth of Bandwidth MIDI Control",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/ctl/bandwidth.exponential",
+        "shortname": "bw.exp",
+        "name"     : "bandwidth.exponential",
+        "tooltip"  : "Bandwidth Exponential Mode",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/ctl/modwheel.depth",
+        "shortname": "mdw.d",
+        "name"     : "modwheel.depth",
+        "tooltip"  : "Depth of Modwheel MIDI Control",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "80"
+
+    },
+    {
+        "path"     : "/ctl/modwheel.exponential",
+        "shortname": "mdw.exp",
+        "name"     : "modwheel.exponential",
+        "tooltip"  : "Modwheel Exponential Mode",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/ctl/pitchwheel.is_split",
+        "name"     : "pitchwheel.is_split",
+        "tooltip"  : "If PitchWheel has unified bendrange or not",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/ctl/pitchwheel.bendrange",
+        "shortname": "pch.d",
+        "name"     : "pitchwheel.bendrange",
+        "tooltip"  : "Range of MIDI Pitch Wheel",
+        "units"    : "% of semitone",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [-6400,6400],
+        "default"  : "200"
+
+    },
+    {
+        "path"     : "/ctl/pitchwheel.bendrange_down",
+        "name"     : "pitchwheel.bendrange_down",
+        "tooltip"  : "Lower Range of MIDI Pitch Wheel",
+        "type"     : "i",
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/ctl/expression.receive",
+        "shortname": "exp.rcv",
+        "name"     : "expression.receive",
+        "tooltip"  : "Expression MIDI Receive",
+        "type"     : "t",
+        "default"  : "true"
+
+    },
+    {
+        "path"     : "/ctl/fmamp.receive",
+        "shortname": "fma.rcv",
+        "name"     : "fmamp.receive",
+        "tooltip"  : "FM amplitude MIDI Receive",
+        "type"     : "t",
+        "default"  : "true"
+
+    },
+    {
+        "path"     : "/ctl/volume.receive",
+        "shortname": "vol.rcv",
+        "name"     : "volume.receive",
+        "tooltip"  : "Volume MIDI Receive",
+        "type"     : "t",
+        "default"  : "true"
+
+    },
+    {
+        "path"     : "/ctl/sustain.receive",
+        "shortname": "sus.rcv",
+        "name"     : "sustain.receive",
+        "tooltip"  : "Sustain MIDI Receive",
+        "type"     : "t",
+        "default"  : "true"
+
+    },
+    {
+        "path"     : "/ctl/portamento.receive",
+        "shortname": "prt.rcv",
+        "name"     : "portamento.receive",
+        "tooltip"  : "Portamento MIDI Receive",
+        "type"     : "t",
+        "default"  : "true"
+
+    },
+    {
+        "path"     : "/ctl/portamento.portamento",
+        "name"     : "portamento.portamento",
+        "tooltip"  : "Portamento Enable",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/ctl/portamento.time",
+        "shortname": "time",
+        "name"     : "portamento.time",
+        "tooltip"  : "Portamento Length",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/ctl/portamento.proportional",
+        "shortname": "propt.",
+        "name"     : "portamento.proportional",
+        "tooltip"  : "Whether the portamento time is proportionalto the size of the interval between two notes.",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
+        "path"     : "/ctl/portamento.propRate",
+        "shortname": "scale",
+        "name"     : "portamento.propRate",
+        "tooltip"  : "Portamento proportional scale",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "80"
+
+    },
+    {
+        "path"     : "/ctl/portamento.propDepth",
+        "shortname": "depth",
+        "name"     : "portamento.propDepth",
+        "tooltip"  : "Portamento proportional depth",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "90"
+
+    },
+    {
+        "path"     : "/ctl/portamento.pitchthresh",
+        "shortname": "thresh",
+        "name"     : "portamento.pitchthresh",
+        "tooltip"  : "Threshold for portamento",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "3"
+
+    },
+    {
+        "path"     : "/ctl/portamento.pitchthreshtype",
+        "shortname": "tr.type",
+        "name"     : "portamento.pitchthreshtype",
+        "tooltip"  : "Type of threshold",
+        "type"     : "t",
+        "default"  : "true"
+
+    },
+    {
+        "path"     : "/ctl/portamento.updowntimestretch",
+        "shortname": "up/dwn",
+        "name"     : "portamento.updowntimestretch",
+        "tooltip"  : "Relative length of glide up vs glide down",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/ctl/resonancecenter.depth",
+        "shortname": "rfc.d",
+        "name"     : "resonancecenter.depth",
+        "tooltip"  : "Resonance Center MIDI Depth",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/ctl/resonancebandwidth.depth",
+        "shortname": "rbw.d",
+        "name"     : "resonancebandwidth.depth",
+        "tooltip"  : "Resonance Bandwidth MIDI Depth",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/ctl/NRPN.receive",
+        "name"     : "NRPN.receive",
+        "tooltip"  : "NRPN MIDI Enable",
+        "type"     : "t",
+        "default"  : "true"
+
+    },
+    {
+        "path"     : "/Pinsparts[0,7]",
+        "name"     : "Pinsparts#8",
+        "tooltip"  : "Part to insert part onto",
+        "type"     : "i",
+        "default"  : "[Off ...]"
+,
+        "options"  : [
+        {
+            "id"     : -2,
+            "value"  : "Master"
+        },
+        {
+            "id"     : -1,
+            "value"  : "Off"
+        },
+        {
+            "id"     : 0,
+            "value"  : "Part1"
+        },
+        {
+            "id"     : 1,
+            "value"  : "Part2"
+        },
+        {
+            "id"     : 2,
+            "value"  : "Part3"
+        },
+        {
+            "id"     : 3,
+            "value"  : "Part4"
+        },
+        {
+            "id"     : 4,
+            "value"  : "Part5"
+        },
+        {
+            "id"     : 5,
+            "value"  : "Part6"
+        },
+        {
+            "id"     : 6,
+            "value"  : "Part7"
+        },
+        {
+            "id"     : 7,
+            "value"  : "Part8"
+        },
+        {
+            "id"     : 8,
+            "value"  : "Part9"
+        },
+        {
+            "id"     : 9,
+            "value"  : "Part10"
+        },
+        {
+            "id"     : 10,
+            "value"  : "Part11"
+        },
+        {
+            "id"     : 11,
+            "value"  : "Part12"
+        },
+        {
+            "id"     : 12,
+            "value"  : "Part13"
+        },
+        {
+            "id"     : 13,
+            "value"  : "Part14"
+        },
+        {
+            "id"     : 14,
+            "value"  : "Part15"
+        },
+        {
+            "id"     : 15,
+            "value"  : "Part16"
+        }
+        ]
+    },
+    {
+        "path"     : "/Pkeyshift",
+        "shortname": "key shift",
+        "name"     : "Pkeyshift",
+        "tooltip"  : "Global Key Shift",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "64"
+
+    },
+    {
+        "path"     : "/Pvolume",
+        "shortname": "volume",
+        "name"     : "Pvolume",
+        "tooltip"  : "Master Volume",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127],
+        "default"  : "80"
+
+    },
+    {
+        "path"     : "/volume",
+        "shortname": "volume",
+        "name"     : "volume",
+        "tooltip"  : "Master Volume",
+        "scale"    : "linear",
+        "type"     : "i",
+        "range"    : [0,127]
+    },
+    {
+        "path"     : "/Volume",
+        "shortname": "volume",
+        "name"     : "Volume",
+        "tooltip"  : "Master Volume",
+        "units"    : "dB",
+        "scale"    : "linear",
+        "type"     : "f",
+        "range"    : [-40.0f,13.3333f],
+        "default"  : "-6.66667f"
+
+    },
+    {
+        "path"     : "/Psysefxvol[0,3]/part[0,15]",
+        "name"     : "part#16",
+        "tooltip"  : "gain on part to sysefx routing",
+        "type"     : "i",
+        "default"  : "[0...]"
+
+    },
+    {
+        "path"     : "/sysefxfrom[0,3]/to[0,3]",
+        "name"     : "to#4",
+        "tooltip"  : "sysefx to sysefx routing gain",
+        "type"     : "i",
+        "default"  : "[0...]"
+
+    },
+    {
+        "path"     : "/automate/active-slot",
+        "name"     : "active-slot",
+        "tooltip"  : "Active Slot for macro learning",
+        "type"     : "i",
+        "range"    : [-1,16]
+    },
+    {
+        "path"     : "/automate/slot[0,15]/value",
+        "name"     : "value",
+        "tooltip"  : "Access current value in slot 'i' (0..1)",
+        "scale"    : "linear",
+        "type"     : "f",
+        "range"    : [0,1],
+        "default"  : "0.5"
+
+    },
+    {
+        "path"     : "/automate/slot[0,15]/name",
+        "name"     : "name",
+        "tooltip"  : "Access name of automation slot",
+        "type"     : "s"
+    },
+    {
+        "path"     : "/automate/slot[0,15]/midi-cc",
+        "name"     : "midi-cc",
+        "tooltip"  : "Access assigned midi CC slot",
+        "type"     : "i",
+        "default"  : "-1"
+
+    },
+    {
+        "path"     : "/automate/slot[0,15]/midi-nrpn",
+        "name"     : "midi-nrpn",
+        "tooltip"  : "Access assigned midi NRPN slot",
+        "type"     : "i",
+        "default"  : "-1"
+
+    },
+    {
+        "path"     : "/automate/slot[0,15]/active",
+        "name"     : "active",
+        "tooltip"  : "If Slot is enabled",
+        "type"     : "t",
+        "default"  : "F"
+
+    },
+    {
+        "path"     : "/automate/slot[0,15]/learning",
+        "name"     : "learning",
+        "tooltip"  : "If slot is trying to find a midi learn binding",
+        "type"     : "i",
+        "default"  : "-1"
+
+    },
+    {
+        "path"     : "/automate/slot[0,15]/param[0,3]/used",
+        "name"     : "used",
+        "tooltip"  : "If automation is assigned to anything",
+        "type"     : "t"
+    },
+    {
+        "path"     : "/automate/slot[0,15]/param[0,3]/active",
+        "name"     : "active",
+        "tooltip"  : "If automation is being actively used",
+        "type"     : "t"
+    },
+    {
+        "path"     : "/automate/slot[0,15]/param[0,3]/path",
+        "name"     : "path",
+        "tooltip"  : "Path of parameter",
+        "type"     : "s"
+    },
+    {
+        "path"     : "/automate/slot[0,15]/param[0,3]/mapping/offset",
+        "shortname": "off",
+        "name"     : "offset",
+        "tooltip"  : "",
+        "units"    : "percent",
+        "scale"    : "linear",
+        "type"     : "f",
+        "range"    : [-50,50],
+        "default"  : "0"
+
+    },
+    {
+        "path"     : "/automate/slot[0,15]/param[0,3]/mapping/gain",
+        "shortname": "gain",
+        "name"     : "gain",
+        "tooltip"  : "",
+        "units"    : "percent",
+        "scale"    : "linear",
+        "type"     : "f",
+        "range"    : [-200,200],
+        "default"  : "100"
+
+    },
+    {
+        "path"     : "/config/cfg.SampleRate",
+        "name"     : "cfg.SampleRate",
+        "tooltip"  : "samples of audio per second",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/config/cfg.SoundBufferSize",
+        "name"     : "cfg.SoundBufferSize",
+        "tooltip"  : "Size of processed audio buffer",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/config/cfg.OscilSize",
+        "name"     : "cfg.OscilSize",
+        "tooltip"  : "Size Of Oscillator Wavetable",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/config/cfg.SwapStereo",
+        "name"     : "cfg.SwapStereo",
+        "tooltip"  : "Swap Left And Right Channels",
+        "type"     : "t"
+    },
+    {
+        "path"     : "/config/cfg.BankUIAutoClose",
+        "name"     : "cfg.BankUIAutoClose",
+        "tooltip"  : "Automatic Closing of BackUI After Patch Selection",
+        "type"     : "t"
+    },
+    {
+        "path"     : "/config/cfg.GzipCompression",
+        "name"     : "cfg.GzipCompression",
+        "tooltip"  : "Level of Gzip Compression For Save Files",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/config/cfg.Interpolation",
+        "name"     : "cfg.Interpolation",
+        "tooltip"  : "Level of Interpolation, Linear/Cubic",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/config/cfg.CheckPADsynth",
+        "name"     : "cfg.CheckPADsynth",
+        "tooltip"  : "Old Check For PADsynth functionality within a patch",
+        "type"     : "t"
+    },
+    {
+        "path"     : "/config/cfg.IgnoreProgramChange",
+        "name"     : "cfg.IgnoreProgramChange",
+        "tooltip"  : "Ignore MIDI Program Change Events",
+        "type"     : "t"
+    },
+    {
+        "path"     : "/config/cfg.UserInterfaceMode",
+        "name"     : "cfg.UserInterfaceMode",
+        "tooltip"  : "Beginner/Advanced Mode Select",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/config/cfg.VirKeybLayout",
+        "name"     : "cfg.VirKeybLayout",
+        "tooltip"  : "Keyboard Layout For Virtual Piano Keyboard",
+        "type"     : "i"
+    },
+    {
+        "path"     : "/config/cfg.OscilPower",
+        "name"     : "cfg.OscilPower",
+        "tooltip"  : "Size Of Oscillator Wavetable",
+        "type"     : "i"
+    }
+    ],
+    "actions" : [
+    ]
+}

--- a/src/osc-bridge/src/bridge.c
+++ b/src/osc-bridge/src/bridge.c
@@ -1,0 +1,948 @@
+#include <rtosc/rtosc.h>
+#include <stdio.h>
+#include <string.h>
+#include <ctype.h>
+#include <assert.h>
+#include <stdlib.h>
+#include "bridge.h"
+
+//Forward declarations for private functions
+static void osc_request(bridge_t *br, const char *path);
+static void run_callbacks(bridge_t *br, param_cache_t *line);
+
+/*****************************************************************************
+ *                                                                           *
+ *                      OSC Bridge Data Cache                                *
+ *                                                                           *
+ *****************************************************************************/
+
+static int cache_has(param_cache_t *c, size_t len, uri_t uri)
+{
+    for(size_t i=0; i<len; ++i)
+        if(!strcmp(c[i].path, uri))
+            return 1;
+    return 0;
+}
+
+static void cache_update(bridge_t *br, param_cache_t *ch)
+{
+    double now  = 1e-3*uv_now(br->loop);
+    uri_t uri   = ch->path;
+    ch->valid   = 0;
+    ch->type    = 0;
+    ch->usable  = 1;
+    ch->pending = 1;
+    ch->force_refresh = 0;
+    ch->request_time = now;
+    ch->requests++;
+    memset(&ch->val, 0, sizeof(ch->val));
+
+    if(osc_request_hook) {
+        char buffer[128];
+        const int len = rtosc_message(buffer, 128, uri, "");
+        if(len <= 0)
+            fprintf(stderr, "[ERROR] Osc Bridge Could Not Request Update For \"%s\"\n", uri);
+    	osc_request_hook(br, buffer);
+    } else
+        osc_request(br, uri);
+}
+
+static void cache_push(bridge_t *br, uri_t uri)
+{
+    if(!uri)
+        return;
+    assert(uri);
+    br->cache_len += 1;
+    br->cache = realloc(br->cache, br->cache_len*sizeof(param_cache_t));
+    param_cache_t *ch = br->cache + (br->cache_len - 1);
+    memset(ch, 0, sizeof(param_cache_t));
+    ch->path    = strdup(uri);
+    cache_update(br, ch);
+}
+
+static param_cache_t *cache_get(bridge_t *br, uri_t uri)
+{
+    for(int i=0; i<br->cache_len; ++i)
+        if(!strcmp(br->cache[i].path, uri))
+	    return br->cache + i;
+    cache_push(br, uri);
+    return cache_get(br, uri);
+}
+
+static rtosc_arg_t
+clone_value(char type, rtosc_arg_t val)
+{
+    if(type == 'b') {
+        char *data = (char*)val.b.data;
+        val.b.data = malloc(val.b.len);
+        memcpy(val.b.data, data, val.b.len);
+    } else if(type == 's') {
+        val.s = strdup(val.s);
+    }
+    return val;
+}
+
+static rtosc_arg_t *
+clone_vec_value(char *type, rtosc_arg_t *val)
+{
+    int n = strlen(type);
+    rtosc_arg_t *nargs = calloc(sizeof(rtosc_arg_t), n);
+    for(int i=0; i<n; ++i) {
+        nargs[i] = clone_value(type[i], val[i]);
+    }
+    return nargs;
+}
+
+static void
+declone_value(char type, rtosc_arg_t val)
+{
+    if(type == 'b')
+        free(val.b.data);
+    else if(type == 's')
+        free(strdup(val.s));
+}
+
+static void
+declone_vec_value(const char *type, rtosc_arg_t *val)
+{
+    int n = strlen(type);
+    for(int i=0; i<n; ++i)
+        declone_value(type[i], val[i]);
+    free(val);
+    free((void*)type);
+}
+
+//returns true when the cache has changed values
+static int cache_set(bridge_t *br, uri_t uri, char type, rtosc_arg_t val, int skip_debounce)
+{
+    param_cache_t *line = cache_get(br, uri);
+    assert(line);
+    line->pending = false;
+    if(!line->valid || line->type != type || memcmp(&line->val, &val, sizeof(val)))
+    {
+        if(line->type == 'v')
+            declone_vec_value(line->vec_type, line->vec_value);
+        else
+            declone_value(line->type, line->val);
+        line->valid = true;
+        line->type  = type;
+        line->val   = clone_value(type, val);
+        line->requests = 0;
+
+        //check if cache line is currently debounced...
+        int debounced = false;
+        for(int i=0; i<br->debounce_len; ++i)
+            if(!strcmp(br->bounce[i].path, line->path))
+                debounced = true;
+
+        if(!debounced || skip_debounce)
+            run_callbacks(br, line);
+
+        return true;
+    }
+    return false;
+}
+
+static int cache_set_vector(bridge_t *br, uri_t uri, char *types, rtosc_arg_t *args)
+{
+    param_cache_t *line = cache_get(br, uri);
+    assert(line);
+    line->pending = false;
+
+    int line_size = line->type == 'v' ? strlen(line->vec_type) : 0;
+
+    //If the line is invalid OR
+    //the cache isn't a vector field OR
+    //the vector fields differ in type OR
+    //the vector fields differ in value
+    if(!line->valid || line->type != 'v' || strcmp(line->vec_type, types) ||
+            memcmp(&line->vec_value, &args, sizeof(args[0])*line_size))
+    {
+        if(line->type == 'v')
+            declone_vec_value(line->vec_type, line->vec_value);
+        else
+            declone_value(line->type, line->val);
+
+        line->valid     = true;
+        line->type      = 'v';
+        line->vec_type  = strdup(types);
+        line->vec_value = clone_vec_value(types, args);
+        line->requests = 0;
+
+        //check if cache line is currently debounced...
+        //int debounced = false;
+        //for(int i=0; i<br->debounce_len; ++i)
+        //    if(!strcmp(br->bounce[i].path, line->path))
+        //        debounced = true;
+
+        //if(!debounced)
+            run_callbacks(br, line);
+
+        return true;
+    }
+    return false;
+}
+
+/*****************************************************************************
+ *                                                                           *
+ *                            Network Code                                   *
+ *                                                                           *
+ *****************************************************************************/
+
+//Testing Hooks
+int  (*osc_socket_hook)(void) = NULL;
+int  (*osc_request_hook)(bridge_t *, const char *) = NULL;
+
+static void alloc_buffer(uv_handle_t *handle, size_t suggested_size,
+        uv_buf_t *buf) {
+    (void) handle;
+    *buf = uv_buf_init((char*) malloc(suggested_size), suggested_size);
+}
+
+#if 0
+static void hexdump(const char *data, const char *mask, size_t len)
+{
+    const char *bold_gray = "\x1b[30;1m";
+    const char *reset      = "\x1b[0m";
+    int offset = 0;
+    while(1)
+    {
+        //print line
+        printf("#%07x: ", offset);
+
+        int char_covered = 0;
+
+        //print hex groups (8)
+        for(int i=0; i<8; ++i) {
+
+            //print doublet
+            for(int j=0; j<2; ++j) {
+                int loffset = offset + 2*i + j;
+                if(loffset >= (int)len)
+                    goto escape;
+
+                //print hex
+                {
+                    //start highlight
+                    if(mask && mask[loffset]){printf("%s", bold_gray);}
+
+                    //print chars
+                    printf("%02x", 0xff&data[loffset]);
+
+                    //end highlight
+                    if(mask && mask[loffset]){printf("%s", reset);}
+                    char_covered += 2;
+                }
+            }
+            printf(" ");
+            char_covered += 1;
+        }
+escape:
+
+        //print filler if needed
+        for(int i=char_covered; i<41; ++i)
+            printf(" ");
+
+        //print ascii (16)
+        for(int i=0; i<16; ++i) {
+            if(isprint(data[offset+i]))
+                printf("%c", data[offset+i]);
+            else
+                printf(".");
+        }
+        printf("\n");
+        offset += 16;
+        if(offset >= (int)len)
+            return;
+    }
+}
+#endif
+
+void on_read(uv_udp_t *req, ssize_t nread, const uv_buf_t *buf,
+             const struct sockaddr *addr, unsigned flags) {
+    (void) flags;
+    if(nread > 0) {
+
+        const struct sockaddr_in *addr_in = (const struct sockaddr_in *)addr;
+        if(addr) {
+            char sender[17] = { 0 };
+            uv_ip4_name(addr_in, sender, 16);
+            //printf("Recv from %s\n", sender);
+            //printf("port = %d\n", addr_in->sin_port);
+        }
+        //printf("buffer[%d] = %s\n", nread, buf->base);
+        //hexdump(buf->base, 0, nread);
+        bridge_t *br = (bridge_t*)req->data;
+        br_recv(br, buf->base);
+    }
+    free(buf->base);
+    //free(req);
+}
+
+typedef struct {
+    uv_udp_send_t send_req;
+    char *data;
+} req_t;
+
+static void send_cb(uv_udp_send_t* req, int status)
+{
+    (void) status;
+    req_t *request = (req_t*)req;
+    free(request->data);
+    free(request);
+}
+
+//I know that 300 messages within a single frame results in lost packets, so
+//lets identify a reasonable limit of 100 messages per frame
+
+static void do_send(bridge_t *br, char *buffer, unsigned len)
+{
+    if(br->frame_messages >= BR_RATE_LIMIT) {
+        br->rlimit_len++;
+        br->rlimit = (char**)realloc(br->rlimit, sizeof(char**)*br->rlimit_len);
+        br->rlimit[br->rlimit_len-1] = buffer;
+        return;
+    }
+    br->frame_messages++;
+    req_t *request = (req_t*)malloc(sizeof(req_t));
+    request->data  = buffer;
+    uv_buf_t buf   = uv_buf_init((char*)buffer, len);
+
+    struct sockaddr_in send_addr;
+    uv_ip4_addr(br->address, br->port, &send_addr);
+    uv_udp_send(&request->send_req, &br->socket, &buf, 1, (const struct sockaddr *)&send_addr, send_cb);
+    uv_run(br->loop, UV_RUN_NOWAIT);
+}
+
+void osc_request(bridge_t *br, const char *path)
+{
+    char *buffer = (char*)malloc(4096);
+    size_t len   = rtosc_message(buffer, 4096, path, "");
+    do_send(br, buffer, len);
+    //printf("osc request done<%s>?\n", path);
+}
+
+void osc_send(bridge_t *br, const char *message)
+{
+    size_t   len   = rtosc_message_length(message, -1);
+    char     *copy = (char*)malloc(len);
+    memcpy(copy, message, len);
+    do_send(br, copy, len);
+    //printf("osc sent...<%s>?\n", message);
+}
+
+/*****************************************************************************
+ *                                                                           *
+ *                         Bridge Methods                                    *
+ *                                                                           *
+ *****************************************************************************/
+
+bridge_t *br_create(uri_t uri)
+{
+    bridge_t *br = (bridge_t*)calloc(1,sizeof(bridge_t));
+
+    br->loop = (uv_loop_t*)calloc(1, sizeof(uv_loop_t));
+    uv_loop_init(br->loop);
+
+    uv_udp_init(br->loop, &br->socket);
+    int no_collide = rand()%1000;
+    for(int offset=0; offset < 1000; ++offset) {
+        struct sockaddr_in recv_addr;
+        recv_addr.sin_family = AF_INET;
+        recv_addr.sin_port = htons(1338+(offset+no_collide)%1000);
+        recv_addr.sin_addr.s_addr = INADDR_ANY;
+        if(!uv_udp_bind(&br->socket, (const struct sockaddr *)&recv_addr, 0))
+            break;
+    }
+    br->socket.data = br;
+
+    uv_udp_recv_start(&br->socket, alloc_buffer, on_read);
+
+    //parse the url to read
+    if(strstr(uri, "osc.udp://") != uri) {
+        fprintf(stderr, "[ERROR] Unknown protocol in '%s'\n", uri);
+        fprintf(stderr, "[ERROR] Try something like osc.udp://localhost:1234\n");
+        exit(1);
+    }
+    uri = uri+10;
+    char *tmp = br->address = strdup(uri);
+    while(*tmp && *tmp != ':') ++tmp;
+    if(*tmp == ':')
+        *tmp++ = 0;
+
+    br->port = atoi(tmp);
+
+    return br;
+}
+
+static void
+declone_value(char type, rtosc_arg_t val);
+static void
+declone_vec_value(const char *type, rtosc_arg_t *val);
+
+void br_destroy(bridge_t *br)
+{
+    int close;
+    close = uv_udp_recv_stop(&br->socket);
+    if(close)
+        fprintf(stderr, "[Warning] UV UDP cannot be stopped [%d] (UV_EBUSY=%d)\n", close, UV_EBUSY);
+    else
+        fprintf(stderr, "[INFO] UV UDP Stopped\n");
+    uv_close((uv_handle_t*)&br->socket, NULL);
+
+    //Flush Events
+    int i=100;
+    while(uv_run(br->loop, UV_RUN_NOWAIT) > 1)
+        if(i-- < 0)
+            break;
+
+    close = uv_loop_close(br->loop);
+    if(close)
+        fprintf(stderr, "[Warning] UV Loop Cannot be closed [%d] (UV_EBUSY=%d)\n", close, UV_EBUSY);
+    else
+        fprintf(stderr, "[INFO] UV Loop Stopped\n");
+    free(br->loop);
+
+    for(int i=0; i<br->cache_len; ++i) {
+        free((void*)br->cache[i].path);
+        if(br->cache[i].type == 'v') {
+            declone_vec_value(br->cache[i].vec_type, br->cache[i].vec_value);
+            //free((void*)br->cache[i].vec_type);
+            //free((void*)br->cache[i].vec_value);
+        } else
+            declone_value(br->cache[i].type, br->cache[i].val);
+    }
+    free(br->cache);
+    free(br->bounce);
+    for(int i=0; i<br->callback_len; ++i) {
+        free((void*)br->callback[i].data);
+        free((void*)br->callback[i].path);
+    }
+    free(br->callback);
+    free(br->address);
+    free(br);
+}
+
+void parse_schema(const char *json, schema_t *sch);
+schema_t br_get_schema(bridge_t *br, uri_t uri)
+{
+    (void) uri;
+    schema_t sch;
+
+    //printf("[debug] loading json file\n");
+    FILE *f = fopen("schema/test.json", "r");
+    if(!f && br->search_path) {
+        char tmp[256];
+        snprintf(tmp, sizeof(tmp), "%s%s", br->search_path, "schema/test.json");
+        f = fopen(tmp, "r");
+    }
+    if(!f)
+        f = fopen("src/osc-bridge/schema/test.json", "r");
+    if(!f) {
+        printf("[ERROR:Zyn] schema/test.json file is missing.\n");
+        printf("[ERROR:Zyn] Please check your installation for problems\n");
+        exit(1);
+    }
+    assert(f && "opening json file");
+    fseek(f, 0, SEEK_END);
+    size_t len = ftell(f);
+    rewind(f);
+    char *json = (char*)calloc(1, len+1);
+    fread(json, 1, len, f);
+    fclose(f);
+
+    printf("[debug] parsing json file\n");
+    parse_schema(json, &sch);
+    printf("[debug] json parsed succesfully\n");
+    sch.json = json;
+
+
+	return sch;
+}
+
+/*****************************************************************************
+ *                                                                           *
+ *                   Bridge Allocation/Destruction                           *
+ *                                                                           *
+ *****************************************************************************/
+
+static void debounce_push(bridge_t *br, param_cache_t *line, double obs)
+{
+    br->debounce_len += 1;
+    br->bounce        = (debounce_t*)realloc(br->bounce, br->debounce_len*sizeof(debounce_t));
+    debounce_t *bo = br->bounce + (br->debounce_len - 1);
+    bo->path = line->path;
+    bo->last_set = obs;
+}
+
+static void debounce_update(bridge_t *br, param_cache_t *line)
+{
+    uv_update_time(br->loop);
+    uint64_t now = uv_now(br->loop);
+    double obs   = 1e-3*now;
+    for(int i=0; i<br->debounce_len; ++i) {
+        if(!strcmp(line->path, br->bounce[i].path)) {
+            br->bounce[i].last_set = obs;
+            return;
+        }
+    }
+    debounce_push(br, line, obs);
+}
+
+static void debounce_pop(bridge_t *br, int idx)
+{
+    assert(idx < br->debounce_len);
+    for(int i=idx; i<br->debounce_len-1; ++i)
+        br->bounce[i] = br->bounce[i+1];
+    br->debounce_len -= 1;
+}
+
+
+static void callback_push(bridge_t *br, uri_t uri, bridge_cb_t cb, void *data)
+{
+    br->callback_len += 1;
+    br->callback = (bridge_callback_t*)realloc(br->callback, br->callback_len*sizeof(bridge_callback_t));
+    bridge_callback_t *ch = br->callback + (br->callback_len - 1);
+    ch->path    = strdup(uri);
+    ch->cb      = cb;
+    ch->data    = data;
+}
+
+static void callback_pop(bridge_t *br, uri_t uri, bridge_cb_t cb, void *data)
+{
+    int len = br->callback_len;
+
+    int idx = 0;
+    while(idx < len) {
+        bridge_callback_t item = br->callback[idx];
+        if(!strcmp(item.path, uri) && item.cb == cb && item.data == data) {
+            //We should remove this element
+
+            //Deallocate resources
+            free((void*)item.path);
+
+            //Move all other items
+            for(int i=idx; i<len-1; ++i)
+                br->callback[i] = br->callback[i+1];
+
+            //Shrink list
+            len--;
+        } else {
+            //move on to the next element of the list
+            idx++;
+        }
+    }
+
+    br->callback_len = len;
+}
+
+
+static int valid_type(char ch)
+{
+    switch(ch)
+    {
+        case 'i'://official types
+        case 's':
+        case 'b':
+        case 'f':
+
+        case 'h'://unofficial
+        case 't':
+        case 'd':
+        case 'S':
+        case 'r':
+        case 'm':
+        case 'c':
+        case 'T':
+        case 'F':
+        case 'N':
+        case 'I':
+            return 1;
+        default:
+            return 0;
+    }
+}
+
+static void
+run_callbacks(bridge_t *br, param_cache_t *line)
+{
+    char buffer[1024*16];
+    int len = 0;
+    if(line->type != 'v') {
+        char args[2] = {line->type, 0};
+        assert(valid_type(line->type));
+        len = rtosc_amessage(buffer, sizeof(buffer), line->path, args, &line->val);
+    } else {
+        len = rtosc_amessage(buffer, sizeof(buffer), line->path, line->vec_type,
+                line->vec_value);
+    }
+
+    if(len == 0) {
+        //TODO USE DYNAMIC ALLOCATION...
+        printf("[ERROR] Message Too long for cache line <%s>\n", line->path);
+        if(line->type != 'v') {
+            char args[2] = {line->type, 0};
+            assert(valid_type(line->type));
+            len = rtosc_amessage(0, 0, line->path, args, &line->val);
+        } else {
+            len = rtosc_amessage(0, 0, line->path, line->vec_type,
+                    line->vec_value);
+        }
+        printf("[ERROR] Needs %d bytes of space...\n", len);
+    }
+
+
+    //run callbacks
+    for(int i=0; i<br->callback_len; ++i)
+        if(!strcmp(br->callback[i].path, line->path))
+            br->callback[i].cb(buffer, br->callback[i].data);
+}
+
+void br_randomize(bridge_t *br, uri_t uri)
+{
+    (void) br;
+    (void) uri;
+    //TODO
+}
+
+void br_default(bridge_t *br, schema_t s, uri_t uri)
+{
+    schema_handle_t handle = sm_get(s, uri);
+    if(!sm_valid(handle))
+        return;
+    if(handle.type == 'i' && handle.default_)
+        br_set_value_int(br, uri, atoi(handle.default_));
+    else if(handle.type == 'f' && handle.default_)
+        br_set_value_float(br, uri, atof(handle.default_));
+}
+
+void br_set_array(bridge_t *br, uri_t uri, char *type, rtosc_arg_t*args)
+{
+    if(cache_set_vector(br, uri, type, args)) {
+        char buffer[1024*8];
+        int len = rtosc_amessage(buffer, sizeof(buffer), uri, type, args);
+        (void) len;
+        //hexdump(buffer, 0, len);
+        osc_send(br, buffer);
+        debounce_update(br, cache_get(br, uri));
+    }
+}
+
+void br_set_value_bool(bridge_t *br, uri_t uri, int value)
+{
+    rtosc_arg_t arg = {.i = value};
+    char type = value ? 'T' : 'F';
+    if(cache_set(br, uri, type, arg, 1)) {
+        char buffer[1024];
+        char typestr[2] = {type, '\0'};
+        rtosc_message(buffer, 1024, uri, typestr, value);
+        osc_send(br, buffer);
+        debounce_update(br, cache_get(br, uri));
+    }
+}
+
+void br_set_value_int(bridge_t *br, uri_t uri, int value)
+{
+    rtosc_arg_t arg = {.i = value};
+    if(cache_set(br, uri, 'i', arg, 1)) {
+        char buffer[1024];
+        rtosc_message(buffer, 1024, uri, "i", value);
+        osc_send(br, buffer);
+        debounce_update(br, cache_get(br, uri));
+    }
+}
+
+void br_set_value_float(bridge_t *br, uri_t uri, float value)
+{
+    rtosc_arg_t arg = {.f = value};
+    if(cache_set(br, uri, 'f', arg, 1)) {
+        char buffer[1024];
+        rtosc_message(buffer, 1024, uri, "f", value);
+        osc_send(br, buffer);
+        debounce_update(br, cache_get(br, uri));
+    }
+}
+
+void br_set_value_string(bridge_t *br, uri_t uri, const char *str)
+{
+    rtosc_arg_t arg = {.s = str};
+    if(cache_set(br, uri, 's', arg, 1)) {
+        char buffer[1024];
+        rtosc_message(buffer, 1024, uri, "s", str);
+        osc_send(br, buffer);
+        //debounce_update(br, cache_get(br, uri));
+    }
+}
+
+int br_has_callback(bridge_t *br, uri_t uri)
+{
+    for(int i=0; i < br->callback_len; ++i)
+        if(!strcmp(br->callback[i].path, uri))
+            return true;
+    return false;
+}
+
+void br_add_callback(bridge_t *br, uri_t uri, bridge_cb_t callback, void *data)
+{
+    assert(br);
+    callback_push(br, uri, callback, data);
+    if(!cache_has(br->cache, br->cache_len, uri)) {
+        cache_push(br, uri);
+    } else {
+        //instantly respond when possible
+        param_cache_t *ch = cache_get(br, uri);
+        if(!ch->valid || !ch->usable) {
+            cache_update(br, ch);
+            return;
+        }
+        char buffer[1024*16];
+        int len = 0;
+
+        if(ch->type != 'v') {
+            char typestr[2] = {ch->type,0};
+            len = rtosc_amessage(buffer, sizeof(buffer), ch->path,
+                    typestr, &ch->val);
+        } else {
+            len = rtosc_amessage(buffer, sizeof(buffer), ch->path, ch->vec_type,
+                    ch->vec_value);
+        }
+        if(len == 0) {
+            //TODO USE DYNAMIC ALLOCATION...
+            printf("[ERROR] Message Too long for cache line <%s> @ %d\n", ch->path, __LINE__);
+            if(ch->type != 'v') {
+                char args[2] = {ch->type, 0};
+                assert(valid_type(ch->type));
+                len = rtosc_amessage(0, 0, ch->path, args, &ch->val);
+            } else {
+                len = rtosc_amessage(0, 0, ch->path, ch->vec_type,
+                        ch->vec_value);
+            }
+            printf("[ERROR] Needs %d bytes of space...\n", len);
+        }
+
+        callback(buffer, data);
+    }
+}
+
+void br_add_action_callback(bridge_t *br, uri_t uri, bridge_cb_t callback, void *data)
+{
+    assert(br);
+    callback_push(br, uri, callback, data);
+}
+
+void br_del_callback(bridge_t *br, uri_t uri, bridge_cb_t callback, void *data)
+{
+    callback_pop(br, uri, callback, data);
+}
+
+void br_damage(bridge_t *br, uri_t dmg)
+{
+    //printf("Damage of parameters...\n");
+    //printf("path is %s\n", dmg);
+    for(int i=0; i<br->cache_len; ++i) {
+        if(strstr(br->cache[i].path, dmg)) {
+            int current = br_has_callback(br, br->cache[i].path);
+            if(current) {
+                osc_request(br, br->cache[i].path);
+                br->cache[i].pending = true;
+            } else
+                br->cache[i].usable = false;
+            br->cache[i].requests = 0;
+        }
+    }
+}
+
+void br_refresh(bridge_t *br, uri_t uri)
+{
+    param_cache_t *cline = cache_get(br, uri);
+
+    uv_update_time(br->loop);
+    double now = 1e-3*uv_now(br->loop);
+
+    if(cline->request_time < now) {
+        cline->request_time = now;
+        osc_request(br, uri);
+    } else {
+        //printf("skipping refresh for %s at dt = %f\n", uri, cline->request_time-now);
+    }
+}
+
+void br_force_refresh(bridge_t *br, uri_t uri)
+{
+    param_cache_t *cline = cache_get(br, uri);
+
+    uv_update_time(br->loop);
+    double now = 1e-3*uv_now(br->loop);
+
+    if(cline->request_time < now) {
+        cline->request_time = now;
+        osc_request(br, uri);
+        cline->force_refresh = 0;
+    } else {
+        cline->request_time = now;
+        cline->force_refresh = 1;
+        //printf("skipping refresh for %s at dt = %f\n", uri, cline->request_time-now);
+    }
+}
+
+void br_watch(bridge_t *br, const char *uri)
+{
+    char *buffer = (char*)malloc(4096);
+    size_t len   = rtosc_message(buffer, 4096, "/watch/add", "s", uri);
+    do_send(br, buffer, len);
+
+}
+
+void br_action(bridge_t *br, const char *uri, const char *argt,
+        const rtosc_arg_t *args)
+{
+    char *buffer = (char*)malloc(4096);
+    size_t len   = rtosc_amessage(buffer, 4096, uri, argt, args);
+    do_send(br, buffer, len);
+}
+
+void br_recv(bridge_t *br, const char *msg)
+{
+    //char buffer[128];
+    //rtosc_message(buffer, 128, "/part0/Pvolume", "i", 74);
+    if(!msg)
+        return;
+
+    //if(rtosc_narguments(msg) < 3) {
+    //    //printf("BR RECEIVE %s:%s\n", msg, rtosc_argument_string(msg));
+    //    //printf("MESSAGE IS %d bytes\n", rtosc_message_length(msg, -1));
+    //}
+    br->last_update = 1e-3*uv_now(br->loop);
+
+    if(!strcmp("/damage", msg) && !strcmp("s", rtosc_argument_string(msg))) {
+        const char *dmg = rtosc_argument(msg, 0).s;
+        br_damage(br, dmg);
+        return;
+    }
+
+    const int nargs = rtosc_narguments(msg);
+    if(nargs == 1)
+        cache_set(br, msg, rtosc_type(msg, 0), rtosc_argument(msg, 0), 0);
+    else {
+        //Try to handle the vector message cases
+        //printf("BRIDGE RECEIVE A VECTOR MESSAGE\n");
+        //TODO verify that we've got some sort of uniformity?
+        rtosc_arg_itr_t  itr   = rtosc_itr_begin(msg);
+        rtosc_arg_t     *args  = (rtosc_arg_t*)calloc(nargs, sizeof(rtosc_arg_t));
+        char            *types = strdup(rtosc_argument_string(msg));
+
+        int offset = 0;
+        while(!rtosc_itr_end(itr))
+            args[offset++] = rtosc_itr_next(&itr).val;
+
+        cache_set_vector(br, msg, types, args);
+        free(args);
+        free(types);
+    }
+    //for(int i=0; i<br->callback_len; ++i) {
+    //    printf("cb name = %s\n", br->callback[i].path);
+    //    bridge_callback_t cb = br->callback[i];
+    //    if(!strcmp(cb.path, msg))
+    //        cb.cb(msg, cb.data);
+    //}
+}
+
+int br_pending(bridge_t *br)
+{
+    int pending = 0;
+    for(int i=0; i<br->cache_len; ++i)
+        pending += !!(br->cache[i].pending);
+    return pending;
+}
+
+void br_tick(bridge_t *br)
+{
+    //Run all network events
+    for(int i=0; i<200; ++i)
+        uv_run(br->loop, UV_RUN_NOWAIT);
+
+    if(br->frame_messages >= BR_RATE_LIMIT) {
+        //printf("[INFO] Hit rate limit\n");
+    }
+
+    br->frame_messages = 0;
+    if(br->rlimit) {
+        //printf("[INFO] Reading through rate limited fields\n");
+        for(int i=0; i<br->rlimit_len && i<BR_RATE_LIMIT; ++i) {
+            char *msg = br->rlimit[i];
+            //printf("[DEBUG] message = \"%s\"\n", msg);
+            do_send(br, msg, rtosc_message_length(msg, -1));
+        }
+        if(br->frame_messages == br->rlimit_len) {
+            //printf("[INFO] Clearing rate limit queue\n");
+            br->rlimit_len = 0;
+            free(br->rlimit);
+            br->rlimit = 0;
+        } else {
+            char **base = br->rlimit;
+            int N = br->frame_messages;
+            int M = br->rlimit_len;
+            //printf("[INFO] Shrinking rate limit queue %d=>%d\n", M, M-N);
+            memmove(base, base+N, sizeof(void*)*(M-N));
+            br->rlimit_len = M-N;
+        }
+        //wait 10ms
+        //usleep(10000);
+    }
+    uv_update_time(br->loop);
+    double now  = 1e-3*uv_now(br->loop);
+
+    if(!br->rlimit) {
+        for(int i=0; i<br->cache_len; ++i) {
+            char *path   = br->cache[i].path;
+            int   pend   = br->cache[i].pending;
+            int   valid  = br->cache[i].valid;
+            int   usable = br->cache[i].usable;
+            int   fref   = br->cache[i].force_refresh;
+            double uptim = br->cache[i].request_time;
+            int   rq     = br->cache[i].requests;
+            (void) path;
+            if(usable && (pend || !valid)) {
+                //printf("cache status = <%s, %d, %d, %f, %d>\n", path, pend, valid, uptim, rq);
+                if(uptim < now - 300e-3) {
+                    if(rq < 10)
+                        cache_update(br, &br->cache[i]);
+                    //else if(br->cache[i].requests++ == 10)
+                    //    printf("[ERROR] Invalid parameter cannot be accessed at <%s>\n", path);
+                }
+            } else if(usable && fref)
+                if(uptim < now - 50e-3)
+                    cache_update(br, &br->cache[i]);
+
+        }
+    }
+
+    //Attempt to disable debouncing
+    if(br->debounce_len == 0)
+        return;
+    double delta  = 200e-3;
+    double thresh = now - delta;
+    for(int i=br->debounce_len-1; i >= 0; --i) {
+        if(br->bounce[i].last_set < thresh) {
+            run_callbacks(br, cache_get(br, br->bounce[i].path));
+            debounce_pop(br, i);
+        }
+    }
+
+
+}
+
+int br_last_update(bridge_t *br)
+{
+    return 1e-3*uv_now(br->loop)-br->last_update;
+}
+
+//Statistics
+void print_stats(bridge_t *br, schema_t sch)
+{
+    printf("Bridge Statistics:\n");
+    printf("    Total cache lines:          %d\n", br->cache_len);
+    printf("    Total callbacks:            %d\n", br->callback_len);
+    printf("Schema Statistics:\n");
+    printf("    Known Parameters Patterns:  %d\n", sch.elements);
+}

--- a/src/osc-bridge/src/bridge.h
+++ b/src/osc-bridge/src/bridge.h
@@ -1,0 +1,166 @@
+#include <uv.h>
+#include "schema.h"
+#include "cache.h"
+//A means of staying synchonized with respect to a collection of parameters
+//presented over OSC in a REST like fashion
+
+typedef struct {
+    const char *path;
+    double last_set;
+} debounce_t;
+
+typedef void (*bridge_cb_t)(const char *, void*);
+typedef struct {
+    const char *path;
+    bridge_cb_t cb;
+    void *data;
+} bridge_callback_t;
+
+//Bridge
+typedef struct {
+    uv_loop_t *loop;
+    uv_udp_t socket;
+    void *pending_requests;
+
+    char *search_path;
+    char *address;
+    int port;
+    int frame_messages;
+
+    param_cache_t     *cache;
+    debounce_t        *bounce;
+    bridge_callback_t *callback;
+    char             **rlimit;
+    int cache_len;
+    int debounce_len;
+    int callback_len;
+    int rlimit_len;
+    uint64_t last_update;
+} bridge_t;
+
+//Maximum messages per br_tick() frame
+#define BR_RATE_LIMIT 128
+
+//Create a remote OSC bridge
+bridge_t *br_create(uri_t);
+//Destroy and deallocate an OSC bridge
+void      br_destroy(bridge_t *br);
+
+//Obtain a copy of the scheama used to communicate over OSC
+schema_t br_get_schema(bridge_t*, uri_t);
+//Deallocate a schema instance
+void br_destroy_schema(schema_t);
+
+/**
+ * Randomize a value according to schema min/max
+ *
+ * XXX - This method is not yet implemented
+ */
+void br_randomize(bridge_t *, uri_t);
+
+void br_default(bridge_t *, schema_t, uri_t);
+
+//Value setters
+void br_set_array(bridge_t *, uri_t, char*, rtosc_arg_t*);
+void br_set_value_bool(bridge_t *, uri_t, int);
+void br_set_value_int(bridge_t *, uri_t, int);
+void br_set_value_float(bridge_t *, uri_t, float);
+void br_set_value_string(bridge_t *, uri_t, const char *);
+
+/** Return 1 if uri has a callback bound to it*/
+int  br_has_callback(bridge_t *, uri_t);
+
+/**
+ * Add a callback to the provided uri
+ *
+ * If the provided uri has data in the cache it, the callback is invoked
+ * immediately. Otherwise the data is requested and the callback is
+ * called when data is available. The callback is invoked when the bound
+ * data changes.
+ */
+void br_add_callback(bridge_t *, uri_t, bridge_cb_t, void*);
+
+/**
+ * Add callback to the provided uri without requesting data
+ */
+void br_add_action_callback(bridge_t *, uri_t, bridge_cb_t, void*);
+
+/**
+ * Remove callback from uri
+ */
+void br_del_callback(bridge_t *, uri_t, bridge_cb_t, void*);
+
+/**
+ * Invalidate cached data which matches the partial path provided
+ */
+void br_damage(bridge_t *, uri_t);
+
+/**
+ * Rate limited refresh of given uri
+ */
+void br_refresh(bridge_t *, uri_t);
+
+/**
+ * Rate limited refresh of given uri
+ *
+ * Note: this is different than br_refresh in the case that:
+ *
+ * 1. br_refresh(a)
+ * 2. send osc message which alters 'a', but does not broadcast the change
+ * 3. br_refresh(a)
+ *
+ * Will not send a request with step 3 while force_refresh will 'eventually'
+ * send an update for 'a' after a timeout
+ */
+void br_force_refresh(bridge_t *, uri_t);
+
+/**
+ * Start a state watch on remote host via '/watch/add' port
+ */
+void br_watch(bridge_t *, uri_t);
+
+/**
+ * Send a raw OSC message to the remote host
+ *
+ * These messages should conform to the actions specified in the osc schema
+ */
+void br_action(bridge_t *, uri_t, const char *argt, const rtosc_arg_t *args);
+
+/**
+ * Handle incoming OSC messages from remote host
+ */
+void br_recv(bridge_t *, const char *);
+
+//Returns the number of cache fields in the 'pending' state
+int  br_pending(bridge_t *);
+
+/**
+ * Communicate with remote host
+ *
+ * This function should be called frequently (10-120Hz) in the main loop
+ * of the program.
+ *
+ * This routine:
+ * - Sends requests for data
+ * - Receives data based upon requests
+ * - Runs callbacks based upon new data
+ * - Retries requesting data based upon timeouts
+ * - Rate limits data requests
+ */
+void br_tick(bridge_t *);
+
+/*
+ * Report last update from remote in seconds
+ *
+ * Note - For a system which isn't experiencing lag, this should typically be
+ *        zero
+ */
+int  br_last_update(bridge_t *);//returns delta time in seconds
+
+//Print statistics about bridge/schema
+void print_stats(bridge_t *br, schema_t sch);
+
+
+//Testing Hooks
+extern int  (*osc_socket_hook)(void);
+extern int  (*osc_request_hook)(bridge_t *, const char *);

--- a/src/osc-bridge/src/cache.h
+++ b/src/osc-bridge/src/cache.h
@@ -1,0 +1,60 @@
+#ifndef OSC_BRIDGE_CACHE
+#define OSC_BRIDGE_CACHE
+#include <stdint.h>
+
+//Forward definitions for rtosc
+//This avoids the need for other libs to need any information
+//about rtosc
+#ifndef RTOSC_H
+typedef struct {
+    int32_t len;
+    uint8_t *data;
+} rtosc_blob_t;
+
+typedef union {
+    int32_t       i;   //i,c,r
+    char          T;   //I,T,F,N
+    float         f;   //f
+    double        d;   //d
+    int64_t       h;   //h
+    uint64_t      t;   //t
+    uint8_t       m[4];//m
+    const char   *s;   //s,S
+    rtosc_blob_t  b;   //b
+} rtosc_arg_t;
+#endif
+
+typedef struct {
+    //Path of OSC value
+    char *path;
+    //TODO condense valid+pending+usable into one variable
+    char  valid:1;
+    char  pending:1;
+    char  usable:1;
+    char  force_refresh:1;
+
+    //Type of OSC value stored in cache
+    //In the case of multiple values, type is 'v'
+    char  type;
+
+    //Time that last request was issued. Useful to:
+    //- avoid repeated requests in the case of lost packets
+    //- track remote latency
+    double request_time;
+
+    //Number of times a value has been requested without a response
+    //A high number of requests either indicates high packet loss or that the
+    //remote application will not respond to the parameter (i.e. the parameter
+    //doesn't exist)
+    int   requests;
+
+    //Data stored
+    union {
+        rtosc_arg_t val;
+        struct {
+            const char  *vec_type;
+            rtosc_arg_t *vec_value;
+        };
+    };
+} param_cache_t;
+#endif

--- a/src/osc-bridge/src/mm_json.h
+++ b/src/osc-bridge/src/mm_json.h
@@ -1,0 +1,1340 @@
+/*
+    mm_json.h - zlib - Micha Mettke
+
+ABOUT:
+    This is a single header JSON parser header and implementation without
+    any dependencies (even the standard library),
+    string memory allocation or complex tree generation.
+    Instead this library focuses on parsing tokens from a previously
+    loaded in memory JSON file. Each token thereby references the JSON file
+    string and limits the allocation to the initial JSON file instead of
+    allocating a new string for each token.
+
+QUICK:
+    To use this file do:
+    #define MM_JSON_IMPLEMENTATION
+    before you include this file in *one* C or C++ file to create the implementation
+
+    If you want to keep the implementation in that file you have to do
+    #define MM_JSON_STATIC before including this file
+
+    If you want to use asserts to add validation add
+    #define MM_JSON_ASSERT before including this file
+
+    To overwrite the default seperator character used inside
+    the query functions
+    #define MM_JSON_DELIMITER (character) before including this file
+
+CONCEPT:
+    The library contains three different parts.
+    Tokenizer
+    The tokenizer divides the initial in memory JSON file string into
+    smaller interpreterable tokens and does not require any allocations at all.
+    This is achieved by using an iterator to walk over each object inside an
+    object and parsing each subobject with a new iterator.
+    You can use the tokenizer without the parser if you either only want to
+    parse a subsection of a JSON object or use a different language like Lua.
+
+    Parser
+    The parser uses the tokenizer internally to read in a JSON file into a
+    token array. Each token thereby contains information about the JSON
+    object tree and you can access the tree by a number of utility functions.
+
+    Utility
+    The library has a number of utility functions to access or parse and convert
+    a previously read token. In addition if you use the parser a number of functions
+    are provided to look for a token inside the parsed array.
+
+    It is important to note that while every valid JSON tree should be parsable
+    without problems, there is no guarantee that any invalid input is detected as
+    such, since the parser has only minimal validation.
+    In addition if you want to use the library with Multithreading make sure
+    to call `mm_json_init` once before using.
+
+LICENSE: (zlib)
+    Copyright (c) 2016 Micha Mettke
+
+    This software is provided 'as-is', without any express or implied
+    warranty.  In no event will the authors be held liable for any damages
+    arising from the use of this software.
+
+    Permission is granted to anyone to use this software for any purpose,
+    including commercial applications, and to alter it and redistribute it
+    freely, subject to the following restrictions:
+
+    1.  The origin of this software must not be misrepresented; you must not
+        claim that you wrote the original software. If you use this software
+        in a product, an acknowledgment in the product documentation would be
+        appreciated but is not required.
+    2.  Altered source versions must be plainly marked as such, and must not be
+        misrepresented as being the original software.
+    3.  This notice may not be removed or altered from any source distribution.
+
+USAGE:
+    This file behaves differently depending on what symbols you define
+    before including it.
+
+    Header-File mode:
+    If you do not define MM_JSON_IMPLEMENTATION before including this file, it
+    will operate in header only mode. In this mode it declares all used structs
+    and the API of the library without including the implementation of the library.
+
+    Implementation mode:
+    If you define MM_JSON_IMPLEMENTATIOn before including this file, it will
+    compile the implementation of the JSON parser. To specify the visibility
+    as private and limit all symbols inside the implementation file
+    you can define MM_JSON_STATIC before including this file.
+    Make sure that you only include this file implementation in *one* C or C++ file
+    to prevent collisions.
+
+EXAMPLES:*/
+#if 0
+    /* Lexer example */
+    const char *json = "{a:"test",b:5, c:[0,1,2,4,5]}";
+    mm_json_size len = strlen(json);
+
+    /* create iterator  */
+    struct mm_json_iter iter;
+    iter = mm_json_begin(json, len);
+
+    /* read token pair */
+    struct mm_json_pair pair;
+    iter = mm_json_parse(&pair, &iter);
+    assert(!mm_json_cmp(&pair.name, "a"));
+    assert(!mm_json_cmp(&pair.value, "test"));
+    assert(pair.value.type == MM_JSON_STRING);
+
+    /* convert token to number */
+    mm_json_number num;
+    iter = mm_json_parse(&pair, &iter);
+    mm_json_test_assert(mm_json_convert(&num, &pair.value) == MM_JSON_NUMBER);
+    assert(num == 5.0);
+
+    /* read subobject (array/objects) */
+    iter = mm_json_parse(&pair, &iter);
+    mm_json_test_assert(pair.value.type == MM_JSON_ARRAY);
+
+    struct mm_json_iter array = mm_json_begin(pair.value.str, pair.value.len);
+    iter = mm_json_read(&tok, &array);
+    while (array.src) {
+        /* read single token */
+        array = mm_json_read(&tok, &array);
+    }
+#endif
+#if 0
+    /* Parser example */
+    const char *json = "{...}";
+    mm_json_size len = strlen(json);
+
+    /* load content into token array */
+    mm_json_size read = 0;
+    mm_json_size num = mm_json_num(json, len);
+    struct mm_json_token *toks = calloc(num, sizeof(struct mm_json_token));
+    mm_json_load(toks, num, &read, json, len);
+
+    /* query token */
+    struct mm_json_token * t0 = mm_json_query(toks, num, "map.entity[4].position");
+    struct mm_json_token * t1 = mm_json_query_del(toks, num, "map:entity[4]:position", ':');
+
+    /* query string */
+    char buffer[64];
+    mm_json_size size;
+    mm_json_query_string(buffer, 64, &size, toks, num, "map.entity[4].name");
+    mm_json_query_string_del(buffer, 64, &size, toks, num, "map%entity[9]%name", '%');
+
+    /* query number */
+    mm_json_number num;
+    mm_json_query_number(&num, toks, num, "map.soldier[2].position.x");
+    mm_json_query_number_del(&num, toks, num, "map/soldier[2]/position.x", "/");
+
+    /* query type */
+    mm_json_int type0 = mm_json_query_number(toks, num, "map.soldier[2]");
+    mm_json_int type1 = mm_json_query_number_del(toks, num, "map_soldier[2]", '_');
+
+    /* subqueries */
+    json_token *entity = mm_json_query(toks, num, "map.entity[4]");
+    json_token *position = mm_json_query(entity, entity->sub, "position");
+    json_token *rotation = mm_json_query(entity, entity->sub, "rotation");
+#endif
+
+ /* ===============================================================
+ *
+ *                          HEADER
+ *
+ * =============================================================== */
+#ifndef MM_JSON_H_
+#define MM_JSON_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef MM_JSON_STATIC
+#define MM_JSON_API static
+#else
+#define MM_JSON_API extern
+#endif
+
+typedef int mm_json_int;
+typedef char mm_json_char;
+typedef unsigned long mm_json_size;
+typedef double mm_json_number;
+
+/* default delimiter used in the `mm_json_query` function to seperate elements path */
+#ifndef MM_JSON_DELIMITER
+#define MM_JSON_DELIMITER '.'
+#endif
+
+enum mm_json_token_type {
+    MM_JSON_NONE,      /* invalid token */
+    MM_JSON_OBJECT,    /* subobject */
+    MM_JSON_ARRAY,     /* subarray */
+    MM_JSON_NUMBER,    /* float point number token */
+    MM_JSON_STRING,    /* string text token */
+    MM_JSON_TRUE,      /* true constant token */
+    MM_JSON_FALSE,     /* false constant token*/
+    MM_JSON_NULL,      /* null constant token */
+    MM_JSON_MAX
+};
+
+struct mm_json_token {
+    /*A Token represents a section in a string containing a valid json DOM value.
+    Since the token only references the json object string, no actual memory needs
+    to be allocated from the library to hold each token. Therefore the library does not
+    represent a classical datastructure representing the json object as a tree, instead
+    it is only responsible for parsing the string. In addition it is to note that the string
+    inside of the token is not terminated with '\0' since it would require write
+    access to the json string which is not always wanted. */
+    const mm_json_char *str;
+    /* pointer to the beginning of the token */
+    mm_json_size len;
+    /* length of the token */
+    mm_json_size children;
+    /* number of direct child tokens */
+    mm_json_size sub;
+    /* total number of subtokens (note: not pairs). Used for querying inside
+     * previsouly queried tokens */
+    enum mm_json_token_type type;
+    /* token type */
+};
+
+struct mm_json_pair {
+    /* A Pair represents two tokens with name and value token. Every Object, Array and
+    Element in a Object except values inside a Array are pairs. So it is possible
+    to read in two tokens directly at once while still getting correct results. */
+    struct mm_json_token name;
+    /* token representing the name of the pair */
+    struct mm_json_token value;
+    /* token holding the value*/
+};
+/*--------------------------------------------------------------------------
+                            UTILITY
+  -------------------------------------------------------------------------*/
+/*
+    UTILITY
+    The utiltiy API provided access to the string inside a previously read token or
+    token array. Its main purpose of existence lies in the way tokens are
+    handled in this library. Tokens do not allocate memory for every string,
+    but instead only reference the source json DOM string. But since a number
+    of operation are needed on the string the utility function were added.
+
+    USAGE
+    The utility function allow to copy the string of a token into a char buffer,
+    converting number tokens into number and compare the string inside the
+    token with another string.
+
+    Utility function API (not neccessary for the actual parsing process)
+    mm_json_find   -- queries a token array with a path to a key and returns the value
+    mm_json_cpy    -- copies a prev read token into a user provided buffer and returns the len
+    mm_json_cmp    -- compares a prev read token with a user provided string
+    mm_json_convert-- converts a previously parsed token into a number
+    mm_json_init   -- initilizes the parser look up tables only needs to be called
+                    before the first use and if the library is used with multithreading
+*/
+MM_JSON_API mm_json_int mm_json_cmp(const struct mm_json_token*, const mm_json_char*);
+/*  this function compares a previously read token with a user provieded string
+    Input:
+    - previously parsed token that needs to be compared against
+    - user provided string
+    Output:
+    - if both are equal 0 otherwise 1
+*/
+MM_JSON_API mm_json_size mm_json_cpy(mm_json_char*, mm_json_size, const struct mm_json_token*);
+/*  this function copies a previously read token into a user provided buffer
+    Input:
+    - max fill size of the buffer
+    - previously parsed token that will be copied into the buffer
+    Output:
+    - buffer containing the token
+*/
+MM_JSON_API mm_json_int mm_json_convert(mm_json_number *, const struct mm_json_token*);
+/*  this function converts a previously read token into a number
+    Input:
+    - previously parsed token that needs to be converted
+    Output:
+    - number that has been converted from the token
+    - MM_JSON_NUMBER on success or mm_json_NOME on failure
+*/
+MM_JSON_API void mm_json_init(void);
+/* this function initializes the internal parser lookup tables.
+ * Only needed to be called at the beginning if used with multithreading */
+
+/*--------------------------------------------------------------------------
+                            TOKENIZER
+  -------------------------------------------------------------------------*/
+/*
+    TOKENIZER
+    -----------------------
+    The tokenizer is based around an iterator which steps
+    over the first depth of an object. Deeper levels can be reached with
+    iterators by parsing the resulting tokens. The tokenizer does not
+    allocate any memory for tokens instead the string inside the token only
+    references the source string and has therefore a very low memory foot print.
+    Internally the tokenizer uses a look up table to parse tokens. Which
+    costs ~1.5kB of memory which is quite a lot but makes the parsing process
+    quite easy and even readable.
+
+    USAGE
+    ------------------------
+    To use the tokenizer you have to first create an iterator with
+    `mm_json_begin`. After that the iterator can be used to iterate over the first
+    depth of the DOM-Tree. This is done by either using `mm_json_parse` for pairs
+    or `mm_json_read` or single tokens which is useful for array values.
+
+    Tokenzier API (based around an iterator)
+    mm_json_begin  -- creates a parsing lexer iterator from a json string and a string length
+    mm_json_read   -- parses a token and returns the iterator to the next token
+    mm_json_parse  -- parses a token pair and returns the iterator to the next token
+*/
+struct mm_json_iter {
+    /* The lexer iterator controlls the parsing procedure and is similar to the
+    container iterator found in the C++ STL library. Important to note is that
+    the iterator only works up to the first depth of a JSON DOM tree, but a
+    new iterator can be created with the parsed output. */
+    mm_json_int err;
+    /* flag indicating if a parsing error or EOF took place */
+    mm_json_int depth;
+    /* current depth of the parsed DOM JSON tree iterator */
+    const char *go;
+    /* current jump table used in the parser */
+    const mm_json_char *src;
+    /* current pointer to the parsed string */
+    mm_json_size len;
+    /* curent length of the current parsed string */
+};
+
+MM_JSON_API struct mm_json_iter mm_json_begin(const mm_json_char *json, mm_json_size length);
+/*  this function initializes an lexer iterator
+    Input:
+    - json is a string containing a json DOM object that needs to be parsed
+    - length descripes the number of bytes that makeup the DOM object
+    Output:
+    - new lexer iterator ready to parse the specified string
+*/
+MM_JSON_API struct mm_json_iter mm_json_read(struct mm_json_token*, const struct mm_json_iter*);
+/*  this function uses the lexer to read in one single token and returns a
+    a iterator pointing to the next token.
+    Input:
+    - lexer iterator pointing to a valid json string object
+    Output:
+    - lexer iterator ready to parse the specified string
+    - token that will be read from the lexer iterator
+*/
+MM_JSON_API struct mm_json_iter mm_json_parse(struct mm_json_pair*, const struct mm_json_iter*);
+/*  this function uses the lexer to read in one token pair and returns a
+    a iterator pointing to the next token.
+    Input:
+    - lexer iterator pointing to a valid json string object
+    Output:
+    - new lexer iterator ready to parse the specified string
+    - pair that will be read from the lexer iterator
+*/
+
+/*-------------------------------------------------------------------------
+                            PARSER
+  -------------------------------------------------------------------------
+    PARSER
+    -----------------------
+    The parser uses the tokenizer internally to fill an array with JSON tokens.
+    Each token does not allocate memory, instead they directly reference the
+    JSON-DOM source string. The parsed output of the parser can be used to fill
+    a tree datastructure or to query against a path.
+
+    USAGE
+    ------------------------
+    The parser has to function. The first function `mm_json_num` calculates
+    the needed number of tokens, while the `mm_json_load` function reads in all tokens.
+
+    Retain mode parsing API (based on preallocated token array)
+    mm_json_num    -- returns the total number of tokens inside a json DOM tree
+    mm_json_load   -- loads all tokens in a json DOM tree into tokens
+*/
+enum mm_json_status {
+    MM_JSON_OK = 0,
+    /* The parsing process was successfull and no problem were found */
+    MM_JSON_INVAL,
+    /* A invalid value has been passed into the function */
+    MM_JSON_OUT_OF_TOKEN,
+    /* Not enough tokens have been passed so the parsing process had to be stopped*/
+    MM_JSON_PARSING_ERROR
+    /* A invalid token or wrong json string has been passed */
+};
+
+MM_JSON_API mm_json_size mm_json_num(const mm_json_char *json, mm_json_size length);
+/*  this function calculates the number of tokens inside the JSON DOM object
+    Input:
+    - json is a string containing a json DOM object that needs to be parsed
+    - length descripes the number of bytes that makeup the DOM object
+    Output:
+    - number of tokens inside the json string
+*/
+MM_JSON_API enum mm_json_status mm_json_load(struct mm_json_token *toks, mm_json_size max,
+                                            mm_json_size *read, const mm_json_char *json,
+                                            mm_json_size length);
+/*  this function reads all JSON DOM tree tokens into a token array
+    Input:
+    - toks is a token array to fill with tokens
+    - max is the maximum number of tokens in the array
+    - read is the final token count which needs to be initialized to zero
+    - json is a string containing a json DOM object that needs to be parsed
+    - length descripes the number of bytes that makeup the DOM object
+    Output:
+    - error status of the operation
+*/
+
+/*--------------------------------------------------------------------------
+                            QUERY
+  -------------------------------------------------------------------------
+    QUERY
+    -----------------------
+    Each query function pair allows either to find and convert, buffer or check
+    its type of a token in a previouly parsed token array. The query in itself
+    is based around a path to the token. Each segement of the path is seperated
+    by a delemiter. The delimiter is defined in macro MM_JSON_DELIMITER but
+    each query function provides a additional function with delimiter argument.
+
+    USAGE
+    ------------------------
+    To query for a token or token content you first have to load the content
+    of the json string into a token array by using the parser API. After that
+    you can call each query function on the token array.
+
+    Query API (based on parser token array output)
+    mm_json_query          -- finds a token at a given path in the token array
+    mm_json_query_number   -- finds and converts a token at a given path to a number
+    mm_json_query_string   -- finds and buffers a string token at a given path
+    mm_json_query_type     -- returns the type of a token at a given path in the token array
+*/
+MM_JSON_API struct mm_json_token *mm_json_query(struct mm_json_token *toks, mm_json_size count,
+                                                const mm_json_char *path);
+MM_JSON_API struct mm_json_token *mm_json_query_del(struct mm_json_token *toks, mm_json_size count,
+                                                    const mm_json_char *path, mm_json_char del);
+/*  this function trys to find a certain node in the JSON-DOM tree by path
+    Input:
+    - toks is a token array that has to be previously parsed
+    - count is the number of tokens inside the array
+    - path is a sequence of node names to a destiniation inside the tree seperated
+        by '.' eg.: map.entity[0].position.x (case sensitive) and [i] for arrays
+    [-del is the delemiter between each key name in the path or if not set MM_JSON_DELIMITER]
+    Output:
+    - the requested token if it exist otherwise NULL
+*/
+MM_JSON_API mm_json_int mm_json_query_number(mm_json_number*, struct mm_json_token *toks,
+                                            mm_json_size count, const mm_json_char *path);
+MM_JSON_API mm_json_int mm_json_query_number_del(mm_json_number*, struct mm_json_token *toks,
+                                                mm_json_size count, const mm_json_char *path,
+                                                mm_json_char del);
+/*  this function trys to find and convert a certain token by path to number
+    Input:
+    - toks is a token array that has to be previously parsed
+    - count is the number of tokens inside the array
+    - path is a sequence of node names to a destiniation inside the tree seperated
+        by '.' eg.: map.entity[0].position.x (case sensitive) and [i] for arrays
+    [-del is the delemiter between each key name in the path or if not set MM_JSON_DELIMITER]
+    Output:
+    - number that has been converted from the token
+    - MM_JSON_NUMBER on success, MM_JSON_NONE on not found, token type otherwise
+*/
+MM_JSON_API mm_json_int mm_json_query_string(mm_json_char*, mm_json_size max, mm_json_size *size,
+                                            struct mm_json_token *toks, mm_json_size count,
+                                            const mm_json_char *path);
+MM_JSON_API mm_json_int mm_json_query_string_del(mm_json_char*, mm_json_size max, mm_json_size *size,
+                                            struct mm_json_token *toks, mm_json_size count,
+                                            const mm_json_char *path, mm_json_char del);
+/*  this function trys to find and buffer a certain string token by path
+    Input:
+    - maximum number of bytes inside the buffer
+    - toks is a token array that has to be previously parsed
+    - count is the number of tokens inside the array
+    - path is a sequence of node names to a destiniation inside the tree seperated
+        by '.' eg.: map.entity[0].position.x (case sensitive) and [i] for arrays
+    [-del is the delemiter between each key name in the path or if not set MM_JSON_DELIMITER]
+    Output:
+    - buffer containing the token
+    - size of the buffer in bytes
+    - MM_JSON_STRING on success, MM_JSON_NONE on not found, token type otherwise
+*/
+MM_JSON_API mm_json_int mm_json_query_type(struct mm_json_token *toks, mm_json_size count,
+                                            const mm_json_char *path);
+MM_JSON_API mm_json_int mm_json_query_type_del(struct mm_json_token *toks, mm_json_size count,
+                                            const mm_json_char *path, mm_json_char del);
+/*  this function trys to find a token and return its type
+    Input:
+    - toks is a token array that has to be previously parsed
+    - count is the number of tokens inside the array
+    - path is a sequence of node names to a destiniation inside the tree seperated
+        by '.' eg.: map.entity[0].position.x (case sensitive) and [i] for arrays
+    [-del is the delemiter between each key name in the path or if not set MM_JSON_DELIMITER]
+    Output:
+    - MM_JSON_NONE if not found, token type otherwise
+*/
+#ifdef __cplusplus
+}
+#endif
+#endif /* MM_JSON_H_ */
+
+/*===============================================================
+ *
+ *                          IMPLEMENTATION
+ *
+ * =============================================================== */
+#ifdef MM_JSON_IMPLEMENTATION
+/* this flag inserts the <assert.h> header into the json.c file and adds
+ assert call to every function in DEBUG mode. If activated then
+ the clib will be used. So if you want to compile without clib then
+ deactivate this flag. */
+#ifdef MM_JSON_USE_ASSERT
+#ifndef MM_JSON_ASSERT
+#include <assert.h>
+#define MM_JSON_ASSERT(expr) assert(expr)
+#endif
+#else
+#define MM_JSON_ASSERT(expr)
+#endif
+
+#define MM_JSON_INTERN static
+#define MM_JSON_GLOBAL static
+
+#ifndef NULL
+#define NULL ((void*)0)
+#endif
+
+#ifndef MAX
+#define MAX(a,b) ((a) > (b) ? (a) : (b))
+#endif
+
+/* Main token parsing function states */
+enum mm_json_parser_states {
+    MM_JSON_STATE_FAILED,
+    MM_JSON_STATE_LOOP,
+    MM_JSON_STATE_SEP,
+    MM_JSON_STATE_UP,
+    MM_JSON_STATE_DOWN,
+    MM_JSON_STATE_QUP,
+    MM_JSON_STATE_QDOWN,
+    MM_JSON_STATE_ESC,
+    MM_JSON_STATE_UNESC,
+    MM_JSON_STATE_BARE,
+    MM_JSON_STATE_UNBARE,
+    MM_JSON_STATE_UTF8_2,
+    MM_JSON_STATE_UTF8_3,
+    MM_JSON_STATE_UTF8_4,
+    MM_JSON_STATE_UTF8_NEXT,
+    MM_JSON_STATE_MAX
+};
+
+/* Main token to number conversion states */
+enum mm_json_nuber_states {
+    MM_JSON_STATE_NUM_FAILED,
+    MM_JSON_STATE_NUM_LOOP,
+    MM_JSON_STATE_NUM_FLT,
+    MM_JSON_STATE_NUM_EXP,
+    MM_JSON_STATE_NUM_BREAK,
+    MM_JSON_STATE_NUM_MAX
+};
+
+/* global parser jump tables */
+MM_JSON_GLOBAL char mm_json_go_struct[256];
+MM_JSON_GLOBAL char mm_json_go_bare[256];
+MM_JSON_GLOBAL char mm_json_go_string[256];
+MM_JSON_GLOBAL char mm_json_go_utf8[256];
+MM_JSON_GLOBAL char mm_json_go_esc[256];
+MM_JSON_GLOBAL char mm_json_go_num[256];
+MM_JSON_GLOBAL const struct mm_json_iter MM_JSON_ITER_NULL = {0,0,0,0,0};
+MM_JSON_GLOBAL const struct mm_json_token MM_JSON_TOKEN_NULL = {0,0,0,0,MM_JSON_NONE};
+MM_JSON_GLOBAL int mm_json_is_initialized;
+
+/*--------------------------------------------------------------------------
+                                HELPER
+  -------------------------------------------------------------------------*/
+/* initializes the parser jump tables */
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wchar-subscripts"
+#endif
+
+MM_JSON_API void
+mm_json_init(void)
+{
+    int i;
+    if (mm_json_is_initialized) return;
+    mm_json_is_initialized = 1;
+    for (i = 48; i <= 57; ++i)
+        mm_json_go_struct[i] = MM_JSON_STATE_BARE;
+    mm_json_go_struct['\t'] = MM_JSON_STATE_LOOP;
+    mm_json_go_struct['\r'] = MM_JSON_STATE_LOOP;
+    mm_json_go_struct['\n'] = MM_JSON_STATE_LOOP;
+    mm_json_go_struct[' '] = MM_JSON_STATE_LOOP;
+    mm_json_go_struct['"'] = MM_JSON_STATE_QUP;
+    mm_json_go_struct[':'] = MM_JSON_STATE_SEP;
+    mm_json_go_struct['='] = MM_JSON_STATE_SEP;
+    mm_json_go_struct[','] = MM_JSON_STATE_LOOP;
+    mm_json_go_struct['['] = MM_JSON_STATE_UP;
+    mm_json_go_struct[']'] = MM_JSON_STATE_DOWN;
+    mm_json_go_struct['{'] = MM_JSON_STATE_UP;
+    mm_json_go_struct['}'] = MM_JSON_STATE_DOWN;
+    mm_json_go_struct['-'] = MM_JSON_STATE_BARE;
+    mm_json_go_struct['t'] = MM_JSON_STATE_BARE;
+    mm_json_go_struct['f'] = MM_JSON_STATE_BARE;
+    mm_json_go_struct['n'] = MM_JSON_STATE_BARE;
+
+    for (i = 32; i <= 126; ++i)
+        mm_json_go_bare[i] = MM_JSON_STATE_LOOP;
+    mm_json_go_bare['\t'] = MM_JSON_STATE_UNBARE;
+    mm_json_go_bare['\r'] = MM_JSON_STATE_UNBARE;
+    mm_json_go_bare['\n'] = MM_JSON_STATE_UNBARE;
+    mm_json_go_bare[','] = MM_JSON_STATE_UNBARE;
+    mm_json_go_bare[']'] = MM_JSON_STATE_UNBARE;
+    mm_json_go_bare['}'] = MM_JSON_STATE_UNBARE;
+
+    for (i = 32; i <= 126; ++i)
+        mm_json_go_string[i] = MM_JSON_STATE_LOOP;
+    for (i = 192; i <= 223; ++i)
+        mm_json_go_string[i] = MM_JSON_STATE_UTF8_2;
+    for (i = 224; i <= 239; ++i)
+        mm_json_go_string[i] = MM_JSON_STATE_UTF8_3;
+    for (i = 240; i <= 247; ++i)
+        mm_json_go_string[i] = MM_JSON_STATE_UTF8_4;
+    mm_json_go_string['\\'] = MM_JSON_STATE_ESC;
+    mm_json_go_string['"'] = MM_JSON_STATE_QDOWN;
+    for (i = 128; i <= 191; ++i)
+        mm_json_go_utf8[i] = MM_JSON_STATE_UTF8_NEXT;
+
+    mm_json_go_esc['"'] = MM_JSON_STATE_UNESC;
+    mm_json_go_esc['\\'] = MM_JSON_STATE_UNESC;
+    mm_json_go_esc['/'] = MM_JSON_STATE_UNESC;
+    mm_json_go_esc['b'] = MM_JSON_STATE_UNESC;
+    mm_json_go_esc['f'] = MM_JSON_STATE_UNESC;
+    mm_json_go_esc['n'] = MM_JSON_STATE_UNESC;
+    mm_json_go_esc['r'] = MM_JSON_STATE_UNESC;
+    mm_json_go_esc['t'] = MM_JSON_STATE_UNESC;
+    mm_json_go_esc['u'] = MM_JSON_STATE_UNESC;
+
+    for (i = 48; i <= 57; ++i)
+        mm_json_go_num[i] = MM_JSON_STATE_LOOP;
+    mm_json_go_num['-'] = MM_JSON_STATE_NUM_LOOP;
+    mm_json_go_num['+'] = MM_JSON_STATE_NUM_LOOP;
+    mm_json_go_num['.'] = MM_JSON_STATE_NUM_FLT;
+    mm_json_go_num['e'] = MM_JSON_STATE_NUM_EXP;
+    mm_json_go_num['E'] = MM_JSON_STATE_NUM_EXP;
+    mm_json_go_num[' '] = MM_JSON_STATE_NUM_BREAK;
+    mm_json_go_num['\n'] = MM_JSON_STATE_NUM_BREAK;
+    mm_json_go_num['\t'] = MM_JSON_STATE_NUM_BREAK;
+    mm_json_go_num['\r'] = MM_JSON_STATE_NUM_BREAK;
+}
+
+/* checks and returns the type of a token */
+static enum mm_json_token_type
+mm_json_type(const struct mm_json_token *tok)
+{
+    if (!tok || !tok->str || !tok->len)
+        return MM_JSON_NONE;
+    if (tok->str[0] == '{')
+        return MM_JSON_OBJECT;
+    if (tok->str[0] == '[')
+        return MM_JSON_ARRAY;
+    if (tok->str[0] == '\"')
+        return MM_JSON_STRING;
+    if (tok->str[0] == 't')
+        return MM_JSON_TRUE;
+    if (tok->str[0] == 'f')
+        return MM_JSON_FALSE;
+    if (tok->str[0] == 'n')
+        return MM_JSON_NULL;
+    return MM_JSON_NUMBER;
+}
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+
+/* dequotes a string token */
+static void
+mm_json_deq(struct mm_json_token *tok)
+{
+    if (tok->str[0] == '\"') {
+        tok->str++; tok->len-=2;
+    }
+}
+
+/* simple power function for json exponent numbers */
+static mm_json_number
+mm_json_ipow(int base, unsigned exp)
+{
+    long res = 1;
+    while (exp) {
+        if (exp & 1)
+            res *= base;
+        exp >>= 1;
+        base *= base;
+    }
+    return (mm_json_number)res;
+}
+
+/* converts a token containing a integer value into a number */
+static mm_json_number
+mm_json_stoi(struct mm_json_token *tok)
+{
+    mm_json_number n = 0;
+    mm_json_size i = 0;
+    mm_json_size off;
+    mm_json_size neg;
+    if (!tok->str || !tok->len)
+        return 0;
+
+    off = (tok->str[0] == '-' || tok->str[0] == '+') ? 1 : 0;
+    neg = (tok->str[0] == '-') ? 1 : 0;
+    for (i = off; i < tok->len; i++) {
+        if ((tok->str[i] >= '0') && (tok->str[i] <= '9'))
+            n = (n * 10) + tok->str[i]  - '0';
+    }
+    return (neg) ? -n : n;
+}
+
+/* converts a token containing a real value into a floating point number */
+static mm_json_number
+mm_json_stof(struct mm_json_token *tok)
+{
+    mm_json_size i = 0;
+    mm_json_number n = 0;
+    mm_json_number f = 0.1;
+    if (!tok->str || !tok->len) return 0;
+    for (i = 0; i < tok->len; i++) {
+        if ((tok->str[i] >= '0') && (tok->str[i] <= '9')) {
+            n = n + (tok->str[i] - '0') * f;
+            f *= 0.1;
+        }
+    }
+    return n;
+}
+
+/* compares a size limited string with a string inside a token */
+static mm_json_int
+mm_json_lcmp(const struct mm_json_token* tok, const mm_json_char* str, mm_json_size len)
+{
+    mm_json_size i;
+    MM_JSON_ASSERT(tok);
+    MM_JSON_ASSERT(str);
+    if (!tok || !str || !len) return 1;
+    for (i = 0; (i < tok->len && i < len); i++, str++){
+        if (tok->str[i] != *str)
+            return 1;
+    }
+    return 0;
+}
+
+/*--------------------------------------------------------------------------
+                            UTILITY
+  -------------------------------------------------------------------------*/
+MM_JSON_API mm_json_int
+mm_json_convert(mm_json_number *num, const struct mm_json_token *tok)
+{
+    mm_json_size len;
+    const mm_json_char *cur;
+    mm_json_number i, f, e, p;
+    enum {INT, FLT, EXP, TOKS};
+    struct mm_json_token nums[TOKS];
+    struct mm_json_token *write = &nums[INT];
+
+    MM_JSON_ASSERT(num);
+    MM_JSON_ASSERT(tok);
+    if (!num || !tok || !tok->str || !tok->len)
+        return MM_JSON_NONE;
+
+    nums[INT] = MM_JSON_TOKEN_NULL;
+    nums[FLT] = MM_JSON_TOKEN_NULL;
+    nums[EXP] = MM_JSON_TOKEN_NULL;
+    len = tok->len;
+    write->str = tok->str;
+
+    for (cur = tok->str; len; cur++, len--) {
+        char state =  mm_json_go_num[*(const unsigned char*)cur];
+        switch (state) {
+            case MM_JSON_STATE_NUM_FAILED: {
+                return MM_JSON_NONE;
+            } break;
+            case MM_JSON_STATE_NUM_FLT: {
+                if (nums[FLT].str)
+                    return MM_JSON_NONE;
+                if (nums[EXP].str)
+                    return MM_JSON_NONE;
+                write->len = (mm_json_size)(cur - write->str);
+                write = &nums[FLT];
+                write->str = cur + 1;
+            } break;
+            case MM_JSON_STATE_NUM_EXP: {
+                if (nums[EXP].str)
+                    return MM_JSON_NONE;
+                write->len = (mm_json_size)(cur - write->str);
+                write = &nums[EXP];
+                write->str = cur + 1;
+            } break;
+            case MM_JSON_STATE_NUM_BREAK: {
+                len = 1;
+            } break;
+            default: break;
+        }
+    }
+    write->len = (mm_json_size)(cur - write->str);
+
+    i = mm_json_stoi(&nums[INT]);
+    f = mm_json_stof(&nums[FLT]);
+    e = mm_json_stoi(&nums[EXP]);
+    p = mm_json_ipow(10, (unsigned)((e < 0) ? -e : e));
+    if (e < 0) p = (1 / p);
+    *num = (i + ((i < 0) ? -f : f)) * p;
+    return MM_JSON_NUMBER;
+}
+
+MM_JSON_API mm_json_size
+mm_json_cpy(mm_json_char *dst, mm_json_size max, const struct mm_json_token* tok)
+{
+    unsigned i = 0;
+    mm_json_size ret;
+    mm_json_size siz;
+
+    MM_JSON_ASSERT(dst);
+    MM_JSON_ASSERT(tok);
+    if (!dst || !max || !tok)
+        return 0;
+
+    ret = (max < (tok->len + 1)) ? max : tok->len;
+    siz = (max < (tok->len + 1)) ? max-1 : tok->len;
+    for (i = 0; i < siz; i++)
+        dst[i] = tok->str[i];
+    dst[siz] = '\0';
+    return ret;
+}
+
+MM_JSON_API mm_json_int
+mm_json_cmp(const struct mm_json_token* tok, const mm_json_char* str)
+{
+    mm_json_size i;
+    MM_JSON_ASSERT(tok);
+    MM_JSON_ASSERT(str);
+    if (!tok || !str) return 1;
+    for (i = 0; (i < tok->len && *str); i++, str++){
+        if (tok->str[i] != *str)
+            return 1;
+    }
+    return 0;
+}
+/*--------------------------------------------------------------------------
+                            TOKENIZER
+  -------------------------------------------------------------------------*/
+MM_JSON_API struct mm_json_iter
+mm_json_begin(const mm_json_char *str, mm_json_size len)
+{
+    struct mm_json_iter iter = MM_JSON_ITER_NULL;
+    mm_json_init();
+    iter.src = str;
+    iter.len = len;
+    return iter;
+}
+
+MM_JSON_API struct mm_json_iter
+mm_json_read(struct mm_json_token *obj, const struct mm_json_iter* prev)
+{
+    struct mm_json_iter iter;
+    mm_json_size len;
+    const mm_json_char *cur;
+    mm_json_int utf8_remain = 0;
+
+    MM_JSON_ASSERT(obj);
+    MM_JSON_ASSERT(prev);
+    if (!prev || !obj || !prev->src || !prev->len || prev->err) {
+        /* case either invalid iterator or eof  */
+        struct mm_json_iter it = MM_JSON_ITER_NULL;
+        *obj = MM_JSON_TOKEN_NULL;
+        it.err = 1;
+        return it;
+    }
+
+    iter = *prev;
+    *obj = MM_JSON_TOKEN_NULL;
+    iter.err = 0;
+    if (!iter.go) /* begin of parsing process */
+        iter.go = mm_json_go_struct;
+
+    len = iter.len;
+    for (cur = iter.src; len; cur++, len--) {
+        const unsigned char *tbl = (const unsigned char*)iter.go;
+        unsigned char c = (unsigned char)*cur;
+        if (c == '\0') {
+            iter.src = 0;
+            iter.len = 0;
+        }
+        switch (tbl[c]) {
+        case MM_JSON_STATE_FAILED: {
+            iter.err = 1;
+            return iter;
+        } break;
+        case MM_JSON_STATE_LOOP: break;
+        case MM_JSON_STATE_SEP: {
+            if (iter.depth == 2)
+                obj->children--;
+        } break;
+        case MM_JSON_STATE_UP: {
+            if (iter.depth > 1) {
+                if (iter.depth == 2)
+                    obj->children++;
+                obj->sub++;
+            }
+            if (iter.depth++ == 1)
+                obj->str = cur;
+        } break;
+        case MM_JSON_STATE_DOWN: {
+            if (--iter.depth == 1) {
+                obj->len = (mm_json_size)(cur - obj->str) + 1;
+                if (iter.depth != 1 || !obj->str)
+                    goto l_loop;
+                goto l_yield;
+            }
+        } break;
+        case MM_JSON_STATE_QUP: {
+            iter.go = mm_json_go_string;
+            if (iter.depth == 1) {
+                obj->str = cur;
+            } else {
+                if (iter.depth == 2)
+                    obj->children++;
+                obj->sub++;
+            }
+        } break;
+        case MM_JSON_STATE_QDOWN: {
+            iter.go = mm_json_go_struct;
+            if (iter.depth == 1) {
+                obj->len = (mm_json_size)(cur - obj->str) + 1;
+                if (iter.depth != 1 || !obj->str)
+                    goto l_loop;
+                goto l_yield;
+            }
+        } break;
+        case MM_JSON_STATE_ESC: {
+            iter.go = mm_json_go_esc;
+        } break;
+        case MM_JSON_STATE_UNESC: {
+            iter.go = mm_json_go_string;
+        } break;
+        case MM_JSON_STATE_BARE: {
+            if (iter.depth == 1) {
+                obj->str = cur;
+            } else {
+                if (iter.depth == 2)
+                    obj->children++;
+                obj->sub++;
+            }
+            iter.go = mm_json_go_bare;
+        } break;
+        case MM_JSON_STATE_UNBARE: {
+            iter.go = mm_json_go_struct;
+            if (iter.depth == 1) {
+                obj->len = (mm_json_size)(cur - obj->str);
+                obj->type = (enum mm_json_token_type)mm_json_type(obj);
+                if (obj->type == MM_JSON_STRING)
+                    mm_json_deq(obj);
+                iter.src = cur;
+                iter.len = len;
+                return iter;
+            }
+            cur--; len++;
+        } break;
+        case MM_JSON_STATE_UTF8_2: {
+            iter.go = mm_json_go_utf8;
+            utf8_remain = 1;
+        } break;
+        case MM_JSON_STATE_UTF8_3: {
+            iter.go = mm_json_go_utf8;
+            utf8_remain = 2;
+        } break;
+        case MM_JSON_STATE_UTF8_4: {
+            iter.go = mm_json_go_utf8;
+            utf8_remain = 3;
+        } break;
+        case MM_JSON_STATE_UTF8_NEXT: {
+            if (!--utf8_remain)
+                iter.go = mm_json_go_string;
+        } break;
+        default:
+            break;
+        }
+        l_loop:;
+    }
+
+    if (!iter.depth) {
+        /* reached eof */
+        iter.src = 0;
+        iter.len = 0;
+        if (obj->str) {
+            obj->len = (mm_json_size)((cur-1) - obj->str);
+            obj->type = (enum mm_json_token_type)mm_json_type(obj);
+            if (obj->type == MM_JSON_STRING)
+                mm_json_deq(obj);
+        }
+        return iter;
+    }
+    return iter;
+
+l_yield:
+    iter.src = cur + 1;
+    iter.len = len - 1;
+    obj->type = mm_json_type(obj);
+    if (obj->type == MM_JSON_STRING)
+        mm_json_deq(obj);
+    return iter;
+}
+
+MM_JSON_API struct mm_json_iter
+mm_json_parse(struct mm_json_pair *p, const struct mm_json_iter* it)
+{
+    struct mm_json_iter next;
+    MM_JSON_ASSERT(p);
+    MM_JSON_ASSERT(it);
+    next = mm_json_read(&p->name, it);
+    if (next.err) return next;
+    return mm_json_read(&p->value, &next);
+}
+
+/*--------------------------------------------------------------------------
+                            PARSER
+  -------------------------------------------------------------------------*/
+MM_JSON_API mm_json_size
+mm_json_num(const mm_json_char *json, mm_json_size length)
+{
+    struct mm_json_iter iter;
+    struct mm_json_token tok;
+    mm_json_size count = 0;
+
+    MM_JSON_ASSERT(json);
+    MM_JSON_ASSERT(length);
+    if (!json || !length)
+        return 0;
+
+    iter = mm_json_begin(json, length);
+    iter = mm_json_read(&tok, &iter);
+    while (!iter.err) {
+        count += (1 + tok.sub);
+        iter = mm_json_read(&tok, &iter);
+    }
+    return count;
+}
+
+MM_JSON_API enum mm_json_status
+mm_json_load(struct mm_json_token *toks, mm_json_size max, mm_json_size *read,
+            const mm_json_char *json, mm_json_size length)
+{
+    enum mm_json_status status = MM_JSON_OK;
+    struct mm_json_token tok;
+    struct mm_json_iter iter;
+
+    MM_JSON_ASSERT(toks);
+    MM_JSON_ASSERT(json);
+    MM_JSON_ASSERT(length);
+    MM_JSON_ASSERT(max);
+    MM_JSON_ASSERT(read);
+
+    if (!toks || !json || !length || !max || !read)
+        return MM_JSON_INVAL;
+    if (*read >= max)
+        return MM_JSON_OUT_OF_TOKEN;
+
+    iter = mm_json_begin(json, length);
+    iter = mm_json_read(&tok, &iter);
+    if (iter.err && iter.len)
+        return MM_JSON_PARSING_ERROR;
+
+    while (iter.len) {
+        toks[*read] = tok;
+        *read += 1;
+        if (*read > max) return MM_JSON_OUT_OF_TOKEN;
+        if (toks[*read-1].type == MM_JSON_OBJECT ||  toks[*read-1].type == MM_JSON_ARRAY) {
+            status = mm_json_load(toks, max, read, toks[*read-1].str, toks[*read-1].len);
+            if (status != MM_JSON_OK) return status;
+        }
+
+        iter = mm_json_read(&tok, &iter);
+        if (iter.err && iter.src && iter.len)
+            return MM_JSON_PARSING_ERROR;
+    }
+    return status;
+}
+/*--------------------------------------------------------------------------
+                            QUERY
+  -------------------------------------------------------------------------*/
+static const mm_json_char*
+mm_json_strchr(const mm_json_char *str, mm_json_char c, mm_json_int len)
+{
+    mm_json_int neg = (len < 0) ? 1: 0;
+    mm_json_int dec = neg ? 0 : 1;
+    len = neg ? 0 : len;
+    if (!str) return NULL;
+    while (*str && len >= 0) {
+        if (*str == c)
+            return str;
+        len -= dec;
+        str++;
+    }
+    if (neg) return str;
+    return NULL;
+}
+
+
+static const mm_json_char*
+mm_json_path_parse_name(struct mm_json_token *tok, const mm_json_char *path,
+    mm_json_char delimiter)
+{
+    const mm_json_char *del;
+    const mm_json_char *begin, *end;
+    if (!path || *path == '\0')
+        return NULL;
+
+    tok->str = path;
+    del = mm_json_strchr(tok->str, delimiter, -1);
+    begin = mm_json_strchr(tok->str, '[', -1);
+    end = mm_json_strchr(tok->str, ']', -1);
+
+    /* array part left */
+    if (begin && end && begin == tok->str) {
+        tok->len = (mm_json_size)((end - begin) + 1);
+        if (*(end + 1) == '\0')
+            return NULL;
+        if (*(end + 1) == '.')
+            return(end + 2);
+        else return(end + 1);
+    }
+
+    /* only array after name */
+    if (begin < del) {
+        tok->len = (mm_json_size)(begin - tok->str);
+        return begin;
+    }
+
+    if (!del) return NULL;
+    if (*del == '\0') {
+        tok->len = (mm_json_size)(del - tok->str);
+        return NULL;
+    }
+    tok->len = (mm_json_size)(del - tok->str);
+    return del+1;
+}
+
+static mm_json_int
+mm_json_path_parse_array(struct mm_json_token *array, const struct mm_json_token *token)
+{
+    const mm_json_char *begin;
+    const mm_json_char *end;
+
+    array->str = token->str;
+    begin = mm_json_strchr(array->str, '[', (mm_json_int)token->len);
+    if (!begin || ((mm_json_size)(begin - array->str) >= token->len))
+        return 0;
+
+    end = mm_json_strchr(begin, ']', (mm_json_int)(token->len - (mm_json_size)(begin - array->str)));
+    if (!end || ((mm_json_size)(end - array->str) >= token->len))
+        return 0;
+
+    array->str = begin + 1;
+    array->len = (mm_json_size)((end-1) - begin);
+    return 1;
+}
+
+MM_JSON_API struct mm_json_token*
+mm_json_query_del(struct mm_json_token *toks, mm_json_size count,
+    const mm_json_char *path, mm_json_char delemiter)
+{
+    mm_json_size i = 0;
+    mm_json_int begin = 1;
+    struct mm_json_token *iter = NULL;
+    /* iterator to step over each token in the toks array */
+    struct mm_json_token name;
+    /* current segment in the path to search in the tree for */
+    struct mm_json_token array;
+    /* array token to store the current path segment array index */
+    struct mm_json_object {mm_json_size index, size;} obj;
+    /* current object iterator with current pair index and total pairs in object */
+
+    MM_JSON_ASSERT(toks);
+    MM_JSON_ASSERT(count);
+    if (!toks || !count) return iter;
+    if (!path) return &toks[i];
+
+    iter = &toks[i];
+    array.len = 0;
+    array.str = NULL;
+
+    path = mm_json_path_parse_name(&name, path, delemiter);
+    while (1) {
+        if (iter->type == MM_JSON_OBJECT || iter->type == MM_JSON_ARRAY || begin) {
+            /* setup iteration over elements inside a object or array */
+            obj.index = 0;
+            if (begin) {
+                begin = 0;
+                obj.size = count;
+            } else if (iter->type == MM_JSON_OBJECT) {
+                obj.size = iter->children;
+                if ((i + 1) > count) return NULL;
+                iter = &toks[++i];
+            } else {
+                mm_json_number n;
+                mm_json_size j = 0;
+
+                /* array object so set iterator to array index */
+                if (!mm_json_path_parse_array(&array, &name))
+                    return NULL;
+                if ((i+1) >= count)
+                    return NULL;
+                if (array.len < 1)
+                    return NULL;
+                if (mm_json_convert(&n, &array) != MM_JSON_NUMBER)
+                    return NULL;
+                if ((mm_json_size)n >= iter->children)
+                    return NULL;
+                array.str = NULL;
+                array.len = 0;
+
+                /* iterate over each array element and find the correct index */
+                iter++; i++;
+                for (j = 0; j < n; ++j) {
+                    if (iter->type == MM_JSON_ARRAY || iter->type == MM_JSON_OBJECT) {
+                        i = i + (iter->sub) + 1;
+                    } else i += 1;
+                    if (i > count)
+                        return NULL;
+                    iter = &toks[i];
+                }
+                if (!path) return iter;
+                path = mm_json_path_parse_name(&name, path, delemiter);
+            }
+            continue;
+        }
+        {
+            /* check if current table element is equal to the current path  */
+            if (!mm_json_lcmp(iter, name.str, name.len)) {
+                /* correct token found and end of path */
+                if (!path) {
+                    if ((i + 1) > count)
+                        return NULL;
+                    return (iter + 1);
+                }
+                /* check if path points to invalid token */
+                if ((i+1) > count)
+                    return NULL;
+                if(toks[i+1].type != MM_JSON_OBJECT && toks[i+1].type != MM_JSON_ARRAY)
+                    return NULL;
+
+                /* look deeper into child object/array */
+                iter = &toks[++i];
+                path = mm_json_path_parse_name(&name, path, delemiter);
+            } else {
+                /* key is not correct iterate until end of object */
+                if (++obj.index >= obj.size)
+                    return NULL;
+                if ((i + 1) >= count)
+                    return NULL;
+                if (iter[1].type == MM_JSON_ARRAY || iter[1].type == MM_JSON_OBJECT) {
+                    i = i + (iter[1].sub + 2);
+                } else i = i + 2;
+                if (i >= count)
+                    return NULL;
+                iter = &toks[i];
+            }
+        }
+    }
+    return iter;
+}
+
+MM_JSON_API struct mm_json_token*
+mm_json_query(struct mm_json_token *toks, mm_json_size count, const mm_json_char *path)
+{return mm_json_query_del(toks, count, path, MM_JSON_DELIMITER);}
+
+MM_JSON_API mm_json_int
+mm_json_query_number_del(mm_json_number *num, struct mm_json_token *toks, mm_json_size count,
+    const mm_json_char *path, mm_json_char del)
+{
+    struct mm_json_token *tok;
+    MM_JSON_ASSERT(toks);
+    MM_JSON_ASSERT(count);
+    MM_JSON_ASSERT(num);
+    MM_JSON_ASSERT(path);
+    if (!toks || !count || !num || !path)
+        return MM_JSON_NONE;
+
+    tok = mm_json_query_del(toks, count, path, del);
+    if (!tok) return MM_JSON_NONE;
+    if (tok->type != MM_JSON_NUMBER)
+        return tok->type;
+    return mm_json_convert(num, tok);
+}
+
+MM_JSON_API mm_json_int
+mm_json_query_number(mm_json_number *num, struct mm_json_token *toks, mm_json_size count,
+    const mm_json_char *path)
+{return mm_json_query_number_del(num, toks, count, path, MM_JSON_DELIMITER);}
+
+MM_JSON_API mm_json_int
+mm_json_query_string_del(mm_json_char *buffer, mm_json_size max, mm_json_size *size,
+    struct mm_json_token *toks, mm_json_size count, const mm_json_char *path, mm_json_char del)
+{
+    struct mm_json_token *tok;
+    MM_JSON_ASSERT(toks);
+    MM_JSON_ASSERT(count);
+    MM_JSON_ASSERT(buffer);
+    MM_JSON_ASSERT(size);
+    MM_JSON_ASSERT(path);
+    if (!toks || !count || !buffer || !size || !path)
+        return MM_JSON_NONE;
+
+    tok = mm_json_query_del(toks, count, path, del);
+    if (!tok) return MM_JSON_NONE;
+    if (tok->type != MM_JSON_STRING)
+        return tok->type;
+    *size = mm_json_cpy(buffer, max, tok);
+    return tok->type;
+}
+
+MM_JSON_API mm_json_int
+mm_json_query_string(mm_json_char *buffer, mm_json_size max, mm_json_size *size,
+    struct mm_json_token *toks, mm_json_size count, const mm_json_char *path)
+{return mm_json_query_string_del(buffer, max, size, toks, count, path, MM_JSON_DELIMITER);}
+
+MM_JSON_API mm_json_int
+mm_json_query_type_del(struct mm_json_token *toks, mm_json_size count, const mm_json_char *path,
+    mm_json_char del)
+{
+    struct mm_json_token *tok;
+    MM_JSON_ASSERT(toks);
+    MM_JSON_ASSERT(count);
+    MM_JSON_ASSERT(path);
+    if (!toks || !count || !path)
+        return MM_JSON_NONE;
+
+    tok = mm_json_query_del(toks, count, path, del);
+    if (!tok) return MM_JSON_NONE;
+    return tok->type;
+}
+
+MM_JSON_API mm_json_int
+mm_json_query_type(struct mm_json_token *toks, mm_json_size count, const mm_json_char *path)
+{return mm_json_query_type_del(toks, count, path, MM_JSON_DELIMITER);}
+
+#endif

--- a/src/osc-bridge/src/parse-schema.c
+++ b/src/osc-bridge/src/parse-schema.c
@@ -1,0 +1,239 @@
+#include "schema.h"
+#define MM_JSON_IMPLEMENTATION
+#include "mm_json.h"
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+#include <stdio.h>
+
+//Disable debug prints
+#define printf(...) do {} while(0)
+#define putchar(x) (void)(x)
+
+//Shadow string duplication due to windows build issues
+#ifdef  strndup
+#undef  strndup
+#endif
+#define strndup(dat, len) strndup_custom(dat,len)
+
+static char *strndup_custom(const char *data, int len)
+{
+    char *dest = calloc(len+1,1);
+    for(int i=0; i<len; ++i)
+        dest[i] = data[i];
+    return dest;
+}
+
+
+void print_string(const char *str, unsigned len)
+{
+    for(unsigned i=0; i<len; ++i)
+        putchar(str[i]);
+}
+
+opt_t *parse_options(const char *str, int len)
+{
+    printf("parse options...\n");
+    opt_t *o = calloc(1, sizeof(opt_t));
+    struct mm_json_iter array = mm_json_begin(str, len);
+    struct mm_json_token tok;
+    array = mm_json_read(&tok, &array);
+    while(array.src) {
+        //printf("option?\n");
+
+        int   id   = 0xcafebeef;
+        char *text = 0;
+
+        struct mm_json_iter array2 = mm_json_begin(tok.str, tok.len);
+        struct mm_json_pair pair;
+        array2 = mm_json_parse(&pair, &array2);
+        while (!array2.err) {
+            assert(pair.name.type == MM_JSON_STRING);
+
+            if(pair.value.type == MM_JSON_STRING) {
+                struct mm_json_token v = pair.value;
+                if(mm_json_cmp(&pair.name, "value") == 0)
+                    text = strndup(v.str, v.len);
+            } else if(pair.value.type == MM_JSON_NUMBER) {
+                struct mm_json_token v = pair.value;
+                if(mm_json_cmp(&pair.name, "id") == 0)
+                    id = atoi(v.str);
+            } else
+                printf(" = ????\n");
+
+            array2 = mm_json_parse(&pair, &array2);
+        }
+
+        assert(id != (int) 0xcafebeef);
+
+        //Add to the list of options
+        o->num_opts++;
+        o->ids = realloc(o->ids, sizeof(o->ids[0])*o->num_opts);
+        o->labels = realloc(o->labels, sizeof(o->labels[0])*o->num_opts);
+        o->ids[o->num_opts-1]    = id;
+        o->labels[o->num_opts-1] = text;
+        //printf(" %d -> <%s>\n", id, text);
+
+
+        array = mm_json_read(&tok, &array);
+    }
+    return o;
+}
+
+void parse_range(schema_handle_t *handle, const char *str, int len)
+{
+    struct mm_json_iter array = mm_json_begin(str, len);
+    struct mm_json_token tok;
+    array = mm_json_read(&tok, &array);
+    if(!array.src) {
+        fprintf(stdout, "[WARNING] Unexpected range termination in parse_range()\n");
+        return;
+    }
+
+    if(tok.type == MM_JSON_NUMBER)
+        handle->value_min = atof(tok.str);
+    else
+        fprintf(stdout, "[WARNING] Unexpected Range Type %d For Min\n", tok.type);
+
+    array = mm_json_read(&tok, &array);
+    if(!array.src) {
+        fprintf(stdout, "[WARNING] Unexpected range termination in parse_range() P2\n");
+        return;
+    }
+
+    if(tok.type == MM_JSON_NUMBER)
+        handle->value_max = atof(tok.str);
+    else
+        fprintf(stdout, "[WARNING] Unexpected Range Type %d For Max\n", tok.type);
+}
+
+void parse_schema(const char *json, schema_t *sch)
+{
+    sch->elements = 0;
+    sch->handles  = 0;
+
+    /* Lexer example */
+    mm_json_size len = strlen(json);
+
+    /* create iterator  */
+    struct mm_json_iter iter;
+    iter = mm_json_begin(json, len);
+
+    //Read in parameters
+    struct mm_json_pair pair;
+    iter = mm_json_parse(&pair, &iter);
+    assert(!mm_json_cmp(&pair.name, "parameters"));
+    assert(pair.value.type == MM_JSON_ARRAY);
+
+    //Read in parameter objects
+    struct mm_json_iter array = mm_json_begin(pair.value.str, pair.value.len);
+    struct mm_json_token tok;
+    array = mm_json_read(&tok, &array);
+    while (array.src) {
+        /* read single token */
+        printf("new schema handle...\n");
+        sch->elements += 1;
+        sch->handles   = realloc(sch->handles, sch->elements*sizeof(schema_handle_t));
+
+        schema_handle_t *handle = sch->handles+(sch->elements-1);
+        memset(handle, 0, sizeof(schema_handle_t));
+
+        struct mm_json_iter array2 = mm_json_begin(tok.str, tok.len);
+        struct mm_json_pair pair2;
+        array2 = mm_json_parse(&pair2, &array2);
+        while (!array2.err) {
+            assert(pair2.name.type == MM_JSON_STRING);
+            printf("  ");
+            print_string(pair2.name.str, pair2.name.len);
+            unsigned pad = pair2.name.len < 10 ? 10-pair2.name.len : 0;
+            for(unsigned i=0; i<pad; ++i)
+                putchar(' ');
+
+            if(pair2.value.type == MM_JSON_STRING) {
+                printf(" = \"");
+                print_string(pair2.value.str, pair2.value.len);
+                printf("\"\n");
+
+                struct mm_json_token v = pair2.value;
+                if(mm_json_cmp(&pair2.name, "path") == 0)
+                    handle->pattern = strndup(v.str, v.len);
+                else if(mm_json_cmp(&pair2.name, "name") == 0)
+                    handle->name = strndup(v.str, v.len);
+                else if(mm_json_cmp(&pair2.name, "shortname") == 0)
+                    handle->short_name = strndup(v.str, v.len);
+                else if(mm_json_cmp(&pair2.name, "units") == 0)
+                    handle->units = strndup(v.str, v.len);
+                else if(mm_json_cmp(&pair2.name, "scale") == 0)
+                    handle->scale = strndup(v.str, v.len);
+                else if(mm_json_cmp(&pair2.name, "tooltip") == 0)
+                    handle->documentation = strndup(v.str, v.len);
+                else if(mm_json_cmp(&pair2.name, "default") == 0)
+                    handle->default_ = strndup(v.str, v.len);
+                else if(mm_json_cmp(&pair2.name, "type") == 0) {
+                    if(v.str[0] == 'i')
+                        handle->type = 'i';
+                    else if(v.str[0] == 'f')
+                        handle->type = 'f';
+                    else if(v.str[0] == 'T')
+                        handle->type = 'T';
+                    else
+                        handle->type = 0;
+                }
+            } else if(pair2.value.type == MM_JSON_ARRAY &&
+                    mm_json_cmp(&pair2.name, "options") == 0) {
+                handle->opts = parse_options(pair2.value.str, pair2.value.len);
+            } else if(pair2.value.type == MM_JSON_ARRAY &&
+                    mm_json_cmp(&pair2.name, "range") == 0) {
+                parse_range(handle, pair2.value.str, pair2.value.len);
+            } else
+                printf(" = ????\n");
+            array2 = mm_json_parse(&pair2, &array2);
+        }
+
+        //MM_JSON_OBJECT
+        array = mm_json_read(&tok, &array);
+    }
+
+    {
+        printf("ACTIONS...\n\n");
+        iter = mm_json_parse(&pair, &iter);
+        assert(!mm_json_cmp(&pair.name, "actions"));
+        assert(pair.value.type == MM_JSON_ARRAY);
+
+        //Read in parameter objects
+        struct mm_json_iter array = mm_json_begin(pair.value.str, pair.value.len);
+        struct mm_json_token tok;
+        iter = mm_json_read(&tok, &array);
+        while (array.src) {
+            /* read single token */
+            printf("field.type = %d\n", tok.type);
+            struct mm_json_iter array2 = mm_json_begin(tok.str, tok.len);
+            struct mm_json_pair pair2;
+            array2 = mm_json_parse(&pair2, &array2);
+            while (!array2.err) {
+                assert(pair2.name.type == MM_JSON_STRING);
+                printf("  field.name[");
+                print_string(pair2.name.str, pair2.name.len);
+                if(pair2.value.type == MM_JSON_STRING) {
+                    printf("] = \"");
+                    print_string(pair2.value.str, pair2.value.len);
+                    printf("\"\n");
+                } else
+                    printf("] = ????\n");
+                array2 = mm_json_parse(&pair2, &array2);
+            }
+
+            //MM_JSON_OBJECT
+            array = mm_json_read(&tok, &array);
+        }
+    }
+
+    return;
+
+    /* read subobject (array/objects) */
+    iter = mm_json_parse(&pair, &iter);
+    printf("pair.name = %s\n", pair.name.str);
+    printf("pair.value.type = %d\n", pair.value.type);
+    assert(pair.value.type == MM_JSON_ARRAY);
+
+}

--- a/src/osc-bridge/src/schema.c
+++ b/src/osc-bridge/src/schema.c
@@ -1,0 +1,123 @@
+#include "schema.h"
+#include <assert.h>
+#include <ctype.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h> //for error printing
+
+static int match_path(const char *uri, const char *pattern)
+{
+    if(!pattern)
+        return 0;
+
+    //uri_i = pattern_j when uri_i !\in range
+    //range = atoi(pattern_j) when \in  range
+
+    while(*uri && *pattern)
+    {
+        if(*pattern != '[') {
+            if(*uri != *pattern)
+                return 0;
+            uri++;
+            pattern++;
+        } else {
+            pattern++;
+            assert(isdigit(*pattern));
+            int low = atoi(pattern);
+            while(*pattern && isdigit(*pattern))
+                pattern++;
+            assert(*pattern == ',');
+            pattern++;
+            int high = atoi(pattern);
+            while(*pattern && isdigit(*pattern))
+                pattern++;
+            assert(*pattern == ']');
+            pattern++;
+
+            int real = atoi(uri);
+            while(*uri && isdigit(*uri))
+                uri++;
+
+            if(real < low || real > high)
+                return 0;
+        }
+
+    }
+
+    //partial match, but not a complete one
+    if(!*pattern && *uri)
+        return 0;
+
+    return 1;
+}
+
+void br_destroy_schema(schema_t sch)
+{
+    free(sch.json);
+    for(int i=0; i<sch.elements; ++i) {
+        if(sch.handles[i].opts) {
+            free(sch.handles[i].opts->ids);
+            for(size_t j=0; j<sch.handles[i].opts->num_opts; ++j)
+                free((void*)sch.handles[i].opts->labels[j]);
+            free(sch.handles[i].opts->labels);
+        }
+        free((void*)sch.handles[i].documentation);
+        free((void*)sch.handles[i].name);
+        free((void*)sch.handles[i].short_name);
+        free((void*)sch.handles[i].pattern);
+        free((void*)sch.handles[i].default_);
+        free(sch.handles[i].opts);
+    }
+    free(sch.handles);
+}
+
+//Schema
+schema_handle_t sm_get(schema_t sch, uri_t u)
+{
+    schema_handle_t invalid;
+    memset(&invalid, 0, sizeof(invalid));
+    invalid.flag = 0xdeadbeef;
+    //printf("Getting a handle(%s)...\n", u);
+    for(int i=0; i<sch.elements; ++i)
+        if(match_path(u, sch.handles[i].pattern))
+            return sch.handles[i];
+    if(!(strstr(u, "VoicePar") && strstr(u, "Enabled")))
+        printf("[WARNING:osc-bridge] Invalid Handle \"%s\"...\n", u);
+    return invalid;
+}
+str_t sm_get_name(schema_handle_t h)
+{
+    return h.name ? h.name : "";
+}
+
+str_t sm_get_short(schema_handle_t h)
+{
+    return h.short_name ? h.short_name : "";
+}
+
+str_t sm_get_tooltip(schema_handle_t h)
+{
+    return h.documentation ? h.documentation : "";
+}
+
+str_t sm_get_units(schema_handle_t h)
+{
+    (void) h;
+    return "";
+}
+
+float sm_get_min_flt(schema_handle_t h)
+{
+    return h.value_min;
+}
+
+float sm_get_max_flt(schema_handle_t h)
+{
+    return h.value_max;
+}
+
+int sm_valid(schema_handle_t h)
+{
+    return h.flag != (int) 0xdeadbeef;
+}
+

--- a/src/osc-bridge/src/schema.h
+++ b/src/osc-bridge/src/schema.h
@@ -1,0 +1,56 @@
+#ifndef OSC_BRIDGE_SCHEMA
+#define OSC_BRIDGE_SCHEMA
+//OSC Schema
+
+//Options for an enumerated parameter
+typedef struct {
+    int         *ids;      //Integer mapping of values (num_opts long)
+    const char **labels;   //Text labels of values (num_opts long)
+    unsigned     num_opts; //Number of options
+} opt_t;
+
+//Schema handle
+typedef struct {
+    //Note: all pointers are dynamically allocated here
+    int   flag;
+    opt_t *opts;
+    const char *pattern;
+    const char *name;
+    const char *short_name;
+    const char *units;
+    const char *documentation;
+    const char *scale;
+    const char *default_;
+    char  type;
+    float value_min;
+    float value_max;
+} schema_handle_t;
+
+//Schema instance
+typedef struct {
+    char            *json;     //Raw JSON
+    schema_handle_t *handles;  //Array of parsed handles
+    int              elements; //Array len
+} schema_t;
+
+typedef const char *uri_t;
+typedef const char *str_t;
+
+/**
+ * Returns a schema handle which matches the provided uri
+ *
+ * Returns an invalid handle if no matching handle exists
+ */
+schema_handle_t sm_get(schema_t, uri_t u);
+
+// Get field from handle or "" when no value was specified
+str_t sm_get_name(schema_handle_t);
+str_t sm_get_short(schema_handle_t);
+str_t sm_get_tooltip(schema_handle_t);
+str_t sm_get_units(schema_handle_t);
+float sm_get_min_flt(schema_handle_t);
+float sm_get_max_flt(schema_handle_t);
+
+//Verify that handle contains valid data
+int sm_valid(schema_handle_t);
+#endif

--- a/src/osc-bridge/test/basic-remote.c
+++ b/src/osc-bridge/test/basic-remote.c
@@ -1,0 +1,151 @@
+#include <rtosc/rtosc.h>
+#include "../src/bridge.h"
+#include "common.h"
+#include <sys/time.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+#include <unistd.h>
+
+float Pfreq     = 12345.0;
+int Pfreqrand   = 255;
+bool Pcontinous = true;
+
+void print_response(const char *osc, void *vv)
+{
+    char type = rtosc_type(osc, 0);
+    //printf("[callback] got a message '%s':%c data=%p...\n", osc, type, v);
+
+    rtosc_arg_t arg = rtosc_argument(osc, 0);
+
+    if(!vv)
+        return;
+    void *v = *(void**)vv;
+
+
+    if(type == 'i')
+        *(int*)v = arg.i;
+    else if(type == 'T')
+        *(bool*)v = true;
+    else if(type == 'F')
+        *(bool*)v = false;
+    else if(type == 'f')
+        *(float*)v = arg.f;
+
+    //if(type == 'i')
+    //    printf("[callback] value = %d\n", arg.i);
+    //else if(type == 'f')
+    //    printf("[callback] value = %a\n", (double)arg.f);
+    //else if(type == 'T')
+    //    printf("[callback] value = true\n");
+    //else if(type == 'F')
+    //    printf("[callback] value = false\n");
+}
+
+float asdf = 0x1.93264cp-2;
+
+
+//Paths to check for a minimal(ish) example subwindow
+const char *paths[] = {
+"/part0/kit0/adpars/VoicePar0/FreqLfo/Pfreq",
+"/part0/kit0/adpars/VoicePar0/FreqLfo/Pintensity",
+"/part0/kit0/adpars/VoicePar0/FreqLfo/Pstartphase",
+"/part0/kit0/adpars/VoicePar0/FreqLfo/PLFOtype",
+"/part0/kit0/adpars/VoicePar0/FreqLfo/Prandomness",
+"/part0/kit0/adpars/VoicePar0/FreqLfo/Pfreqrand",
+"/part0/kit0/adpars/VoicePar0/FreqLfo/Pdelay",
+"/part0/kit0/adpars/VoicePar0/FreqLfo/Pcontinous",
+"/part0/kit0/adpars/VoicePar0/FreqLfo/Pstretch",
+};
+void test_lfo(schema_t schema, bridge_t *bridge)
+{
+    for(unsigned i=0; i<sizeof(paths)/sizeof(paths[0]); ++i) {
+        uri_t uri = paths[i];
+        printf("#Testing address '%s'\n", uri);
+        schema_handle_t handle = sm_get(schema, uri);
+
+        assert_true(sm_valid(handle), "Verify Handle", __LINE__);
+
+        //printf("(1#{%s} 2#{%s} 3#{%s} 4#{%s}\n",
+        //sm_get_name(handle),    sm_get_short(handle),
+        //sm_get_tooltip(handle), sm_get_units(handle));
+        br_add_callback(bridge, uri, print_response, NULL);
+        void **data = malloc(sizeof(void*));
+        if(strstr(uri, "Pfreqrand")) {
+            *data = &Pfreqrand;
+            br_add_callback(bridge, uri, print_response, (void*)data);
+        } else if(strstr(uri, "Pfreq")) {
+            *data = &Pfreq;
+            br_add_callback(bridge, uri, print_response, (void*)data);
+        } else if(strstr(uri, "Pcontinous")) {
+            *data = &Pcontinous;
+            br_add_callback(bridge, uri, print_response, (void*)data);
+        } else
+            free(data);
+    }
+}
+
+int main()
+{
+    test_plan(17);
+    //Define that there is a bridge on localhost:1337
+    printf("#Creating Bridge To Remote...\n");
+    bridge_t *bridge = br_create("osc.udp://localhost:1337");
+
+    //Get the bridge to obtain the schema
+    printf("#Creating Schema For Remote...\n");
+    schema_t schema = br_get_schema(bridge, "/schema");
+    
+    assert_true(1000 <  schema.elements,
+            "Schema has around the right number of elements", __LINE__);
+
+    test_lfo(schema, bridge);
+
+    br_recv(bridge, 0);
+
+    assert_int_eq(9, bridge->cache_len,
+            "Check Cache Size", __LINE__);
+    assert_int_eq(12, bridge->callback_len,
+            "Check Callback Size", __LINE__);
+
+
+    //print_stats(bridge, schema);
+    
+
+    int old_pending = br_pending(bridge);
+    //printf("STARTING UV RUN...\n");
+    struct timeval tv1;
+    struct timeval tv2;
+    gettimeofday(&tv1, 0);
+    int tic = 0;
+    while(old_pending) {
+        uv_run(bridge->loop, UV_RUN_NOWAIT);
+        int new_pending = br_pending(bridge);
+        tic++;
+        if(old_pending != new_pending)
+            old_pending = new_pending;
+        else
+            usleep(1);
+        gettimeofday(&tv2, 0);
+        float delta = (tv2.tv_sec-tv1.tv_sec) + 1e-6*(tv2.tv_usec-tv1.tv_usec);
+        if(delta > 0.100)
+            break;
+    }
+    gettimeofday(&tv2, 0);
+    float delta = (tv2.tv_sec-tv1.tv_sec) + 1e-6*(tv2.tv_usec-tv1.tv_usec);
+    printf("#delta time is %f ms\n", delta*1e3);
+
+
+    assert_int_eq(0, old_pending, "Cache is up-to-date", __LINE__);
+    assert_true(delta < 0.100, "Check for timeout", __LINE__);
+
+    assert_flt_eq(0x1.93264cp-2, Pfreq, "Default frequency is set", __LINE__);
+    assert_int_eq(0, Pfreqrand, "Default randomness is zero", __LINE__);
+    assert_false(Pcontinous, "Default LFO is not continious", __LINE__);
+
+    br_destroy(bridge);
+    br_destroy_schema(schema);
+
+    return test_summary();
+}

--- a/src/osc-bridge/test/common.h
+++ b/src/osc-bridge/test/common.h
@@ -1,0 +1,210 @@
+#include <stdio.h>
+#include <string.h>
+#include <ctype.h>
+#include <stdlib.h>
+
+int global_err = 0;
+int test_counter = 0;
+//expect a
+//actual b
+int assert_int_eq(int a, int b, const char *testcase, int line)
+{
+    test_counter++;
+    int err = a!=b;
+    if(err) {
+        printf("not ok %d - %s...\n", test_counter, testcase);
+        printf("# Expected %d, but observed %d instead (line %d)\n", a, b, line);
+        global_err++;
+    } else
+        printf("ok %d - %s...\n", test_counter, testcase);
+    return err;
+}
+
+int assert_char_eq(char a, char b, const char *testcase, int line)
+{
+    test_counter++;
+    int err = a!=b;
+    if(err) {
+        printf("not ok %d - %s...\n", test_counter, testcase);
+        printf("# Expected %c, but observed %c instead (line %d)\n", a, b, line);
+        global_err++;
+    } else
+        printf("ok %d - %s...\n", test_counter, testcase);
+    return err;
+}
+
+int assert_true(int a, const char *testcase, int line)
+{
+    test_counter++;
+    int err = !a;
+    if(err) {
+        printf("not ok %d - %s...\n", test_counter, testcase);
+        printf("# Failure on line %d\n", line);
+        global_err++;
+    } else
+        printf("ok %d - %s...\n", test_counter, testcase);
+    return err;
+}
+
+int assert_false(int a, const char *testcase, int line)
+{
+    return assert_true(!a, testcase, line);
+}
+
+
+int assert_str_eq(const char *a, const char *b, const char *testcase, int line)
+{
+    test_counter++;
+    int err = strcmp(a,b);
+    if(err) {
+        printf("not ok %d - %s...\n", test_counter, testcase);
+        printf("# Expected '%s', but observed '%s' instead (line %d)\n", a, b, line);
+        global_err++;
+    } else
+        printf("ok %d - %s...\n", test_counter, testcase);
+    return err;
+}
+
+int assert_non_null(const void *v, const char *testcase, int line)
+{
+    test_counter++;
+    int err = !v;
+    if(err) {
+        printf("not ok %d - %s...\n", test_counter, testcase);
+        printf("# Expected Non-NULL value, but observed NULL instead (line %d)\n", line);
+        global_err++;
+    } else
+        printf("ok %d - %s...\n", test_counter, testcase);
+    return err;
+}
+
+int assert_f32_eq(float a, float b,const char *testcase, int line)
+{
+    test_counter++;
+    int err = a!=b;
+    if(err) {
+        printf("not ok %d - %s...\n", test_counter, testcase);
+        printf("# Expected %f, but observed %f instead (line %d)\n", a, b, line);
+        global_err++;
+    } else
+        printf("ok %d - %s...\n", test_counter, testcase);
+    return err;
+}
+
+//produce a xxd style hexdump with sections highlighted using escape sequences
+//
+//e.g.
+//0000000: 2369 6e63 6c75 6465 203c 7374 6469 6f2e  #include <stdio.
+//0000010: 683e 0a23 696e 636c 7564 6520 3c73 7472  h>.#include <str
+//0000020: 696e 672e 683e 0a0a 696e 7420 676c 6f62  ing.h>..int glob
+//0000030: 616c 5f65 7272 203d 2030 3b0a 696e 7420  al_err = 0;.int
+//0000040: 7465 7374 5f63 6f75 6e74 6572 203d 2030  test_counter = 0
+//0000050: 3b0a 2f2f 6578 7065 6374 2061 0a2f 2f61  ;.//expect a.//a
+//
+void hexdump(const char *data, const char *mask, size_t len)
+{
+    const char *bold_gray = "\x1b[30;1m";
+    const char *reset      = "\x1b[0m";
+    int offset = 0;
+    while(1)
+    {
+        //print line
+        printf("#%07x: ", offset);
+
+        int char_covered = 0;
+
+        //print hex groups (8)
+        for(int i=0; i<8; ++i) {
+
+            //print doublet
+            for(int j=0; j<2; ++j) {
+                int loffset = offset + 2*i + j;
+                if(loffset >= (int)len)
+                    goto escape;
+
+                //print hex
+                {
+                    //start highlight
+                    if(mask && mask[loffset]){printf("%s", bold_gray);}
+
+                    //print chars
+                    printf("%02x", 0xff&data[loffset]);
+
+                    //end highlight
+                    if(mask && mask[loffset]){printf("%s", reset);}
+                    char_covered += 2;
+                }
+            }
+            printf(" ");
+            char_covered += 1;
+        }
+escape:
+
+        //print filler if needed
+        for(int i=char_covered; i<41; ++i)
+            printf(" ");
+
+        //print ascii (16)
+        for(int i=0; i<16; ++i) {
+            if(isprint(data[offset+i]))
+                printf("%c", data[offset+i]);
+            else
+                printf(".");
+        }
+        printf("\n");
+        offset += 16;
+        if(offset >= (int)len)
+            return;
+    }
+}
+
+
+int assert_hex_eq(const char *a, const char *b, size_t size_a, size_t size_b,
+                  const char *testcase, int line)
+{
+    test_counter++;
+    int err = (size_a != size_b) || memcmp(a, b, size_a);
+    if(err) {
+        printf("not ok %d - %s...\n", test_counter, testcase);
+        printf("# Error on line %d\n", line);
+        //printf("# Expected '%s', but observed '%s' instead (line %d)\n", a, b, line);
+
+        //create difference mask
+        const int longer  = size_a > size_b ? size_a : size_b;
+        const int shorter = size_a < size_b ? size_a : size_b;
+        char mask[longer];
+        memset(mask, 0, longer);
+        for(int i=0; i<shorter; ++i)
+            if(a[i] != b[i])
+                mask[i] = 1;
+
+        printf("#\n");
+        printf("# Expected:\n");
+        hexdump(a, mask, size_a);
+        printf("#\n");
+        printf("# Observed:\n");
+        hexdump(b, mask, size_b);
+
+        global_err++;
+    } else
+        printf("ok %d - %s...\n", test_counter, testcase);
+    return err;
+}
+
+int assert_flt_eq(float a, float b, const char *testcase, int line)
+{
+    return assert_hex_eq((char*)&a, (char*)&b, sizeof(float), sizeof(float),
+            testcase, line);
+}
+
+void test_plan(int tests)
+{
+    printf("1..%d\n", tests);
+}
+
+int test_summary(void)
+{
+    printf("# %d test(s) failed out of %d (passing %d%% tests)\n",
+            global_err, test_counter, (int)(100.0-global_err*100./test_counter));
+    return global_err ? EXIT_FAILURE : EXIT_SUCCESS;
+}

--- a/src/osc-bridge/test/mock-test.c
+++ b/src/osc-bridge/test/mock-test.c
@@ -1,0 +1,233 @@
+#include <rtosc/rtosc.h>
+#include "../src/bridge.h"
+#include <sys/time.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <assert.h>
+#include <unistd.h>
+#include "common.h"
+
+int  v1 = 0xff;
+int  v2 = 0xff;
+bool v3 = false;
+
+int osc_socket_hook_fn(void)
+{
+    return 0;
+}
+
+int osc_request_hook_fn(bridge_t *br, const char *msg)
+{
+    // /schema        - return the schema file
+    // /part0/Pvolume - return the volume
+    char *buffer = NULL;
+
+    const char *args = rtosc_argument_string(msg);
+    //printf("[REQUEST] osc_request_hook_fn(%p,%s,%s)\n", br, msg,args);
+    if(!strcmp(msg, "/schema") && !strcmp(args, "")) {
+        size_t buf_size = rtosc_message(NULL, 0, "/schema", "s", "");
+        buffer = malloc(buf_size);
+        rtosc_message(buffer, buf_size, "/schema", "s", "");
+        br_recv(br, buffer);
+    } else if(!strcmp(msg, "/part0/Pvolume") && !strcmp(args, "")) {
+        size_t buf_size = rtosc_message(NULL, 0, "/part0/Pvolume", "i", 32);
+        buffer = malloc(buf_size);
+        rtosc_message(buffer, 128, "/part0/Pvolume", "i", 32);
+        br_recv(br, buffer);
+    } else if(!strcmp(msg, "/part0/Penabled") && !strcmp(args, "")) {
+        size_t buf_size = rtosc_message(NULL, 0, "/part0/Penabled", "T");
+        buffer = malloc(buf_size);
+        rtosc_message(buffer, buf_size, "/part0/Penabled", "T");
+        br_recv(br, buffer);
+    } else if(!strcmp(msg, "/vector/test")) {
+        //do nothing
+    } else {
+        printf("[ERROR] unexpected message...\n");
+        assert(false);
+        return 0;
+    }
+
+    //TODO send the message
+
+    free(buffer);
+
+    return 0;
+}
+
+
+
+void print_response(const char *osc, void *vv)
+{
+    char type = rtosc_type(osc, 0);
+    //printf("[callback] got a message '%s':%c data=%p...\n", osc, type, v);
+
+    rtosc_arg_t arg = rtosc_argument(osc, 0);
+
+    void *v = *(void**)vv;
+
+    if(type == 'i')
+        *(int*)v = arg.i;
+    else if(type == 'T')
+        *(bool*)v = true;
+    else if(type == 'F')
+        *(bool*)v = false;
+    else if(type == 'f')
+        for(rtosc_arg_itr_t itr = rtosc_itr_begin(osc); !rtosc_itr_end(itr);)
+            printf("# vec arg %f\n", rtosc_itr_next(&itr).val.f);
+
+    //if(type == 'i')
+    //    printf("[callback] value = %d\n", arg.i);
+    //else if(type == 'f')
+    //    printf("[callback] value = %f\n", arg.f);
+    //else if(type == 'T')
+    //    printf("[callback] value = true\n");
+    //else if(type == 'F')
+    //    printf("[callback] value = false\n");
+}
+
+void test_pvolume(schema_t schema, bridge_t *bridge)
+{
+    //Add a view to /part0/Pvolume
+    printf("#Grabbing Pvolume Handle On Schema...\n");
+    uri_t uri = "/part0/Pvolume";
+    schema_handle_t handle = sm_get(schema, uri);
+
+    assert_true(sm_valid(handle), "A valid handle is obtained", __LINE__);
+
+    //printf("Obtained Handle for <%s>...\n", uri);
+    assert_str_eq("Pvolume", sm_get_name(handle),
+            "The name of the parameter is available", __LINE__);
+    assert_str_eq("Vol", sm_get_short(handle),
+            "The abbreviated name is available", __LINE__);
+    assert_str_eq("Part Volume", sm_get_tooltip(handle),
+            "The tooltip is available", __LINE__);
+    assert_str_eq("", sm_get_units(handle),
+            "Optional units have some return value", __LINE__);
+
+    void **v1_ = malloc(sizeof(void*));
+    void **v2_ = malloc(sizeof(void*));
+    *v1_ = &v1;
+    *v2_ = &v2;
+
+    br_add_callback(bridge, uri, print_response, v1_);
+    br_add_callback(bridge, uri, print_response, v2_);
+}
+
+void test_enable(schema_t schema, bridge_t *bridge)
+{
+    printf("#Grabbing Penabled Handle On Schema...\n");
+    uri_t uri = "/part0/Penabled";
+    schema_handle_t handle = sm_get(schema, uri);
+
+    assert_true(sm_valid(handle), "A valid handle is obtained", __LINE__);
+    assert_str_eq("Penabled", sm_get_name(handle),
+            "The name of the parameter is available", __LINE__);
+    assert_str_eq("enable", sm_get_short(handle),
+            "The abbreviated name is available", __LINE__);
+    assert_str_eq("Part enable", sm_get_tooltip(handle),
+            "The tooltip is available", __LINE__);
+    assert_str_eq("", sm_get_units(handle),
+            "Optional units have some return value", __LINE__);
+
+    void **v3_ = malloc(sizeof(void*));
+    *v3_ = &v3;
+
+    br_add_callback(bridge, uri, print_response, v3_);
+}
+
+void test_options(schema_t schema, bridge_t *bridge)
+{
+    (void) bridge;
+    printf("#Grabbing filter type...\n"); 
+    uri_t uri = "/part3/kit8/adpars/VoicePar3/FMSmp/Pfiltertype";
+    schema_handle_t handle = sm_get(schema, uri);
+
+    assert_true(sm_valid(handle), "A valid handle is obtained", __LINE__);
+    assert_int_eq(14, handle.opts->num_opts, "All Options are recorded", __LINE__);
+    assert_int_eq(7, handle.opts->ids[7], "The Option Id is recorded", __LINE__);
+    assert_str_eq("hp2", handle.opts->labels[7], "The Option label is recorded", __LINE__);
+}
+
+void test_part_level(schema_t schema, bridge_t *bridge)
+{
+    test_pvolume(schema, bridge);
+    test_enable(schema, bridge);
+}
+
+void test_vector_functionality(bridge_t *br)
+{
+    char buffer[1024];
+    rtosc_message(buffer, sizeof(buffer), "/vector/test", "ffff", 1.1, 2.2, 3.3, 4.4);
+    br_recv(br, buffer);
+    br_recv(br, buffer);
+    void **v1_ = malloc(sizeof(void*));
+    *v1_ = &v1;
+
+    br_add_callback(br, "/vector/test", print_response, v1_);
+}
+
+int main()
+{
+    bool verbose = false;
+    test_plan(21);
+
+    //Apply Debug Hooks
+    printf("#Setting up hooks...\n");
+    osc_request_hook = osc_request_hook_fn;
+    osc_socket_hook  = osc_socket_hook_fn;
+
+    //Define that there is a bridge on localhost:1337
+    bridge_t *bridge = br_create("osc.udp://localhost:1337");
+    assert_non_null(bridge, "A Bridge is allocated", __LINE__);
+
+    //Get the bridge to obtain the schema
+    printf("#Creating Schema For Remote...\n");
+    schema_t schema = br_get_schema(bridge, "/schema");
+    assert_true(1000 <  schema.elements,
+            "Schema has around the right number of elements", __LINE__);
+
+    assert_int_eq(255, v1, "Verify pre-callback #1 data", __LINE__);
+    assert_int_eq(255, v2, "Verify pre-callback #2 data", __LINE__);
+    assert_false(v3, "Verify pre-callback #3 data", __LINE__);
+
+    test_part_level(schema, bridge);
+    test_options(schema, bridge);
+    assert_int_eq(32, v1, "Callback #1 was applied", __LINE__);
+    assert_int_eq(32, v2, "Callback #2 was applied", __LINE__);
+    assert_true(v3, "Callback #3 was applied", __LINE__);
+
+    br_default(bridge, schema, "/part0/Pvolume");
+
+    assert_int_eq(96, v1, "Default #1 was applied", __LINE__);
+    assert_int_eq(96, v2, "Default #2 was applied", __LINE__);
+
+    printf("#bridge receive...\n");
+    assert_int_eq(2, bridge->cache_len,
+            "Verify number of cache fields", __LINE__);
+    assert_int_eq(3, bridge->callback_len,
+            "Verify number of callbacks", __LINE__);
+    br_recv(bridge, 0);
+
+    if(verbose) {
+        for(int i=0; i<bridge->callback_len; ++i)
+            printf("callback[%d][%s][%p]\n", i, bridge->callback[i].path,
+                    bridge->callback[i].data);
+        for(int i=0; i<bridge->cache_len; ++i)
+            printf("cache[%d][%s][%d]\n", i, bridge->cache[i].path,
+                    bridge->cache[i].pending);
+    }
+
+    assert_int_eq(0, br_pending(bridge),
+            "No Cache Line is Pending", __LINE__);
+
+    test_vector_functionality(bridge);
+
+    //cleanup
+    br_destroy(bridge);
+    br_destroy_schema(schema);
+
+
+    return test_summary();
+}


### PR DESCRIPTION
This PR replaces the mruby-zest and osc-bridge submodules by a git-subrepo equivalent. All the commits have been obtained using a bash script shown below. Note that it brings in the latest version of mruby-zest as well.

CAVEAT: anybody who has a checked-out version of mruby-zest-build with submodules initialized and updated won't be able to "git pull" through those commits without manually deleting src/osc-bridge and src/mruby-zest prior to it. An alternative solution is to start from a fresh repository clone.

So the upgrade path is something like:

```
git fetch
git checkout master
rm -rf src/mruby-zest src/osc-bridge
git pull
```

Script used to generate this PR, to be run in the parent directory of mruby-zest-build/. Requires an install of git-subrepo. It can be easily adapted to convert any other submodule:

```
DIRECTORY=mruby-zest-build

function submodule_to_subrepo() {    
    git config -f .gitmodules --remove-section submodule.${SUBMODULE_SECTION}
    git add .gitmodules
    git config --local --remove-section submodule.${SUBMODULE_SECTION}
    git rm --cached ${SUBMODULE_PATH}
    rm -rf .git/modules/${SUBMODULE_SECTION}
    git commit -m "Deleted ${SUBMODULE_PATH} submodule"
    rm -rf ${SUBMODULE_PATH}
    git subrepo clone ${SUBMODULE_URL} ${SUBMODULE_PATH}
}

pushd ${DIRECTORY}
git checkout -b git-subrepo

SUBMODULE_PATH=src/mruby-zest
SUBMODULE_NAME=mruby-zest
SUBMODULE_URL=git@github.com:mruby-zest/mruby-zest.git
SUBMODULE_SECTION=${SUBMODULE_PATH}
submodule_to_subrepo
    
SUBMODULE_PATH=src/osc-bridge
SUBMODULE_NAME=osc-bridge
SUBMODULE_URL=git@github.com:mruby-zest/osc-bridge.git
SUBMODULE_SECTION=deps/osc-bridge

submodule_to_subrepo
popd
```