### PR TITLE
Add resonance tab to PADsynth

### DIFF
--- a/src/mruby-zest/example/ZynPadSynth.qml
+++ b/src/mruby-zest/example/ZynPadSynth.qml
@@ -14,6 +14,7 @@ Widget {
         TabButton { label: "harmonic structure";}
         TabButton { label: "oscillator";}
         TabButton { label: "envelopes & lfos"; whenClick: lambda {root.set_view_pos(:vis, :envelope)};}
+        TabButton { whenClick: lambda {header.set_tab(3)}; label: "resonance"}
 
         ApplyButton {
             id: appl
@@ -30,7 +31,7 @@ Widget {
             root.set_view_pos(:subview, :global_pad)
             root.set_view_pos(:vis, :oscilloscope)
             root.change_view
-            center.turn_off_tab()  
+            center.turn_off_tab()
              }
         }
 
@@ -55,7 +56,8 @@ Widget {
             mapping = {0 => :harmonics,
                        1 => :oscil,
                        2 => :global_pad,
-                       3 => :oscilloscope}
+                       3 => :resonance,
+                       4 => :oscilloscope}
             root.set_view_pos(:subview, mapping[selected])
             root.change_view
         }
@@ -78,16 +80,19 @@ Widget {
         mapping = {:harmonics   => Qml::ZynPadHarmonics,
                    :oscil       => Qml::ZynOscil,
                    :global_pad  => Qml::ZynPadGlobal,
+                   :resonance => Qml::ZynResonance,
                    :oscilloscope => Qml::ZynPadOscilloscope}
         base = center.extern
         ext     = {:harmonics  => "",
                    :oscil      => "oscilgen/",
                    :global_pad => "",
+                   :resonance => "resonance/",
                    :oscilloscope => ""}
         tabid   = {:harmonics  => 0,
                    :oscil      => 1,
                    :global_pad => 2,
-                   :oscilloscope => 3}
+                   :resonance => 3,
+                   :oscilloscope => 4}
         if(!mapping.include?(subview))
             subview = :oscil
             root.set_view_pos(:subview, :oscil)
@@ -108,7 +113,7 @@ Widget {
         n = 2
         (0..n).each do |ch_id|
             child = header.children[ch_id]
-           
+
                 if(child.value)
                     child.value = false
                     child.damage_self


### PR DESCRIPTION
Implements zynaddsubfx/zyn-fusion-issues#358

I noticed that PADsynth didn't have a resonance view, so I tried adding it. I essentially re-used the panel from ADDSynth. It seems to be working, that is, I can access the resonance panel in PADsynth, and enabling resonance and turning the knobs has an effect on the sound. However, as I am wholly unfamiliar with this codebase, I would appreciate someone with experience to double check if everything is working as intended.

Previously posted at https://github.com/mruby-zest/mruby-zest/pull/59, but seeing how there are more recent commits in this repo, perhaps this PR belongs here instead?!