### PR TITLE
Add settings toggle for XML Full Save

### DIFF
--- a/src/mruby-zest/example/ZynSettings.qml
+++ b/src/mruby-zest/example/ZynSettings.qml
@@ -29,6 +29,11 @@ Widget {
             extern: settings.extern+"config/cfg.GzipCompression"
         }
         ToggleButton {
+            tooltip: "Include disabled parts in save:"
+            label: "XML Full Save"
+            extern: settings.extern+"config/cfg.SaveFullXml"
+        }
+        ToggleButton {
             tooltip: "Ignore MIDI Program Change:"
             label: "MIDI PGM Chg"
             extern: settings.extern+"config/cfg.IgnoreProgramChange"

--- a/src/osc-bridge/schema/test.json
+++ b/src/osc-bridge/schema/test.json
@@ -15615,6 +15615,12 @@
         "type"     : "i"
     },
     {
+        "path"     : "/config/cfg.SaveFullXml",
+        "name"     : "cfg.SaveFullXml",
+        "tooltip"  : "Include Disabled parts in save",
+        "type"     : "t"
+    },
+    {
         "path"     : "/config/cfg.CheckPADsynth",
         "name"     : "cfg.CheckPADsynth",
         "tooltip"  : "Old Check For PADsynth functionality within a patch",


### PR DESCRIPTION
Commits are now simplified.
This modification is required after/if matching pull request to zynaddsubfx is approved.