### PR TITLE
UI: SubSynth: Fix getting stuck in oscilloscope

### DIFF
--- a/src/mruby-zest/example/ZynSubSynth.qml
+++ b/src/mruby-zest/example/ZynSubSynth.qml
@@ -5,7 +5,7 @@ Widget {
     TabGroup {
         id: subtabs
         TabButton {label: "harmonic" }
-        TabButton {label: "global" }
+        TabButton {label: "global"; whenClick: lambda {root.set_view_pos(:vis, :envelope)}; }
         TabButton {label: "bandwidth" }
 
         TriggerButton {


### PR DESCRIPTION
In SubFX, once I switch to oscilloscope, I'll not be able to go back to
"Global" panel, as the envelope won't show anymore.
This patch should fix this problem: when click the "Global" tab button,
Zest should re-open the envelope view.

Reference: ZynPadSynth.qml (in src/mruby-zest/example)

**NOTE: Maybe f21c3da should be dropped.**