### PR TITLE
Rocker buttons

### DIFF
--- a/src/mruby-zest/example/ZynAmpEnv.qml
+++ b/src/mruby-zest/example/ZynAmpEnv.qml
@@ -33,7 +33,7 @@ Group {
     ParModuleRow {
         id: bot
         Knob     { whenValue: lambda { box.cb }; extern: box.extern+"Penvstretch"}
-        ToggleButton   { label: "lin/log"; whenValue: lambda { box.cb }; extern: box.extern+"Plinearenvelope"}
+        ToggleButton   { label: "lin/log"; rocker: true; whenValue: lambda { box.cb }; extern: box.extern+"Plinearenvelope"}
         Col {
             ToggleButton   { label: "FRCR"; whenValue: lambda { box.cb }; extern: box.extern+"Pforcedrelease"}
             ToggleButton   { label: "repeat"; whenValue: lambda { box.cb }; extern: box.extern+"Prepeating"}

--- a/src/mruby-zest/example/ZynPortamento.qml
+++ b/src/mruby-zest/example/ZynPortamento.qml
@@ -20,6 +20,8 @@ Group {
     ParModuleRow {
         ToggleButton {
             extern: port.extern+"portamento.pitchthreshtype"
+            rocker: true
+            label ">/<"
         }
         NumEntry {
             extern: port.extern+"portamento.pitchthresh"

--- a/src/mruby-zest/qml/Button.qml
+++ b/src/mruby-zest/qml/Button.qml
@@ -66,6 +66,11 @@ Widget {
         text_color2   = Theme::TextColor
         vg.font_face("bold")
         vg.font_size h*self.textScale
+        # While it initially looks redundant to test against 'true', remember
+        # that 'value' is a float when the Button is a TriggerButton. If we
+        # don't check against true here, the button text while change to the
+        # 'enabled' color (light blue) when clicking a TriggerButton, and
+        # remain in that color, rather than just staying light grey.
         if(value == true)
             vg.fill_color(text_color1)
         else
@@ -99,6 +104,10 @@ Widget {
         cs = 0
         vg.path do |v|
             v.rounded_rect(w*pad, h*pad, w*(1-2*pad), h*(1-2*pad), 2)
+            # Although the test against 'true' might seem redundant, it's
+            # needed because 'value' will be a float when the Button is a
+            # TriggerButton, and we purposely want to check for a boolean
+            # false here.
             if(button.value == true)
                 cs = 1
                 v.fill_color on_color


### PR DESCRIPTION
It's over a year ago since I opened issue https://github.com/zynaddsubfx/zyn-fusion-issues/issues/352, but I finally got around to implementing a variant of the Button class, as suggested by @zynmuse, where a new _rocker_ attribute has been added to the class, which when enabled will display the button as two adjacent buttons of half the width, where one is depressed and the other not. The labels for the two button halves will be extracted from the two portions of the label string separated by a '/'.

Technically, the button isn't really a rocker button, as that would imply that one half would be sloping, but it seemed a better name than 'two button radio button' or similar. I feel it ties in with the existing graphic style quite nicely.

Two commits utilize the new rocker property, one for the trigger threshold in the portamento section, and one for the amplifier envelopes.

![Linlog button with lin depressed](https://butoba.net/pix/linlog-lin-detail.jpg)

![Linlog button with log depressed](https://butoba.net/pix/linlog-log-detail.jpg)