### PR TITLE
Restored the radial menu on the pad > apply button

### DIFF
--- a/src/mruby-zest/example/ApplyButton.qml
+++ b/src/mruby-zest/example/ApplyButton.qml
@@ -41,7 +41,7 @@ Button {
 
         diameter = [2.0*ropt, 3.0*0.5*(self.w+self.h)].min
 
-        widget = RadialMenu.new(self.db)
+        widget = Qml::RadialMenu.new(self.db)
         widget.w = diameter
         widget.h = diameter
         widget.x = self.w/2-diameter/2

--- a/src/mruby-zest/qml/Valuator.qml
+++ b/src/mruby-zest/qml/Valuator.qml
@@ -51,7 +51,7 @@ Widget {
 
         diameter = [2.0*ropt, 3.0*0.5*(valuator.w+valuator.h)].min
 
-        widget = RadialMenu.new(valuator.db)
+        widget = Qml::RadialMenu.new(valuator.db)
         widget.w = diameter
         widget.h = diameter
         widget.x = valuator.w/2-diameter/2


### PR DESCRIPTION
Previous state: a right-click on this button would crash zynfusion.