### PR TITLE
Improve bank ops

### DIFF
--- a/src/mruby-zest/example/SelColumn.qml
+++ b/src/mruby-zest/example/SelColumn.qml
@@ -119,10 +119,18 @@ Widget {
                 else
                     rows[x*stride]
                 end
-                ch.tooltip = if(x*stride+1>=rows.length)
-                    ""
+                if (skip)
+                    ch.tooltip = if(x*stride+1>=rows.length)
+                        ""
+                    else
+                        rows[x*stride+1]
+                    end
                 else
-                    rows[x*stride+1]
+                    ch.tooltip = if(x*stride>=rows.length)
+                        ""
+                    else
+                        rows[x*stride]
+                    end
                 end
             end
             ch.layoutOpts = [:no_constraint]

--- a/src/mruby-zest/example/SelColumn.qml
+++ b/src/mruby-zest/example/SelColumn.qml
@@ -41,6 +41,12 @@ Widget {
         end
     }
 
+    function clear_all()
+    {
+        clear_sel
+        setValue([])
+    }
+
     function clear_sel()
     {
         self.value_sel = nil

--- a/src/mruby-zest/example/ZynBank.qml
+++ b/src/mruby-zest/example/ZynBank.qml
@@ -102,19 +102,22 @@ Widget {
                 label:  "bank"
                 skip:   true
                 extern: "/bank/bank_list"
-                whenValue: lambda { bank.doBank }
+                whenValue: lambda { ins_sel.clear_sel
+                                    bank.doBank }
             }
             SelColumn {
                 id: bank_type
                 label: "type"
                 extern: "/bank/types"
-                whenValue: lambda { bank.doType }
+                whenValue: lambda { ins_sel.clear_sel
+                                    bank.doType }
             }
             SelColumn {
                 id: bank_tag
                 label: "tag"
                 extern: "/bank/tags"
-                whenValue: lambda { bank.doSearch }
+                whenValue: lambda { ins_sel.clear_sel
+                                    bank.doSearch }
             }
             function layout(l, selfBox) {
                 Draw::Layout::hfill(l, selfBox, children, [0.3, 0.3, 0.4])

--- a/src/mruby-zest/example/ZynBank.qml
+++ b/src/mruby-zest/example/ZynBank.qml
@@ -51,12 +51,12 @@ Widget {
     {
         part = root.get_view_pos(:part)
         if bank_name.selected_val.empty?
-            self.root.log(:user_value, "Can't save - no bank selected")
+            self.root.log(:warning, "Can't save - no bank selected")
         elsif ins_sel.selected_val.empty?
-            self.root.log(:user_value, "Can't save - no patch slot selected")
+            self.root.log(:warning, "Can't save - no patch slot selected")
         else
             $remote.action("/bank/save_to_slot", part, ins_sel.selected_val.to_i)
-            self.root.log(:user_value, "Save to slot " + ins_sel.selected_val)
+            self.root.log(:success, "Save to slot " + ins_sel.selected_val)
             # Reload list because contents may have changed due to save
             bank.setBank
         end
@@ -67,9 +67,9 @@ Widget {
         part = root.get_view_pos(:part)
         $remote.action("/part#{part}/savexml")
         if (ins_sel.selected_val.empty?)
-            self.root.log(:user_value, "overwrite current patch")
+            self.root.log(:success, "overwrite current patch")
         else
-            self.root.log(:user_value, "write to: " + ins_sel.selected_val)
+            self.root.log(:success, "write to: " + ins_sel.selected_val)
         end
     }
 

--- a/src/mruby-zest/example/ZynBank.qml
+++ b/src/mruby-zest/example/ZynBank.qml
@@ -146,7 +146,6 @@ Widget {
                     children[0].value = false
                     children[1].value = true
                 end
-                bank_type.clear
                 children[0].damage_self
                 children[1].damage_self
             }

--- a/src/mruby-zest/example/ZynBank.qml
+++ b/src/mruby-zest/example/ZynBank.qml
@@ -50,12 +50,14 @@ Widget {
     function doSave()
     {
         part = root.get_view_pos(:part)
-        if not ins_sel.selected_val.nil?
-            $remote.action("/bank/save_to_slot", part, ins_sel.selected_val.to_i)
-            # Reload list because contents will have been changed due to save
-            bank.setBank
+        if bank_name.selected_val.empty?
+            self.root.log(:user_value, "Can't save - no bank selected")
+        elsif ins_sel.selected_val.empty?
+            self.root.log(:user_value, "Can't save - no patch slot selected")
         else
-            return
+            $remote.action("/bank/save_to_slot", part, ins_sel.selected_val.to_i)
+            # Reload list because contents may have changed due to save
+            bank.setBank
         end
     }
     

--- a/src/mruby-zest/example/ZynBank.qml
+++ b/src/mruby-zest/example/ZynBank.qml
@@ -147,6 +147,7 @@ Widget {
                 layoutOpts: [:no_constraint]
             }
             TriggerButton {
+                id: trigger
                 label: "overwrite"
                 whenValue: lambda { bank.doWrite() }
             }
@@ -158,16 +159,22 @@ Widget {
             {
                 if(x == 0)
                     bank.mode = :read
+                    ins_sel.childTooltipPrefix = "File: "
+                    trigger.label = "overwrite"
+                    trigger.damage_self
                     children[0].value = true
                     children[1].value = false
                 else
                     bank.mode = :write
+                    ins_sel.childTooltipPrefix = "Slot  "
+                    trigger.label = "execute"
+                    trigger.damage_self
                     children[0].value = false
                     children[1].value = true
                 end
                 bank.doBank
                 children[0].tooltip = "read mode (overwrite re-saves latest loaded patch)"
-                children[1].tooltip = "write mode (to write: select slot, then press overwrite)"
+                children[1].tooltip = "write mode (to write: select slot, then press execute)"
                 children[0].damage_self
                 children[1].damage_self
                 # Clear selection, so that a previous read selection does
@@ -188,6 +195,7 @@ Widget {
                 label: "preset"
                 number: false
                 skip:   true
+                childTooltipPrefix: "File: "
                 whenValue: lambda {bank.doInsSelect}
             }
             ZynPatchInfo {}

--- a/src/mruby-zest/example/ZynBank.qml
+++ b/src/mruby-zest/example/ZynBank.qml
@@ -21,7 +21,14 @@ Widget {
 
     function setBank()
     {
-        $remote.action("/bank/blist", bank_name.selected_val)
+        # If no bank is selected, clear the patch column, otherwise
+        # it will display EMPTY PRESET in each slot, but with no
+        # bank to write to, it's not possible to write anything.
+        if (bank_name.selected_val.empty?)
+            ins_sel.clear_all
+        else
+            $remote.action("/bank/blist", bank_name.selected_val)
+        end
     }
 
     function doType()

--- a/src/mruby-zest/example/ZynBank.qml
+++ b/src/mruby-zest/example/ZynBank.qml
@@ -52,6 +52,8 @@ Widget {
         part = root.get_view_pos(:part)
         if not ins_sel.selected_val.nil?
             $remote.action("/bank/save_to_slot", part, ins_sel.selected_val.to_i)
+            # Reload list because contents will have been changed due to save
+            bank.setBank
         else
             return
         end
@@ -72,6 +74,7 @@ Widget {
     function doRescan()
     {
         $remote.action("/bank/rescan")
+        doBank
     }
 
     Widget {
@@ -146,6 +149,7 @@ Widget {
                     children[0].value = false
                     children[1].value = true
                 end
+                bank.doBank
                 children[0].damage_self
                 children[1].damage_self
             }

--- a/src/mruby-zest/example/ZynHeader.qml
+++ b/src/mruby-zest/example/ZynHeader.qml
@@ -12,6 +12,7 @@ Widget {
 
         LogWidget {
             label: "console log"
+            extern: "/alert"
         }
     }
 

--- a/src/mruby-zest/example/ZynPortamento.qml
+++ b/src/mruby-zest/example/ZynPortamento.qml
@@ -6,7 +6,10 @@ Group {
         ToggleButton {
             extern: port.extern+"portamento.receive"
         }
-        Text { }
+        ToggleButton {
+            extern: port.extern+"portamento.automode"
+            label: "auto"
+        }
         ToggleButton {
             extern: port.extern+"portamento.portamento"
             label: "enable"

--- a/src/mruby-zest/qml/LogWidget.qml
+++ b/src/mruby-zest/qml/LogWidget.qml
@@ -2,18 +2,20 @@ Widget {
     id: log
     property Int lines: 2
     property Object extRef: nil
+    property Symbol type: :tooltip
 
     function display_log(type, message, src)
     {
         if(self.label != message)
             self.label = message
+            self.type = type
             damage_self
         end
     }
 
     onExtern: {
         log.extRef = OSC::RemoteParam.new($remote, log.extern)
-        log.extRef.callback = Proc.new {|x| display_log(:user_value, x, "extern") }
+        log.extRef.callback = Proc.new {|x| display_log(:warning, x, "extern") }
     }
 
     function onSetup(old)
@@ -23,7 +25,9 @@ Widget {
 
     function draw(vg)
     {
-        textColor  = color("3ac5ec")
+        textColor  = color("3ac5ec") # Default, for tooltips
+        textColor  = color("ea152c") if(self.type == :warning) # Red-ish
+        textColor  = color("1ac52c") if(self.type == :success) # Green-ish
         splitColor = color("133A4C")
 
         vg.path do |vg|

--- a/src/mruby-zest/qml/LogWidget.qml
+++ b/src/mruby-zest/qml/LogWidget.qml
@@ -3,11 +3,19 @@ Widget {
     property Int lines: 2
     property Object extRef: nil
     property Symbol type: :tooltip
+    property String statusMsg: ""
 
     function display_log(type, message, src)
     {
-        if(self.label != message)
+        if(type == :warning)
+            if(self.statusMsg != message)
+                self.statusMsg = message
+                self.type = type
+                damage_self
+            end
+        elsif(self.label != message)
             self.label = message
+            self.statusMsg = ""
             self.type = type
             damage_self
         end
@@ -26,8 +34,8 @@ Widget {
     function draw(vg)
     {
         textColor  = color("3ac5ec") # Default, for tooltips
-        textColor  = color("ea152c") if(self.type == :warning) # Red-ish
         textColor  = color("1ac52c") if(self.type == :success) # Green-ish
+        msgColor  = color("ea152c") # Red-ish
         splitColor = color("133A4C")
 
         vg.path do |vg|
@@ -43,5 +51,7 @@ Widget {
         vg.text_align NVG::ALIGN_LEFT | NVG::ALIGN_MIDDLE
         vg.fill_color(textColor)
         vg.text_box(0,h/4,w,self.label.upcase)
+        vg.fill_color(msgColor)
+        vg.text_box(0,3*h/4,w,self.statusMsg.upcase)
     }
 }

--- a/src/mruby-zest/qml/LogWidget.qml
+++ b/src/mruby-zest/qml/LogWidget.qml
@@ -1,5 +1,7 @@
 Widget {
+    id: log
     property Int lines: 2
+    property Object extRef: nil
 
     function display_log(type, message, src)
     {
@@ -7,6 +9,11 @@ Widget {
             self.label = message
             damage_self
         end
+    }
+
+    onExtern: {
+        log.extRef = OSC::RemoteParam.new($remote, log.extern)
+        log.extRef.callback = Proc.new {|x| display_log(:user_value, x, "extern") }
     }
 
     function onSetup(old)

--- a/src/mruby-zest/qml/Widget.qml
+++ b/src/mruby-zest/qml/Widget.qml
@@ -9,6 +9,7 @@ Object {
     property String label: ""
 
     property String tooltip: ""
+    property String childTooltipPrefix: ""
 
     property Array layoutOpts: []
 
@@ -150,7 +151,7 @@ Object {
     
     function onMouseEnter(ev) {
         if(self.tooltip != "" and self.root.respond_to?(:log))
-            self.root.log(:tooltip, self.tooltip)
+            self.root.log(:tooltip, self.parent.childTooltipPrefix + self.tooltip)
         end
     }
 

--- a/src/osc-bridge/schema/test.json
+++ b/src/osc-bridge/schema/test.json
@@ -11170,6 +11170,14 @@
 
     },
     {
+        "path"     : "/part[0,15]/ctl/portamento.automode",
+        "name"     : "portamento.automode",
+        "tooltip"  : "Portamento Auto mode",
+        "type"     : "t",
+        "default"  : "false"
+
+    },
+    {
         "path"     : "/part[0,15]/ctl/portamento.time",
         "shortname": "time",
         "name"     : "portamento.time",

--- a/test-libversion.c
+++ b/test-libversion.c
@@ -557,7 +557,7 @@ void *setup_pugl(void *zest)
     puglSetDndTargetOfferTypeFunc(view, onDndTargetOfferType);
     puglSetDndTargetReceiveDataFunc(view, onDndTargetReceiveData);
 
-    puglCreateWindow(view, "ZynAddSubFX 3.0.6");
+    puglCreateWindow(view, "ZynAddSubFX 3.0.7");
     puglShowWindow(view);
     puglProcessEvents(view);
     return view;


### PR DESCRIPTION
This is a series of patches attempting to improve bank read and write operations. I've split them into a several patches as they involve some design decisions which possibly need further discussion.

One thing is the handling of /alert messages. They are displayed, using the (new) :warning type on second line of the console log window, in red, to catch the user's attention. Tooltips (:tooltip) are displayed on the top line as usual. I've introduced a new type :success, which is also displayed on the top line, in green text, in order to indicate success.

The idea is that write operations elicit a green (:success) message on the top line, but if the write operation fails, a subsequent /alert message from Zyn will result in the top line being displayed in the usual subdued blue, and the alert message (:warning) on the bottom line, so that it's possible for the user to see what operation the warning is referring to.

I'm a bit apprehensive about bringing in somewhat gaudy colors to the lovely Fusion interface, but I feel that displaying /alert messages in red is consistent with conveying a sense of urgency being error messages. Furthermore, displaying success messages in green gives positive confirmation that a write operation has succeeded, which I think is important, as contrary to other operations in the UI (i.e., adjusting a parameter), it's not possible for the user to immediately verify that the operation actually took place successfully, so emphasising that all went well bolsters the user's confidence.

I've tried to tone the red and green colors down somewhat (hence the somewhat odd color codes) to not stand out too much from the rest of the UI.