### PR TITLE
add togglebutton to enable audio output compressor

### DIFF
--- a/src/mruby-zest/example/ZynSettings.qml
+++ b/src/mruby-zest/example/ZynSettings.qml
@@ -2,17 +2,17 @@ Widget {
     id: settings
     Forms {
         label: "Global Settings"
-        TextField {tooltip: "Sample Rate:"; label: "48 kHz"}
-        ToggleButton {tooltip: "Swap Stereo:"; label: "Swap Stereo"}
+        TextField {tooltip: "Sample Rate:"; label: "48 kHz"} 
+        ToggleButton {tooltip: "Swap Stereo:"; label: "Swap Stereo"; 
+            extern: settings.extern+"config/cfg.SwapStereo"}
         ToggleButton {tooltip: "Enable Output Compressor:"; 
-            label: "Audio Compressor"; extern: settings.extern+"io/audio-compressor"}
+            label: "Audio Compressor"; extern: settings.extern+"config/cfg.AudioOutputCompressor"}
         TextField {tooltip: "Oscil Size:";  label: "256 samples"}
         TextField {tooltip: "Buffer Size:"; label: "128 samples"}
-        NumEntry {tooltip: "XML Compression:"}
-        Selector {tooltip: "Virtual Keyboard layout:"
-            options: ["QWERTY", "AZERTY"]
-        }
-        ToggleButton {tooltip: "Ignore MIDI Program Change:"}
+        NumEntry {tooltip: "XML Compression:"; 
+            extern: settings.extern+"config/cfg.GzipCompression"}
+        ToggleButton {tooltip: "Ignore MIDI Program Change:"; label: "MIDI PGM Chg"; 
+        extern: settings.extern+"config/cfg.IgnoreProgramChange"}
     }
     Widget{
     function draw(vg) {

--- a/src/mruby-zest/example/ZynSettings.qml
+++ b/src/mruby-zest/example/ZynSettings.qml
@@ -1,8 +1,11 @@
 Widget {
+    id: settings
     Forms {
         label: "Global Settings"
         TextField {tooltip: "Sample Rate:"; label: "48 kHz"}
-        ToggleButton {tooltip: "Swap Stereo:"}
+        ToggleButton {tooltip: "Swap Stereo:"; label: "Swap Stereo"}
+        ToggleButton {tooltip: "Enable Output Compressor:"; 
+            label: "Audio Compressor"; extern: settings.extern+"io/audio-compressor"}
         TextField {tooltip: "Oscil Size:";  label: "256 samples"}
         TextField {tooltip: "Buffer Size:"; label: "128 samples"}
         NumEntry {tooltip: "XML Compression:"}

--- a/src/osc-bridge/schema/test.json
+++ b/src/osc-bridge/schema/test.json
@@ -9587,7 +9587,7 @@
         "tooltip"  : "Denominator of ratio to bpm",
         "scale"    : "linear",
         "type"     : "i",
-        "range"    : [0,99],
+        "range"    : [1,99],
         "default"  : "4"
 
     },
@@ -11792,7 +11792,7 @@
         "tooltip"  : "Denominator of ratio to bpm",
         "scale"    : "linear",
         "type"     : "i",
-        "range"    : [0,99],
+        "range"    : [1,99],
         "default"  : "4"
 
     },
@@ -13436,7 +13436,7 @@
         "tooltip"  : "Denominator of ratio to bpm",
         "scale"    : "linear",
         "type"     : "i",
-        "range"    : [0,99],
+        "range"    : [1,99],
         "default"  : "4"
 
     },
@@ -15403,6 +15403,12 @@
         "path"     : "/config/cfg.SwapStereo",
         "name"     : "cfg.SwapStereo",
         "tooltip"  : "Swap Left And Right Channels",
+        "type"     : "t"
+    },
+    {
+        "path"     : "/config/cfg.AudioOutputCompressor",
+        "name"     : "cfg.AudioOutputCompressor",
+        "tooltip"  : "Apply Compressor to Audio Output",
         "type"     : "t"
     },
     {


### PR DESCRIPTION
adds a button in ZynSettings for the port /io/audio-compressor