### PR TITLE
Fix uninitialized 'count' variable in expose event

### DIFF
--- a/deps/pugl/pugl/pugl_x11.c
+++ b/deps/pugl/pugl/pugl_x11.c
@@ -1633,6 +1633,7 @@ puglProcessEvents(PuglView* view)
 		expose_event.expose.y          = 0;
 		expose_event.expose.width      = view->width;
 		expose_event.expose.height     = view->height;
+		expose_event.expose.count      = 0;
 		view->redisplay                = false;
 	}
 


### PR DESCRIPTION
This is a quick fix for https://github.com/mruby-zest/mruby-zest-build/issues/127, in case something is preventing the pugl-2026 branch from being merged.