### PR TITLE
Fix some harmonic edit bugs

### DIFF
--- a/src/mruby-zest/example/HarmonicEdit.qml
+++ b/src/mruby-zest/example/HarmonicEdit.qml
@@ -30,7 +30,7 @@ Widget {
 
         children.each_with_index do |ch, i|
             ii = (i+off).to_i.to_s
-            ch.children[1].label = ii
+            ch.children[1].label = (i+off+1).to_i.to_s
             if(self.type == :oscil)
                 ch.children[0].extern = self.extern + "magnitude" + ii
                 ch.children[2].extern = self.extern + "phase"     + ii

--- a/src/mruby-zest/example/ZynOscil.qml
+++ b/src/mruby-zest/example/ZynOscil.qml
@@ -79,6 +79,7 @@ Widget {
         id: scroll
         vertical: false
         value: 0
+        unclValue: 0
         whenValue: lambda {hedit.set_scroll scroll.value}
     }
 


### PR DESCRIPTION
In the oscillator tabs for ADsynth and PADsynth, the harmonics are initially numbered from 1 to 128. However, after scrolling the horizontal scrollbar at the bottom of the oscillator tab, the harmonics change to be numbered from 0 to 127. I assume the 1 to 128 behaviour is the intended one since that's how harmonics are serialized in .xiz files, so I made a minor change so that the harmonics are numbered from 1 to 128 after scrolling.

Also, I fixed another problem where the scrollbar at the bottom of the oscillator tab jumps to the end when you drag it with the mouse.