### PR TITLE
Fix FBO alpha blending

### DIFF
--- a/src/mruby-widget-lib/src/gem.c
+++ b/src/mruby-widget-lib/src/gem.c
@@ -302,7 +302,9 @@ mrb_fbo_image(mrb_state *mrb, mrb_value self)
     NVGcontext    *ctx = mrb_data_get_ptr(mrb, obj, &mrb_nvg_context_type);
     GLframebuffer *fbo = (GLframebuffer*)mrb_data_get_ptr(mrb, self, &mrb_fbo_type);
 
-    return mrb_fixnum_value(nvglCreateImageFromHandleGL2(ctx, fbo->texture, fbo->w, fbo->h, (1<<2)|(1<<3)));
+    return mrb_fixnum_value(
+        nvglCreateImageFromHandleGL2(ctx, fbo->texture, fbo->w, fbo->h, (1<<2)|(1<<3)|(1<<4))
+    );
 }
 
 static mrb_value

--- a/src/mruby-zest/mrblib/draw-common.rb
+++ b/src/mruby-zest/mrblib/draw-common.rb
@@ -798,8 +798,8 @@ module Theme
     HighlightGrad1      = NVG.rgba(16, 59, 79, 0)
     HighlightGrad2      = NVG.rgba(16, 59, 79, 255)
 
-    FilterHighlight1    = color("0ac5ff", 85)
-    FilterHighlight2    = color("0ac5ff", 165)
+    FilterHighlight1    = color("0a4d70", 0)
+    FilterHighlight2    = color("0a4d70", 200)
 
     GridLine            = color("253743")
 


### PR DESCRIPTION
This PR fixes a small issue which caused the graph in the 'filter' view to look darker than it should.

My understanding is that NanoVG uses premultiplied alpha by default while rendering. Then, the widgets are rendered into framebuffers by zest. However, the framebuffers were converted to an image without setting `NVG_PREMULTIPLIED_ALPHA`. So, transparent subwidgets were being rendered with straight alpha and were not blending correctly.

I've also adjusted the colors of `FilterHighlight1` and `FilterHighlight2`, which now looked very oversaturated (these colors were picked to counteract the 'bad' alpha blending)

Before:
<img width="2560" height="1440" alt="2026-09-12-07:00:49" src="https://github.com/user-attachments/assets/61291863-cccd-4250-b4d3-8737c54f9e95" />

After (without color adjustment):
<img width="2560" height="1440" alt="2026-09-12-07:02:08" src="https://github.com/user-attachments/assets/e34be420-3284-4755-8998-65fa94195a92" />

After (with color adjustment):
<img width="2560" height="1440" alt="2026-09-12-06:57:20" src="https://github.com/user-attachments/assets/47037b86-6f77-4f73-b8cf-2009fc2d89d1" />