### PR TITLE
KitButton: Make right hand button toggle too

### DIFF
--- a/src/mruby-zest/example/KitButton.qml
+++ b/src/mruby-zest/example/KitButton.qml
@@ -3,7 +3,7 @@ Widget {
     property signal action: nil;
     property Bool   value:    false;
     property Bool   enable:   false;
-    tooltip: "Use Middle Mouse To Toggle"
+    tooltip: "Use Middle Or Right Mouse To Toggle"
     
     function set_enable(v) {
         if(button.enable != v)
@@ -16,6 +16,8 @@ Widget {
         if(ev.buttons.include? :leftButton)
             action.call(:change_view) if action
         elsif(ev.buttons.include? :middleButton)
+            action.call(:toggle) if action
+        elsif(ev.buttons.include? :rightButton)
             action.call(:toggle) if action
         end
         damage_self


### PR DESCRIPTION
In order to support systems where there is no middle button, allow right hand button to toggle just like the middle button does. This allows for instance a Wacom touchscreen and stylus to trigger the toggle event (tested on a Lenovo X220i tablet). The right button doesn't seem to be used anything in this situation, so it seems feasible for both the middle and right hand buttons to do the same thing.

This is minor thing so I haven't created an issue for it.