### PR TITLE
Familiarize adsr layout

### DIFF
--- a/src/mruby-zest/example/ZynAmpEnv.qml
+++ b/src/mruby-zest/example/ZynAmpEnv.qml
@@ -10,13 +10,13 @@ Group {
 
     ParModuleRow {
         id: top
-        Knob { 
-            whenValue: lambda { box.cb }; 
+        Knob {
+            whenValue: lambda { box.cb };
             extern: box.extern+"A_dt"
             type:   :float
         }
-        Knob { 
-            whenValue: lambda { box.cb }; 
+        Knob {
+            whenValue: lambda { box.cb };
             extern: box.extern+"D_dt"
             type:   :float
         }
@@ -24,8 +24,8 @@ Group {
     }
     ParModuleRow {
         id: bot
-        Knob     { 
-            whenValue: lambda { box.cb }; 
+        Knob     {
+            whenValue: lambda { box.cb };
             extern: box.extern+"R_dt"
             type:   :float
         }

--- a/src/mruby-zest/example/ZynAmpEnv.qml
+++ b/src/mruby-zest/example/ZynAmpEnv.qml
@@ -20,19 +20,22 @@ Group {
             extern: box.extern+"D_dt"
             type:   :float
         }
-        Knob { whenValue: lambda { box.cb }; extern: box.extern+"PS_val"}
-    }
-    ParModuleRow {
-        id: bot
-        Knob     {
+        Knob {
+            whenValue: lambda { box.cb };
+            extern: box.extern+"PS_val"
+        }
+        Knob {
             whenValue: lambda { box.cb };
             extern: box.extern+"R_dt"
             type:   :float
         }
+    }
+    ParModuleRow {
+        id: bot
         Knob     { whenValue: lambda { box.cb }; extern: box.extern+"Penvstretch"}
+        ToggleButton   { label: "lin/log"; whenValue: lambda { box.cb }; extern: box.extern+"Plinearenvelope"}
         Col {
             ToggleButton   { label: "FRCR"; whenValue: lambda { box.cb }; extern: box.extern+"Pforcedrelease"}
-            ToggleButton   { label: "lin/log"; whenValue: lambda { box.cb }; extern: box.extern+"Plinearenvelope"}
             ToggleButton   { label: "repeat"; whenValue: lambda { box.cb }; extern: box.extern+"Prepeating"}
         }
     }


### PR DESCRIPTION
This minor change has been long overdue. We discussed in issue #311 to adjust the layout for the amp envelopes so that it resembles a classic ADSR layout with all envelope parameters in a row. Also adjust the toggle button layout in the amp env pane to avoid them being rendered as thin hard-to-click stripes, trying to keep the FRCR and REPEAT buttons consistent with the button layout in the filter envelope.